### PR TITLE
BUGFIX: Do not yield storage object when response contains no items

### DIFF
--- a/src/Storage/Bucket.php
+++ b/src/Storage/Bucket.php
@@ -337,6 +337,9 @@ class Bucket
         do {
             $response = $this->connection->listObjects($options + $this->identity);
 
+            if (!array_key_exists('items', $response)) {
+                break;
+            }
             foreach ($response['items'] as $object) {
                 $generation = $includeVersions ? $object['generation'] : null;
                 yield new Object($this->connection, $object['name'], $this->identity['bucket'], $generation, $object);


### PR DESCRIPTION
When listing objects of an empty bucket, previously a notice was raised, which breaks strict environments, since the empty response contains no 'items' index.

The generator was modified to break execution when 'items' isn't present.