### PR TITLE
Introduce translate API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This client supports the following Google Cloud Platform services:
 
 * [Google BigQuery](#google-bigquery)
 * [Google Stackdriver Logging](#google-stackdriver-logging)
+* [Google Translate](#google-translate)
 * [Google Cloud Natural Language](#google-cloud-natural-language)
 * [Google Cloud Pub/Sub](#google-cloud-pubsub)
 * [Google Cloud Storage](#google-cloud-storage)
@@ -94,6 +95,53 @@ $entries = $logging->entries([
 
 foreach ($entries as $entry) {
     echo $entry->info()['textPayload'] . "\n";
+}
+```
+
+## Google Translate
+
+- [API Documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/latest/translate/translateclient)
+- [Official Documentation](https://cloud.google.com/translate/docs)
+
+#### Preview
+
+```php
+<?php
+require 'vendor/autoload.php';
+
+use Google\Cloud\Translate\TranslateClient;
+
+$translate = new TranslateClient([
+    'key' => 'your_key'
+]);
+
+// Translate text from english to french.
+$translation = $translate->translate('Hello world!', [
+    'target' => 'fr'
+]);
+
+echo $translation['text'] . "\n";
+
+// Detect the language of a string.
+$result = $translate->detectLanguage('Greetings from Michigan!');
+
+echo $result['languageCode'] . "\n";
+
+// Get the languages supported for translation specifically for your target language.
+$languages = $translate->localizedLanguages([
+    'target' => 'en'
+]);
+
+foreach ($languages as $language) {
+    echo $language['name'] . "\n";
+    echo $language['code'] . "\n";
+}
+
+// Get all languages supported for translation.
+$languages = $translate->languages();
+
+foreach ($languages as $language) {
+    echo $language . "\n";
 }
 ```
 

--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -99,7 +99,7 @@ class RequestBuilder
         }
 
         if (isset($this->service['parameters'])) {
-            foreach ($this->service['parameters'] as $parameter => $parmeterOptions) {
+            foreach ($this->service['parameters'] as $parameter => $parameterOptions) {
                 if ($parameterOptions['location'] === 'query' && array_key_exists($parameter, $options)) {
                     $query[$parameter] = $options[$parameter];
                 }

--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -98,6 +98,14 @@ class RequestBuilder
             }
         }
 
+        if (isset($this->service['parameters'])) {
+            foreach ($this->service['parameters'] as $parameter => $parmeterOptions) {
+                if ($parameterOptions['location'] === 'query' && array_key_exists($parameter, $options)) {
+                    $query[$parameter] = $options[$parameter];
+                }
+            }
+        }
+
         if (isset($action['request'])) {
             $schema = $action['request']['$ref'];
 

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -259,6 +259,17 @@ class ServiceBuilder
      * [before you begin](https://cloud.google.com/translate/v2/translating-text-with-rest#before-you-begin)
      * instructions to learn how to generate a key.
      *
+     * Example:
+     * ```
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $builder = new ServiceBuilder([
+     *     'key' => 'YOUR_KEY'
+     * ]);
+     *
+     * $translate = $builder->translate();
+     * ```
+     *
      * @param array $config {
      *     Configuration options.
      *

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -23,6 +23,7 @@ use Google\Cloud\Logging\LoggingClient;
 use Google\Cloud\PubSub\PubSubClient;
 use Google\Cloud\NaturalLanguage\NaturalLanguageClient;
 use Google\Cloud\Storage\StorageClient;
+use Google\Cloud\Translate\TranslateClient;
 use Google\Cloud\Vision\VisionClient;
 
 /**
@@ -39,7 +40,7 @@ use Google\Cloud\Vision\VisionClient;
  * options for the specific services you wish to access, e.g. Datastore, or
  * Storage.
  *
- * Please note that all examples below take advantage of
+ * Please note that unless otherwise noted the examples below take advantage of
  * [Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials).
  */
 class ServiceBuilder
@@ -239,6 +240,40 @@ class ServiceBuilder
     public function naturalLanguage(array $config = [])
     {
         return new NaturalLanguageClient($config ? $this->resolveConfig($config) : $this->config);
+    }
+
+    /**
+     * Google Translate client. Provides the ability to dynamically translate
+     * text between thousands of language pairs. The Google Translate API lets
+     * websites and programs integrate with Google Translate API
+     * programmatically. Google Translate API is available as a paid service.
+     * See the [Pricing](https://cloud.google.com/translate/v2/pricing) and
+     * [FAQ](https://cloud.google.com/translate/v2/faq) pages for details. Find
+     * more information at
+     * [Google Translate docs](https://cloud.google.com/translate/docs/).
+     *
+     * Please note that unlike most other Cloud Platform services Google
+     * Translate requires a public API access key and cannot currently be
+     * accessed with a service account or application default credentials.
+     * Follow the
+     * [before you begin](https://cloud.google.com/translate/v2/translating-text-with-rest#before-you-begin)
+     * instructions to learn how to generate a key.
+     *
+     * @param array $config {
+     *     Configuration options.
+     *
+     *     @type string $key A public API access key.
+     *     @type string $target The target language to assign to the client.
+     *           Defaults to `en` (English).
+     *     @type callable $httpHandler A handler used to deliver Psr7 requests.
+     *     @type int $retries Number of retries for a failed request. Defaults
+     *           to 3.
+     * }
+     * @return TranslateClient
+     */
+    public function translate(array $config = [])
+    {
+        return new TranslateClient($config ? $this->resolveConfig($config) : $this->config);
     }
 
     /**

--- a/src/Translate/Connection/ConnectionInterface.php
+++ b/src/Translate/Connection/ConnectionInterface.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Translate\Connection;
+
+/**
+ * Represents a connection to [Translate](https://cloud.google.com/translate/).
+ */
+interface ConnectionInterface
+{
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function listDetections(array $args = []);
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function listLanguages(array $args = []);
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function listTranslations(array $args = []);
+}

--- a/src/Translate/Connection/Rest.php
+++ b/src/Translate/Connection/Rest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Translate\Connection;
+
+use Google\Cloud\RequestBuilder;
+use Google\Cloud\RequestWrapper;
+use Google\Cloud\RestTrait;
+use Google\Cloud\UriTrait;
+
+/**
+ * Implementation of the
+ * [Google Translate REST API](https://cloud.google.com/translate/docs/how-to).
+ */
+class Rest implements ConnectionInterface
+{
+    use RestTrait;
+    use UriTrait;
+
+    const BASE_URI = 'https://www.googleapis.com/language/translate/';
+
+    /**
+     * @param array $config
+     */
+    public function __construct(array $config = [])
+    {
+        $this->setRequestWrapper(new RequestWrapper($config));
+        $this->setRequestBuilder(new RequestBuilder(
+            __DIR__ . '/ServiceDefinition/translate-v2.json',
+            self::BASE_URI
+        ));
+    }
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function listDetections(array $args = [])
+    {
+        return $this->send('detections', 'list', $args);
+    }
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function listLanguages(array $args = [])
+    {
+        return $this->send('languages', 'list', $args);
+    }
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function listTranslations(array $args = [])
+    {
+        return $this->send('translations', 'list', $args);
+    }
+}

--- a/src/Translate/Connection/ServiceDefinition/translate-v2.json
+++ b/src/Translate/Connection/ServiceDefinition/translate-v2.json
@@ -1,0 +1,267 @@
+{
+  "kind": "discovery#restDescription",
+  "etag": "\"C5oy1hgQsABtYOYIOXWcR3BgYqU/6s__cFeA5l1i01rONlu3TmUQEHs\"",
+  "discoveryVersion": "v1",
+  "id": "translate:v2",
+  "name": "translate",
+  "version": "v2",
+  "revision": "20160627",
+  "title": "Translate API",
+  "description": "Translates text from one language to another.",
+  "ownerDomain": "google.com",
+  "ownerName": "Google",
+  "icons": {
+    "x16": "https://www.google.com/images/icons/product/translate-16.png",
+    "x32": "https://www.google.com/images/icons/product/translate-32.png"
+  },
+  "documentationLink": "https://developers.google.com/translate/v2/using_rest",
+  "protocol": "rest",
+  "baseUrl": "https://www.googleapis.com/language/translate/",
+  "basePath": "/language/translate/",
+  "rootUrl": "https://www.googleapis.com/",
+  "servicePath": "language/translate/",
+  "batchPath": "batch",
+  "parameters": {
+    "alt": {
+      "type": "string",
+      "description": "Data format for the response.",
+      "default": "json",
+      "enum": [
+        "json"
+      ],
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json"
+      ],
+      "location": "query"
+    },
+    "fields": {
+      "type": "string",
+      "description": "Selector specifying which fields to include in a partial response.",
+      "location": "query"
+    },
+    "key": {
+      "type": "string",
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query"
+    },
+    "oauth_token": {
+      "type": "string",
+      "description": "OAuth 2.0 token for the current user.",
+      "location": "query"
+    },
+    "prettyPrint": {
+      "type": "boolean",
+      "description": "Returns response with indentations and line breaks.",
+      "default": "true",
+      "location": "query"
+    },
+    "quotaUser": {
+      "type": "string",
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.",
+      "location": "query"
+    },
+    "userIp": {
+      "type": "string",
+      "description": "IP address of the site where the request originates. Use this if you want to enforce per-user limits.",
+      "location": "query"
+    }
+  },
+  "features": [
+    "dataWrapper"
+  ],
+  "schemas": {
+    "DetectionsListResponse": {
+      "id": "DetectionsListResponse",
+      "type": "object",
+      "properties": {
+        "detections": {
+          "type": "array",
+          "description": "A detections contains detection results of several text",
+          "items": {
+            "$ref": "DetectionsResource"
+          }
+        }
+      }
+    },
+    "DetectionsResource": {
+      "id": "DetectionsResource",
+      "type": "array",
+      "description": "An array of languages which we detect for the given text The most likely language list first.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "confidence": {
+            "type": "number",
+            "description": "The confidence of the detection resul of this language.",
+            "format": "float"
+          },
+          "isReliable": {
+            "type": "boolean",
+            "description": "A boolean to indicate is the language detection result reliable."
+          },
+          "language": {
+            "type": "string",
+            "description": "The language we detect"
+          }
+        }
+      }
+    },
+    "LanguagesListResponse": {
+      "id": "LanguagesListResponse",
+      "type": "object",
+      "properties": {
+        "languages": {
+          "type": "array",
+          "description": "List of source/target languages supported by the translation API. If target parameter is unspecified, the list is sorted by the ASCII code point order of the language code. If target parameter is specified, the list is sorted by the collation order of the language name in the target language.",
+          "items": {
+            "$ref": "LanguagesResource"
+          }
+        }
+      }
+    },
+    "LanguagesResource": {
+      "id": "LanguagesResource",
+      "type": "object",
+      "properties": {
+        "language": {
+          "type": "string",
+          "description": "The language code."
+        },
+        "name": {
+          "type": "string",
+          "description": "The localized name of the language if target parameter is given."
+        }
+      }
+    },
+    "TranslationsListResponse": {
+      "id": "TranslationsListResponse",
+      "type": "object",
+      "properties": {
+        "translations": {
+          "type": "array",
+          "description": "Translations contains list of translation results of given text",
+          "items": {
+            "$ref": "TranslationsResource"
+          }
+        }
+      }
+    },
+    "TranslationsResource": {
+      "id": "TranslationsResource",
+      "type": "object",
+      "properties": {
+        "detectedSourceLanguage": {
+          "type": "string",
+          "description": "Detected source language if source parameter is unspecified."
+        },
+        "translatedText": {
+          "type": "string",
+          "description": "The translation."
+        }
+      }
+    }
+  },
+  "resources": {
+    "detections": {
+      "methods": {
+        "list": {
+          "id": "language.detections.list",
+          "path": "v2/detect",
+          "httpMethod": "GET",
+          "description": "Detect the language of text.",
+          "parameters": {
+            "q": {
+              "type": "string",
+              "description": "The text to detect",
+              "required": true,
+              "repeated": true,
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "q"
+          ],
+          "response": {
+            "$ref": "DetectionsListResponse"
+          }
+        }
+      }
+    },
+    "languages": {
+      "methods": {
+        "list": {
+          "id": "language.languages.list",
+          "path": "v2/languages",
+          "httpMethod": "GET",
+          "description": "List the source/target languages supported by the API",
+          "parameters": {
+            "target": {
+              "type": "string",
+              "description": "the language and collation in which the localized results should be returned",
+              "location": "query"
+            }
+          },
+          "response": {
+            "$ref": "LanguagesListResponse"
+          }
+        }
+      }
+    },
+    "translations": {
+      "methods": {
+        "list": {
+          "id": "language.translations.list",
+          "path": "v2",
+          "httpMethod": "GET",
+          "description": "Returns text translations from one language to another.",
+          "parameters": {
+            "cid": {
+              "type": "string",
+              "description": "The customization id for translate",
+              "repeated": true,
+              "location": "query"
+            },
+            "format": {
+              "type": "string",
+              "description": "The format of the text",
+              "enum": [
+                "html",
+                "text"
+              ],
+              "enumDescriptions": [
+                "Specifies the input is in HTML",
+                "Specifies the input is in plain textual format"
+              ],
+              "location": "query"
+            },
+            "q": {
+              "type": "string",
+              "description": "The text to translate",
+              "required": true,
+              "repeated": true,
+              "location": "query"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source language of the text",
+              "location": "query"
+            },
+            "target": {
+              "type": "string",
+              "description": "The target language into which the text should be translated",
+              "required": true,
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "q",
+            "target"
+          ],
+          "response": {
+            "$ref": "TranslationsListResponse"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Translate/TranslateClient.php
+++ b/src/Translate/TranslateClient.php
@@ -1,0 +1,366 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Translate;
+
+use Google\Cloud\ClientTrait;
+use Google\Cloud\Translate\Connection\ConnectionInterface;
+use Google\Cloud\Translate\Connection\Rest;
+
+/**
+ * Google Translate client. Provides the ability to dynamically translate text
+ * between thousands of language pairs. The Google Translate API lets websites
+ * and programs integrate with Google Translate API programmatically. Google
+ * Translate API is available as a paid service. See the
+ * [Pricing](https://cloud.google.com/translate/v2/pricing) and
+ * [FAQ](https://cloud.google.com/translate/v2/faq) pages for details. Find more
+ * information at
+ * [Google Translate docs](https://cloud.google.com/translate/docs/).
+ *
+ * Please note that unlike most other Cloud Platform services Google Translate
+ * requires a public API access key and cannot currently be accessed with a
+ * service account or application default credentials. Follow the
+ * [before you begin](https://cloud.google.com/translate/v2/translating-text-with-rest#before-you-begin)
+ * instructions to learn how to generate a key.
+ */
+class TranslateClient
+{
+    use ClientTrait;
+
+    const ENGLISH_LANGUAGE_CODE = 'en';
+
+    /**
+     * @var ConnectionInterface
+     */
+    protected $connection;
+
+    /**
+     * @var string
+     */
+    private $targetLanguage;
+
+    /**
+     * Create a Translate client.
+     *
+     * Example:
+     * ```
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *     'key' => 'YOUR_KEY'
+     * ]);
+     *
+     * $translate = $cloud->translate();
+     * ```
+     *
+     * ```
+     * // The Translate client can also be instantianted directly.
+     * use Google\Cloud\Translate\TranslateClient;
+     *
+     * $translate = new TranslateClient([
+     *     'key' => 'YOUR_KEY'
+     * ]);
+     * ```
+     *
+     * @param array $config {
+     *     Configuration Options.
+     *
+     *     @type string $key A public API access key.
+     *     @type string $target The target language to assign to the client.
+     *           Must be a valid ISO 639-1 language code. Defaults to `en`
+     *           (English).
+     *     @type callable $httpHandler A handler used to deliver Psr7 requests.
+     *     @type int $retries Number of retries for a failed request. Defaults
+     *           to 3.
+     * }
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(array $config = [])
+    {
+        if (!isset($config['key'])) {
+            throw new \InvalidArgumentException('A key is required.');
+        }
+
+        $this->key = $config['key'];
+        $this->targetLanguage = isset($config['target'])
+            ? $config['target']
+            : self::ENGLISH_LANGUAGE_CODE;
+
+        unset($config['key']);
+        unset($config['target']);
+
+        $this->connection = new Rest($config + [
+            'shouldSignRequest' => false
+        ]);
+    }
+
+    /**
+     * Translate a string from one language to another.
+     *
+     * Example:
+     * ```
+     * $translation = $translate->translate('Hello world!');
+     *
+     * echo $translation['text'];
+     * ```
+     *
+     * @see https://cloud.google.com/translate/v2/translating-text-with-rest Translating Text
+     *
+     * @param string $string The string to translate.
+     * @param array $options {
+     *     Configuration Options.
+     *
+     *     @type string $source The source language to translate from. Must be a
+     *           valid ISO 639-1 language code. If not provided the value will
+     *           be automatically detected by the server.
+     *     @type string $target The target language to translate to. Must be a
+     *           valid ISO 639-1 language code. Defaults to the value assigned
+     *           to the client (`en` by default).
+     *     @type string $format Indicates whether the string to be translated is
+     *           either plain-text or HTML. Acceptable values are `html` or
+     *          `text`. Defaults to `html`.
+     * }
+     * @return array A translation result including a `source` key containing
+     *         the detected or provided langauge of the provided input, an
+     *         `input` key containing the original string, and a `text` key
+     *         containing the translated result.
+     */
+    public function translate($string, array $options = [])
+    {
+        return $this->translateBatch([$string], $options)[0];
+    }
+
+    /**
+     * Translate multiple strings from one language to another.
+     *
+     * Example:
+     * ```
+     * $translations = $translate->translateBatch([
+     *     'Hello world!',
+     *     'My name is David.'
+     * ]);
+     *
+     * foreach ($translations as $translation) {
+     *     echo $translation['text'];
+     * }
+     * ```
+     *
+     * @see https://cloud.google.com/translate/v2/translating-text-with-rest Translating Text
+     *
+     * @param array $strings An array of strings to translate.
+     * @param array $options {
+     *     Configuration Options.
+     *
+     *     @type string $source The source language to translate from. Must be a
+     *           valid ISO 639-1 language code. If not provided the value will
+     *           be automatically detected by the server.
+     *     @type string $target The target language to translate to. Must be a
+     *           valid ISO 639-1 language code. Defaults to the value assigned
+     *           to the client (`en` by default).
+     *     @type string $format Indicates whether the string to be translated is
+     *           either plain-text or HTML. Acceptable values are `html` or
+     *          `text`. Defaults to `html`.
+     * }
+     * @return array A set of translation results. Each result includes a
+     *         `source` key containing the detected or provided language of the
+     *         provided input, an `input` key containing the original string,
+     *         and a `text` key containing the translated result.
+     */
+    public function translateBatch($strings, array $options = [])
+    {
+        $response = $this->connection->listTranslations($options + [
+            'q' => $strings,
+            'key' => $this->key,
+            'target' => $this->targetLanguage
+        ]);
+
+        $translations = [];
+
+        foreach ($response['data']['translations'] as $key => $translation) {
+            $source = isset($translation['detectedSourceLanguage'])
+                ? $translation['detectedSourceLanguage']
+                : $options['source'];
+
+            $translations[] = [
+                'source' => $source,
+                'input' => $strings[$key],
+                'text' => $translation['translatedText']
+            ];
+        }
+
+        return $translations;
+    }
+
+    /**
+     * Detect the language of a string.
+     *
+     * Example:
+     * ```
+     * $result = $translate->detectLanguage('Hello world!');
+     *
+     * echo $result['languageCode'];
+     * ```
+     *
+     * @see https://cloud.google.com/translate/v2/detecting-language-with-rest Detecting Langauge
+     *
+     * @param string $string The string to detect the language of.
+     * @param array $options {
+     *     Configuration Options.
+     *
+     *     @type string $format Indicates whether the string to be translated is
+     *           either plain-text or HTML. Acceptable values are `html` or
+     *          `text`. Defaults to `html`.
+     * }
+     * @return array A result including a `languagecode` key
+     *         containing the detected ISO 639-1 language code, an `input` key
+     *         containing the original string, and in most cases a `confidence`
+     *         key containing a value between 0 - 1 signifying the confidence of
+     *         the result.
+     */
+    public function detectLanguage($string, array $options = [])
+    {
+        return $this->detectLanguageBatch([$string], $options)[0];
+    }
+
+    /**
+     * Detect the language of multiple strings.
+     *
+     * Example:
+     * ```
+     * $results = $translate->detectLanguageBatch([
+     *     'Hello World!',
+     *     'My name is David.'
+     * ]);
+     *
+     * foreach ($results as $result) {
+     *     echo $result['languageCode'];
+     * }
+     * ```
+     *
+     * @see https://cloud.google.com/translate/v2/detecting-language-with-rest Detecting Langauge
+     *
+     * @param string $string The string to detect the language of.
+     * @param array $options {
+     *     Configuration Options.
+     *
+     *     @type string $format Indicates whether the string to be translated is
+     *           either plain-text or HTML. Acceptable values are `html` or
+     *          `text`. Defaults to `html`.
+     * }
+     * @return array A set of results. Each result includes a `languageCode` key
+     *         containing the detected ISO 639-1 language code, an `input` key
+     *         containing the original string, and in most cases a `confidence`
+     *         key containing a value between 0 - 1 signifying the confidence of
+     *         the result.
+     */
+    public function detectLanguageBatch($strings, array $options = [])
+    {
+        $response =  $this->connection->listDetections($options + [
+            'q' => $strings,
+            'key' => $this->key
+        ]);
+
+        $detections = [];
+
+        foreach ($response['data']['detections'] as $key => $detection) {
+            $detection = $detection[0];
+
+            $detections[] = array_filter([
+                'languageCode' => $detection['language'],
+                'input' => $strings[$key],
+                'confidence' => isset($detection['confidence']) ? $detection['confidence'] : null
+            ]);
+        }
+
+        return $detections;
+    }
+
+    /**
+     * Get all supported languages.
+     *
+     * Example:
+     * ```
+     * $languages = $translate->languages();
+     *
+     * foreach ($languages as $language) {
+     *     echo $language;
+     * }
+     * ```
+     *
+     * @codingStandardsIgnoreStart
+     * @see https://cloud.google.com/translate/v2/discovering-supported-languages-with-rest Discovering Supported Languages
+     * @codingStandardsIgnoreEnd
+     *
+     * @param array $options Configuration options.
+     * @return array A list of supported ISO 639-1 language codes.
+     */
+    public function languages(array $options = [])
+    {
+        $response = $this->localizedLanguages($options + ['target' => null]);
+
+        return array_map(function ($language) {
+            return $language['code'];
+        }, $response);
+    }
+
+    /**
+     * Get the supported languages for translation in the targeted language.
+     *
+     * Unlike {@see Google\Cloud\Translate\TranslateClient::languages()} this
+     * will return the localized language names in addition to the ISO 639-1
+     * language codes.
+     *
+     * Example:
+     * ```
+     * $languages = $translate->localizedLanguages();
+     *
+     * foreach ($languages as $language) {
+     *     echo $language['code'];
+     * }
+     * ```
+     *
+     * @codingStandardsIgnoreStart
+     * @see https://cloud.google.com/translate/v2/discovering-supported-languages-with-rest Discovering Supported Languages
+     * @codingStandardsIgnoreEnd
+     *
+     * @param array $options {
+     *     Configuration Options.
+     *
+     *     @type string $target The language to discover supported languages
+     *           for. Must be a valid ISO 639-1 language code. Defaults to the
+     *           value assigned to the client (`en` by default).
+     * }
+     * @return array A set of language results. Each result includes a `code`
+     *         key containing the ISO 639-1 code for the supported language and
+     *         a `name` key containing the name of the language written in the
+     *         target language.
+     */
+    public function localizedLanguages(array $options = [])
+    {
+        $response = $this->connection->listLanguages($options + [
+            'key' => $this->key,
+            'target' => $this->targetLanguage
+        ]);
+
+        return array_map(function ($language) {
+            return array_filter([
+                'code' => $language['language'],
+                'name' => isset($language['name']) ? $language['name'] : null
+            ]);
+        }, $response['data']['languages']);
+    }
+}

--- a/src/Translate/TranslateClient.php
+++ b/src/Translate/TranslateClient.php
@@ -225,7 +225,7 @@ class TranslateClient
      *           either plain-text or HTML. Acceptable values are `html` or
      *          `text`. Defaults to `html`.
      * }
-     * @return array A result including a `languagecode` key
+     * @return array A result including a `languageCode` key
      *         containing the detected ISO 639-1 language code, an `input` key
      *         containing the original string, and in most cases a `confidence`
      *         key containing a value between 0 - 1 signifying the confidence of

--- a/src/Translate/TranslateClient.php
+++ b/src/Translate/TranslateClient.php
@@ -180,7 +180,7 @@ class TranslateClient
      *         provided input, an `input` key containing the original string,
      *         and a `text` key containing the translated result.
      */
-    public function translateBatch($strings, array $options = [])
+    public function translateBatch(array $strings, array $options = [])
     {
         $response = $this->connection->listTranslations($options + [
             'q' => $strings,
@@ -267,7 +267,7 @@ class TranslateClient
      *         key containing a value between 0 - 1 signifying the confidence of
      *         the result.
      */
-    public function detectLanguageBatch($strings, array $options = [])
+    public function detectLanguageBatch(array $strings, array $options = [])
     {
         $response =  $this->connection->listDetections($options + [
             'q' => $strings,

--- a/tests/ClientTraitTest.php
+++ b/tests/ClientTraitTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Tests;
 
 use Google\Cloud\ClientTrait;
+use GuzzleHttp\Psr7\Response;
 
 class ClientTraitTest extends \PHPUnit_Framework_TestCase
 {
@@ -99,7 +100,10 @@ class ClientTraitTest extends \PHPUnit_Framework_TestCase
 
         $trait = new ClientTraitStub;
         $conf = $trait->runDetectProjectId([
-            'keyFile' => $keyFile
+            'keyFile' => $keyFile,
+            'httpHandler' => function ($request, $options = []) {
+                return new Response(500);
+            }
         ]);
     }
 }

--- a/tests/ServiceBuilderTest.php
+++ b/tests/ServiceBuilderTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Tests;
 
 use Google\Cloud\ServiceBuilder;
+use Google\Cloud\Translate\TranslateClient;
 
 class ServiceBuilderTest extends \PHPUnit_Framework_TestCase
 {
@@ -40,6 +41,15 @@ class ServiceBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf($expectedClient, $globalConfigClient);
         $this->assertInstanceOf($expectedClient, $localConfigClient);
+    }
+
+    public function testBuildsTranslateClient()
+    {
+        $config = ['key' => 'test_key'];
+        $serviceBuilder = new ServiceBuilder($config);
+
+        $this->assertInstanceOf(TranslateClient::class, $serviceBuilder->translate());
+        $this->assertInstanceOf(TranslateClient::class, $serviceBuilder->translate($config));
     }
 
     public function serviceProvider()

--- a/tests/Translate/Connection/RestTest.php
+++ b/tests/Translate/Connection/RestTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Translate\Connection;
+
+use Google\Cloud\Translate\Connection\Rest;
+use Google\Cloud\RequestBuilder;
+use Google\Cloud\RequestWrapper;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Prophecy\Argument;
+use Psr\Http\Message\RequestInterface;
+use Rize\UriTemplate;
+
+/**
+ * @group translate
+ */
+class RestTest extends \PHPUnit_Framework_TestCase
+{
+    private $requestWrapper;
+    private $successBody;
+
+    public function setUp()
+    {
+        $this->requestWrapper = $this->prophesize(RequestWrapper::class);
+        $this->successBody = '{"canI":"kickIt"}';
+    }
+
+    /**
+     * @dataProvider methodProvider
+     * @todo revisit this approach
+     */
+    public function testCallBasicMethods($method)
+    {
+        $options = [];
+        $request = new Request('GET', '/somewhere');
+        $response = new Response(200, [], $this->successBody);
+
+        $requestBuilder = $this->prophesize(RequestBuilder::class);
+        $requestBuilder->build(
+            Argument::type('string'),
+            Argument::type('string'),
+            Argument::type('array')
+        )->willReturn($request);
+
+        $this->requestWrapper->send(
+            Argument::type(RequestInterface::class),
+            Argument::type('array')
+        )->willReturn($response);
+
+        $rest = new Rest();
+        $rest->setRequestBuilder($requestBuilder->reveal());
+        $rest->setRequestWrapper($this->requestWrapper->reveal());
+
+        $this->assertEquals(json_decode($this->successBody, true), $rest->$method($options));
+    }
+
+    public function methodProvider()
+    {
+        return [
+            ['listDetections'],
+            ['listTranslations'],
+            ['listLanguages']
+        ];
+    }
+}

--- a/tests/Translate/TranslateClientTest.php
+++ b/tests/Translate/TranslateClientTest.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Translate;
+
+use Google\Cloud\Translate\Connection\ConnectionInterface;
+use Google\Cloud\Translate\TranslateClient;
+use Prophecy\Argument;
+
+/**
+ * @group translate
+ */
+class TranslateClientTest extends \PHPUnit_Framework_TestCase
+{
+    private $client;
+    private $connection;
+    private $key = 'test_key';
+
+    public function setUp()
+    {
+        $this->client = new TranslateTestClient(['key' => $this->key]);
+        $this->connection = $this->prophesize(ConnectionInterface::class);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowsExceptionWithNoKey()
+    {
+        $client = new TranslateClient();
+    }
+
+    public function testTranslate()
+    {
+        $expected = $this->getTranslateExpectedData('translate', 'translated', 'en');
+        $options = [
+            'source' => $expected['source'],
+            'target' => 'de',
+            'format' => 'text'
+        ];
+        $this->connection
+            ->listTranslations($options + [
+                'q' => [$expected['input']],
+                'key' => $this->key
+            ])
+            ->willReturn([
+                'data' => [
+                    'translations' => [
+                        $this->getTranslateApiData($expected['text'])
+                    ]
+                ]
+            ])
+            ->shouldBeCalledTimes(1);
+        $this->client->setConnection($this->connection->reveal());
+        $translation = $this->client->translate($expected['input'], $options);
+
+        $this->assertEquals($expected, $translation);
+    }
+
+    public function testTranslateBatch()
+    {
+        $expected1 = $this->getTranslateExpectedData('translate', 'translated', 'en');
+        $expected2 = $this->getTranslateExpectedData('translate2', 'translated2', 'en');
+        $stringsToTranslate = [$expected1['input'], $expected2['input']];
+        $target = 'de';
+        $this->connection
+            ->listTranslations([
+                'target' => $target,
+                'q' => $stringsToTranslate,
+                'key' => $this->key
+            ])
+            ->willReturn([
+                'data' => [
+                    'translations' => [
+                        $this->getTranslateApiData($expected1['text'], $expected1['source']),
+                        $this->getTranslateApiData($expected2['text'], $expected2['source'])
+                    ]
+                ]
+            ])
+            ->shouldBeCalledTimes(1);
+        $client = new TranslateTestClient(['key' => $this->key, 'target' => $target]);
+        $client->setConnection($this->connection->reveal());
+        $translations = $client->translateBatch($stringsToTranslate);
+
+        $this->assertEquals($expected1, $translations[0]);
+        $this->assertEquals($expected2, $translations[1]);
+    }
+
+    public function testDetectLanguage()
+    {
+        $expected = $this->getDetectionExpectedData('text', 'en', .5);
+        $options = ['format' => 'text'];
+        $this->connection
+            ->listDetections($options + [
+                'q' => [$expected['input']],
+                'key' => $this->key
+            ])
+            ->willReturn([
+                'data' => [
+                    'detections' => [
+                        $this->getDetectionApiData($expected['languageCode'], $expected['confidence'])
+                    ]
+                ]
+            ])
+            ->shouldBeCalledTimes(1);
+        $this->client->setConnection($this->connection->reveal());
+        $detection = $this->client->detectLanguage($expected['input'], $options);
+
+        $this->assertEquals($expected, $detection);
+    }
+
+    public function testDetectLanguageBatch()
+    {
+        $expected1 = $this->getDetectionExpectedData('text', 'en', .5);
+        $expected2 = $this->getDetectionExpectedData('text2', 'en', .7);
+        $stringsToDetect = [$expected1['input'], $expected2['input']];
+        $this->connection
+            ->listDetections([
+                'q' => $stringsToDetect,
+                'key' => $this->key
+            ])
+            ->willReturn([
+                'data' => [
+                    'detections' => [
+                        $this->getDetectionApiData($expected1['languageCode'], $expected1['confidence']),
+                        $this->getDetectionApiData($expected2['languageCode'], $expected2['confidence'])
+                    ]
+                ]
+            ])
+            ->shouldBeCalledTimes(1);
+        $this->client->setConnection($this->connection->reveal());
+        $detections = $this->client->detectLanguageBatch($stringsToDetect);
+
+        $this->assertEquals($expected1, $detections[0]);
+        $this->assertEquals($expected2, $detections[1]);
+    }
+
+    public function testLocalizedLanguages()
+    {
+        $expected = [
+            'code' => 'es',
+            'name' => 'Spanish'
+        ];
+        $target = 'fr';
+        $this->connection
+            ->listLanguages([
+                'target' => $target,
+                'key' => $this->key
+            ])
+            ->willReturn([
+                'data' => [
+                    'languages' => [
+                        $this->getLanguageApiData($expected['code'], $expected['name'])
+                    ]
+                ]
+            ])
+            ->shouldBeCalledTimes(1);
+        $this->client->setConnection($this->connection->reveal());
+        $languages = $this->client->localizedLanguages(['target' => $target]);
+
+        $this->assertEquals($expected, $languages[0]);
+    }
+
+    public function testLanguages()
+    {
+        $expectedLanguage = 'es';
+        $this->connection
+            ->listLanguages([
+                'target' => null,
+                'key' => $this->key
+            ])
+            ->willReturn([
+                'data' => [
+                    'languages' => [
+                        $this->getLanguageApiData($expectedLanguage)
+                    ]
+                ]
+            ])
+            ->shouldBeCalledTimes(1);
+        $this->client->setConnection($this->connection->reveal());
+        $languages = $this->client->languages();
+
+        $this->assertEquals($expectedLanguage, $languages[0]);
+    }
+
+    private function getTranslateApiData($translatedText, $source = null)
+    {
+        return array_filter([
+            'translatedText' => $translatedText,
+            'detectedSourceLanguage' => $source
+        ]);
+    }
+
+    private function getTranslateExpectedData($textToTranslate, $translatedText, $source)
+    {
+        return [
+            'text' => $translatedText,
+            'source' => $source,
+            'input' => $textToTranslate
+        ];
+    }
+
+    private function getDetectionApiData($language, $confidence)
+    {
+        return array_filter([
+            [
+                'language' => $language,
+                'isReliable' => false,
+                'confidence' => $confidence
+            ]
+        ]);
+    }
+
+    private function getDetectionExpectedData($textToDetect, $detectedLanguage, $confidence = null)
+    {
+        return array_filter([
+            'input' => $textToDetect,
+            'languageCode' => $detectedLanguage,
+            'confidence' => $confidence
+        ]);
+    }
+
+    private function getLanguageApiData($languageCode, $name = null)
+    {
+        return array_filter([
+            'language' => $languageCode,
+            'name' => $name
+        ]);
+    }
+}
+
+class TranslateTestClient extends TranslateClient
+{
+    public function setConnection($connection)
+    {
+        $this->connection = $connection;
+    }
+}


### PR DESCRIPTION
Ready for review/feedback!

[Official Translate API docs](https://cloud.google.com/translate/docs/)

#### Quick overview
- The constructor accepts a `target` language which is used by default in any requests that require a target language (defaults to english if not provided). It is possible to override this in each method if preferred as well.
- Public methods implemented
  - `public function translate($string, array $options = [])` 
  - `public function translateBatch(array $strings, array $options = [])`
  - `public function detectLanguage($string, array $options = [])`
  - `public function detectLanguageBatch(array $strings, array $options = [])`
  - `public function languages(array $options = [])`
  - `public function localizedLanguages(array $options = [])`