### PR TITLE
docs: update repo name for links

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2,6 +2,7 @@
   "lang": "php",
   "friendlyLang": "PHP",
   "libraryTitle": "Google Cloud Client Library",
+  "moduleName": "google-cloud-php",
   "defaultService": "servicebuilder",
   "markdown": "php",
   "versions": [


### PR DESCRIPTION
I've updated the <kbd>manifest.json</kbd> file with a key that was recently added - `moduleName`. 

This key is used to generate all the links to stuff like GitHub/StackOverflow/etc. Since your repo name has changed recently, I thought I'd save you some trouble and update it for you!