### PR TITLE
update doc example for Google\Cloud\Storage\Object::info()

### DIFF
--- a/src/Storage/Object.php
+++ b/src/Storage/Object.php
@@ -241,7 +241,7 @@ class Object
      * Example:
      * ```
      * $info = $object->info();
-     * echo $info['metadata'];
+     * echo $info['size'];
      * ```
      *
      * @see https://cloud.google.com/storage/docs/json_api/v1/objects/get Objects get API documentation.


### PR DESCRIPTION
Since `metadata`, if set, is always an [object](https://cloud.google.com/storage/docs/json_api/v1/objects#resource) and therefore casts to an array in php, an `echo $info['metadata']` leads to a PHP notice:
```
PHP Notice:  Array to string conversion in [..]
```
The `size` key instead should not raise any notices and should always be filled.