### PR TITLE
Verify that human-curated json files are valid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
     "phpunit/phpunit": "4.8.*",
     "squizlabs/php_codesniffer": "2.*",
     "phpdocumentor/phpdocumentor": "2.8.*",
-    "symfony/console": "2.*"
+    "symfony/console": "2.*",
+    "league/json-guard": "^0.3"
   },
   "autoload": {
     "psr-4": {

--- a/tests/CallTraitTest.php
+++ b/tests/CallTraitTest.php
@@ -19,6 +19,9 @@ namespace Google\Cloud\Test;
 
 use Google\Cloud\CallTrait;
 
+/**
+ * @group root
+ */
 class CallTraitTest extends \PHPUnit_Framework_TestCase
 {
     public function testCall()

--- a/tests/ClientTraitTest.php
+++ b/tests/ClientTraitTest.php
@@ -20,6 +20,9 @@ namespace Google\Cloud\Tests;
 use Google\Cloud\ClientTrait;
 use GuzzleHttp\Psr7\Response;
 
+/**
+ * @group root
+ */
 class ClientTraitTest extends \PHPUnit_Framework_TestCase
 {
     public function testConfigureAuthentication()

--- a/tests/ExponentialBackoffTest.php
+++ b/tests/ExponentialBackoffTest.php
@@ -20,6 +20,9 @@ namespace Google\Cloud\Tests;
 use Google\Cloud\ExponentialBackoff;
 use Prophecy\Argument;
 
+/**
+ * @group root
+ */
 class ExponentialBackoffTest extends \PHPUnit_Framework_TestCase
 {
     private $delayFunction;

--- a/tests/JsonFileTest.php
+++ b/tests/JsonFileTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests;
+
+use League\JsonGuard\Dereferencer;
+use League\JsonGuard\Validator;
+
+/**
+ * @group root
+ */
+class JsonFileTest extends \PHPUnit_Framework_TestCase
+{
+    public function testComposer()
+    {
+        $file = file_get_contents(__DIR__ .'/../composer.json');
+        $json = json_decode($file);
+        $this->assertEquals(JSON_ERROR_NONE, json_last_error());
+
+        $deref  = new Dereferencer();
+        $schema = $deref->dereference('https://getcomposer.org/schema.json');
+
+        $validator = new Validator($json, $schema);
+
+        $this->assertFalse($validator->fails());
+    }
+
+    public function testManifest()
+    {
+        $file = file_get_contents(__DIR__ .'/../docs/manifest.json');
+        $json = json_decode($file);
+        $this->assertEquals(JSON_ERROR_NONE, json_last_error());
+
+        $deref  = new Dereferencer();
+        $schema = $deref->dereference('https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/site/schemas/manifest.schema.json');
+
+        $validator = new Validator($json, $schema);
+
+        $this->assertFalse($validator->fails());
+    }
+
+    public function testToc()
+    {
+        $file = file_get_contents(__DIR__ .'/../docs/toc.json');
+        $json = json_decode($file);
+        $this->assertEquals(JSON_ERROR_NONE, json_last_error());
+
+        $deref  = new Dereferencer();
+        $schema = $deref->dereference('https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/site/schemas/toc.schema.json');
+
+        $validator = new Validator($json, $schema);
+
+        $this->assertFalse($validator->fails());
+    }
+}

--- a/tests/JsonFileTest.php
+++ b/tests/JsonFileTest.php
@@ -25,6 +25,8 @@ use League\JsonGuard\Validator;
  */
 class JsonFileTest extends \PHPUnit_Framework_TestCase
 {
+    const SCHEMA_PATH = '%s/fixtures/schema/%s';
+
     public function testComposer()
     {
         $file = file_get_contents(__DIR__ .'/../composer.json');
@@ -32,7 +34,10 @@ class JsonFileTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(JSON_ERROR_NONE, json_last_error());
 
         $deref  = new Dereferencer();
-        $schema = $deref->dereference('https://getcomposer.org/schema.json');
+        $schema = $deref->dereference(json_decode(file_get_contents(sprintf(
+            self::SCHEMA_PATH,
+            __DIR__, 'composer.json.schema'
+        ))));
 
         $validator = new Validator($json, $schema);
 
@@ -46,7 +51,10 @@ class JsonFileTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(JSON_ERROR_NONE, json_last_error());
 
         $deref  = new Dereferencer();
-        $schema = $deref->dereference('https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/site/schemas/manifest.schema.json');
+        $schema = $deref->dereference(json_decode(file_get_contents(sprintf(
+            self::SCHEMA_PATH,
+            __DIR__, 'manifest.json.schema'
+        ))));
 
         $validator = new Validator($json, $schema);
 
@@ -60,7 +68,10 @@ class JsonFileTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(JSON_ERROR_NONE, json_last_error());
 
         $deref  = new Dereferencer();
-        $schema = $deref->dereference('https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/site/schemas/toc.schema.json');
+        $schema = $deref->dereference(json_decode(file_get_contents(sprintf(
+            self::SCHEMA_PATH,
+            __DIR__, 'toc.json.schema'
+        ))));
 
         $validator = new Validator($json, $schema);
 

--- a/tests/RequestBuilderTest.php
+++ b/tests/RequestBuilderTest.php
@@ -20,6 +20,9 @@ namespace Google\Cloud\Tests;
 use Google\Cloud\RequestBuilder;
 use Prophecy\Argument;
 
+/**
+ * @group root
+ */
 class RequestBuilderTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()

--- a/tests/RequestWrapperTest.php
+++ b/tests/RequestWrapperTest.php
@@ -24,6 +24,9 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 
+/**
+ * @group root
+ */
 class RequestWrapperTest extends \PHPUnit_Framework_TestCase
 {
     public function testSuccessfullySendsRequest()

--- a/tests/RestTraitTest.php
+++ b/tests/RestTraitTest.php
@@ -23,7 +23,7 @@ use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 
 /**
- * @group core
+ * @group root
  */
 class RestTraitTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/ServiceBuilderTest.php
+++ b/tests/ServiceBuilderTest.php
@@ -20,6 +20,9 @@ namespace Google\Cloud\Tests;
 use Google\Cloud\ServiceBuilder;
 use Google\Cloud\Translate\TranslateClient;
 
+/**
+ * @group root
+ */
 class ServiceBuilderTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/UriTraitTest.php
+++ b/tests/UriTraitTest.php
@@ -19,6 +19,9 @@ namespace Google\Cloud\Tests;
 
 use Google\Cloud\UriTrait;
 
+/**
+ * @group root
+ */
 class UriTraitTest extends \PHPUnit_Framework_TestCase
 {
     private $implementation;

--- a/tests/fixtures/schema/composer.json.schema
+++ b/tests/fixtures/schema/composer.json.schema
@@ -1,0 +1,492 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "name": "Package",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [ "name", "description" ],
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Package name, including 'vendor-name/' prefix."
+        },
+        "type": {
+            "description": "Package type, either 'library' for common packages, 'composer-plugin' for plugins, 'metapackage' for empty packages, or a custom type ([a-z0-9-]+) defined by whatever project this package applies to.",
+            "type": "string"
+        },
+        "target-dir": {
+            "description": "DEPRECATED: Forces the package to be installed into the given subdirectory path. This is used for autoloading PSR-0 packages that do not contain their full path. Use forward slashes for cross-platform compatibility.",
+            "type": "string"
+        },
+        "description": {
+            "type": "string",
+            "description": "Short package description."
+        },
+        "keywords": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "description": "A tag/keyword that this package relates to."
+            }
+        },
+        "homepage": {
+            "type": "string",
+            "description": "Homepage URL for the project.",
+            "format": "uri"
+        },
+        "version": {
+            "type": "string",
+            "description": "Package version, see https://getcomposer.org/doc/04-schema.md#version for more info on valid schemes."
+        },
+        "time": {
+            "type": "string",
+            "description": "Package release date, in 'YYYY-MM-DD', 'YYYY-MM-DD HH:MM:SS' or 'YYYY-MM-DDTHH:MM:SSZ' format."
+        },
+        "license": {
+            "type": ["string", "array"],
+            "description": "License name. Or an array of license names."
+        },
+        "authors": {
+            "type": "array",
+            "description": "List of authors that contributed to the package. This is typically the main maintainers, not the full list.",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [ "name"],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Full name of the author."
+                    },
+                    "email": {
+                        "type": "string",
+                        "description": "Email address of the author.",
+                        "format": "email"
+                    },
+                    "homepage": {
+                        "type": "string",
+                        "description": "Homepage URL for the author.",
+                        "format": "uri"
+                    },
+                    "role": {
+                        "type": "string",
+                        "description": "Author's role in the project."
+                    }
+                }
+            }
+        },
+        "require": {
+            "type": "object",
+            "description": "This is a hash of package name (keys) and version constraints (values) that are required to run this package.",
+            "additionalProperties": true
+        },
+        "replace": {
+            "type": "object",
+            "description": "This is a hash of package name (keys) and version constraints (values) that can be replaced by this package.",
+            "additionalProperties": true
+        },
+        "conflict": {
+            "type": "object",
+            "description": "This is a hash of package name (keys) and version constraints (values) that conflict with this package.",
+            "additionalProperties": true
+        },
+        "provide": {
+            "type": "object",
+            "description": "This is a hash of package name (keys) and version constraints (values) that this package provides in addition to this package's name.",
+            "additionalProperties": true
+        },
+        "require-dev": {
+            "type": "object",
+            "description": "This is a hash of package name (keys) and version constraints (values) that this package requires for developing it (testing tools and such).",
+            "additionalProperties": true
+        },
+        "suggest": {
+            "type": "object",
+            "description": "This is a hash of package name (keys) and descriptions (values) that this package suggests work well with it (this will be suggested to the user during installation).",
+            "additionalProperties": true
+        },
+        "config": {
+            "type": "object",
+            "description": "Composer options.",
+            "properties": {
+                "process-timeout": {
+                    "type": "integer",
+                    "description": "The timeout in seconds for process executions, defaults to 300 (5mins)."
+                },
+                "use-include-path": {
+                    "type": "boolean",
+                    "description": "If true, the Composer autoloader will also look for classes in the PHP include path."
+                },
+                "preferred-install": {
+                    "type": ["string", "object"],
+                    "description": "The install method Composer will prefer to use, defaults to auto and can be any of source, dist, auto, or a hash of {\"pattern\": \"preference\"}."
+                },
+                "notify-on-install": {
+                    "type": "boolean",
+                    "description": "Composer allows repositories to define a notification URL, so that they get notified whenever a package from that repository is installed. This option allows you to disable that behaviour, defaults to true."
+                },
+                "github-protocols": {
+                    "type": "array",
+                    "description": "A list of protocols to use for github.com clones, in priority order, defaults to [\"git\", \"https\", \"http\"].",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "github-oauth": {
+                    "type": "object",
+                    "description": "A hash of domain name => github API oauth tokens, typically {\"github.com\":\"<token>\"}.",
+                    "additionalProperties": true
+                },
+                "gitlab-oauth": {
+                    "type": "object",
+                    "description": "A hash of domain name => gitlab API oauth tokens, typically {\"gitlab.com\":\"<token>\"}.",
+                    "additionalProperties": true
+                },
+                "disable-tls": {
+                    "type": "boolean",
+                    "description": "Defaults to `false`. If set to true all HTTPS URLs will be tried with HTTP instead and no network level encryption is performed. Enabling this is a security risk and is NOT recommended. The better way is to enable the php_openssl extension in php.ini."
+                },
+                "secure-http": {
+                    "type": "boolean",
+                    "description": "Defaults to `true`. If set to true only HTTPS URLs are allowed to be downloaded via Composer. If you really absolutely need HTTP access to something then you can disable it, but using \"Let's Encrypt\" to get a free SSL certificate is generally a better alternative."
+                },
+                "cafile": {
+                    "type": "string",
+                    "description": "A way to set the path to the openssl CA file. In PHP 5.6+ you should rather set this via openssl.cafile in php.ini, although PHP 5.6+ should be able to detect your system CA file automatically."
+                },
+                "capath": {
+                    "type": "string",
+                    "description": "If cafile is not specified or if the certificate is not found there, the directory pointed to by capath is searched for a suitable certificate. capath must be a correctly hashed certificate directory."
+                },
+                "http-basic": {
+                    "type": "object",
+                    "description": "A hash of domain name => {\"username\": \"...\", \"password\": \"...\"}.",
+                    "additionalProperties": true
+                },
+                "store-auths": {
+                    "type": ["string", "boolean"],
+                    "description": "What to do after prompting for authentication, one of: true (store), false (do not store) or \"prompt\" (ask every time), defaults to prompt."
+                },
+                "platform": {
+                    "type": "object",
+                    "description": "This is a hash of package name (keys) and version (values) that will be used to mock the platform packages on this machine.",
+                    "additionalProperties": true
+                },
+                "vendor-dir": {
+                    "type": "string",
+                    "description": "The location where all packages are installed, defaults to \"vendor\"."
+                },
+                "bin-dir": {
+                    "type": "string",
+                    "description": "The location where all binaries are linked, defaults to \"vendor/bin\"."
+                },
+                "data-dir": {
+                    "type": "string",
+                    "description": "The location where old phar files are stored, defaults to \"$home\" except on XDG Base Directory compliant unixes."
+                },
+                "cache-dir": {
+                    "type": "string",
+                    "description": "The location where all caches are located, defaults to \"~/.composer/cache\" on *nix and \"%LOCALAPPDATA%\\Composer\" on windows."
+                },
+                "cache-files-dir": {
+                    "type": "string",
+                    "description": "The location where files (zip downloads) are cached, defaults to \"{$cache-dir}/files\"."
+                },
+                "cache-repo-dir": {
+                    "type": "string",
+                    "description": "The location where repo (git/hg repo clones) are cached, defaults to \"{$cache-dir}/repo\"."
+                },
+                "cache-vcs-dir": {
+                    "type": "string",
+                    "description": "The location where vcs infos (git clones, github api calls, etc. when reading vcs repos) are cached, defaults to \"{$cache-dir}/vcs\"."
+                },
+                "cache-ttl": {
+                    "type": "integer",
+                    "description": "The default cache time-to-live, defaults to 15552000 (6 months)."
+                },
+                "cache-files-ttl": {
+                    "type": "integer",
+                    "description": "The cache time-to-live for files, defaults to the value of cache-ttl."
+                },
+                "cache-files-maxsize": {
+                    "type": ["string", "integer"],
+                    "description": "The cache max size for the files cache, defaults to \"300MiB\"."
+                },
+                "bin-compat": {
+                    "enum": ["auto", "full"],
+                    "description": "The compatibility of the binaries, defaults to \"auto\" (automatically guessed) and can be \"full\" (compatible with both Windows and Unix-based systems)."
+                },
+                "discard-changes": {
+                    "type": ["string", "boolean"],
+                    "description": "The default style of handling dirty updates, defaults to false and can be any of true, false or \"stash\"."
+                },
+                "autoloader-suffix": {
+                    "type": "string",
+                    "description": "Optional string to be used as a suffix for the generated Composer autoloader. When null a random one will be generated."
+                },
+                "optimize-autoloader": {
+                    "type": "boolean",
+                    "description": "Always optimize when dumping the autoloader."
+                },
+                "prepend-autoloader": {
+                    "type": "boolean",
+                    "description": "If false, the composer autoloader will not be prepended to existing autoloaders, defaults to true."
+                },
+                "classmap-authoritative": {
+                    "type": "boolean",
+                    "description": "If true, the composer autoloader will not scan the filesystem for classes that are not found in the class map, defaults to false."
+                },
+                "github-domains": {
+                    "type": "array",
+                    "description": "A list of domains to use in github mode. This is used for GitHub Enterprise setups, defaults to [\"github.com\"].",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "github-expose-hostname": {
+                    "type": "boolean",
+                    "description": "Defaults to true. If set to false, the OAuth tokens created to access the github API will have a date instead of the machine hostname."
+                },
+                "gitlab-domains": {
+                    "type": "array",
+                    "description": "A list of domains to use in gitlab mode. This is used for custom GitLab setups, defaults to [\"gitlab.com\"].",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "archive-format": {
+                    "type": "string",
+                    "description": "The default archiving format when not provided on cli, defaults to \"tar\"."
+                },
+                "archive-dir": {
+                    "type": "string",
+                    "description": "The default archive path when not provided on cli, defaults to \".\"."
+                }
+            }
+        },
+        "extra": {
+            "type": ["object", "array"],
+            "description": "Arbitrary extra data that can be used by plugins, for example, package of type composer-plugin may have a 'class' key defining an installer class name.",
+            "additionalProperties": true
+        },
+        "autoload": {
+            "type": "object",
+            "description": "Description of how the package can be autoloaded.",
+            "properties": {
+                "psr-0": {
+                    "type": "object",
+                    "description": "This is a hash of namespaces (keys) and the directories they can be found in (values, can be arrays of paths) by the autoloader.",
+                    "additionalProperties": true
+                },
+                "psr-4": {
+                    "type": "object",
+                    "description": "This is a hash of namespaces (keys) and the PSR-4 directories they can map to (values, can be arrays of paths) by the autoloader.",
+                    "additionalProperties": true
+                },
+                "classmap": {
+                    "type": "array",
+                    "description": "This is an array of directories that contain classes to be included in the class-map generation process."
+                },
+                "files": {
+                    "type": "array",
+                    "description": "This is an array of files that are always required on every request."
+                },
+                "exclude-from-classmap": {
+                    "type": "array",
+                    "description": "This is an array of patterns to exclude from autoload classmap generation. (e.g. \"exclude-from-classmap\": [\"/test/\", \"/tests/\", \"/Tests/\"]"
+                }
+            }
+        },
+        "autoload-dev": {
+            "type": "object",
+            "description": "Description of additional autoload rules for development purpose (eg. a test suite).",
+            "properties": {
+                "psr-0": {
+                    "type": "object",
+                    "description": "This is a hash of namespaces (keys) and the directories they can be found into (values, can be arrays of paths) by the autoloader.",
+                    "additionalProperties": true
+                },
+                "psr-4": {
+                    "type": "object",
+                    "description": "This is a hash of namespaces (keys) and the PSR-4 directories they can map to (values, can be arrays of paths) by the autoloader.",
+                    "additionalProperties": true
+                },
+                "classmap": {
+                    "type": "array",
+                    "description": "This is an array of directories that contain classes to be included in the class-map generation process."
+                },
+                "files": {
+                    "type": "array",
+                    "description": "This is an array of files that are always required on every request."
+                }
+            }
+        },
+        "archive": {
+            "type": ["object"],
+            "description": "Options for creating package archives for distribution.",
+            "properties": {
+                "exclude": {
+                    "type": "array",
+                    "description": "A list of patterns for paths to exclude or include if prefixed with an exclamation mark."
+                }
+            }
+        },
+        "repositories": {
+            "type": ["object", "array"],
+            "description": "A set of additional repositories where packages can be found.",
+            "additionalProperties": true
+        },
+        "minimum-stability": {
+            "type": ["string"],
+            "description": "The minimum stability the packages must have to be install-able. Possible values are: dev, alpha, beta, RC, stable.",
+            "pattern": "^dev|alpha|beta|rc|RC|stable$"
+        },
+        "prefer-stable": {
+            "type": ["boolean"],
+            "description": "If set to true, stable packages will be preferred to dev packages when possible, even if the minimum-stability allows unstable packages."
+        },
+        "bin": {
+            "type": ["array"],
+            "description": "A set of files that should be treated as binaries and symlinked into bin-dir (from config).",
+            "items": {
+                "type": "string"
+            }
+        },
+        "include-path": {
+            "type": ["array"],
+            "description": "DEPRECATED: A list of directories which should get added to PHP's include path. This is only present to support legacy projects, and all new code should preferably use autoloading.",
+            "items": {
+                "type": "string"
+            }
+        },
+        "scripts": {
+            "type": ["object"],
+            "description": "Scripts listeners that will be executed before/after some events.",
+            "properties": {
+                "pre-install-cmd": {
+                    "type": ["array", "string"],
+                    "description": "Occurs before the install command is executed, contains one or more Class::method callables or shell commands."
+                },
+                "post-install-cmd": {
+                    "type": ["array", "string"],
+                    "description": "Occurs after the install command is executed, contains one or more Class::method callables or shell commands."
+                },
+                "pre-update-cmd": {
+                    "type": ["array", "string"],
+                    "description": "Occurs before the update command is executed, contains one or more Class::method callables or shell commands."
+                },
+                "post-update-cmd": {
+                    "type": ["array", "string"],
+                    "description": "Occurs after the update command is executed, contains one or more Class::method callables or shell commands."
+                },
+                "pre-status-cmd": {
+                    "type": ["array", "string"],
+                    "description": "Occurs before the status command is executed, contains one or more Class::method callables or shell commands."
+                },
+                "post-status-cmd": {
+                    "type": ["array", "string"],
+                    "description": "Occurs after the status command is executed, contains one or more Class::method callables or shell commands."
+                },
+                "pre-package-install": {
+                    "type": ["array", "string"],
+                    "description": "Occurs before a package is installed, contains one or more Class::method callables or shell commands."
+                },
+                "post-package-install": {
+                    "type": ["array", "string"],
+                    "description": "Occurs after a package is installed, contains one or more Class::method callables or shell commands."
+                },
+                "pre-package-update": {
+                    "type": ["array", "string"],
+                    "description": "Occurs before a package is updated, contains one or more Class::method callables or shell commands."
+                },
+                "post-package-update": {
+                    "type": ["array", "string"],
+                    "description": "Occurs after a package is updated, contains one or more Class::method callables or shell commands."
+                },
+                "pre-package-uninstall": {
+                    "type": ["array", "string"],
+                    "description": "Occurs before a package has been uninstalled, contains one or more Class::method callables or shell commands."
+                },
+                "post-package-uninstall": {
+                    "type": ["array", "string"],
+                    "description": "Occurs after a package has been uninstalled, contains one or more Class::method callables or shell commands."
+                },
+                "pre-autoload-dump": {
+                    "type": ["array", "string"],
+                    "description": "Occurs before the autoloader is dumped, contains one or more Class::method callables or shell commands."
+                },
+                "post-autoload-dump": {
+                    "type": ["array", "string"],
+                    "description": "Occurs after the autoloader is dumped, contains one or more Class::method callables or shell commands."
+                },
+                "post-root-package-install": {
+                    "type": ["array", "string"],
+                    "description": "Occurs after the root-package is installed, contains one or more Class::method callables or shell commands."
+                },
+                "post-create-project-cmd": {
+                    "type": ["array", "string"],
+                    "description": "Occurs after the create-project command is executed, contains one or more Class::method callables or shell commands."
+                }
+            }
+        },
+        "support": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "description": "Email address for support.",
+                    "format": "email"
+                },
+                "issues": {
+                    "type": "string",
+                    "description": "URL to the issue tracker.",
+                    "format": "uri"
+                },
+                "forum": {
+                    "type": "string",
+                    "description": "URL to the forum.",
+                    "format": "uri"
+                },
+                "wiki": {
+                    "type": "string",
+                    "description": "URL to the wiki.",
+                    "format": "uri"
+                },
+                "irc": {
+                    "type": "string",
+                    "description": "IRC channel for support, as irc://server/channel.",
+                    "format": "uri"
+                },
+                "source": {
+                    "type": "string",
+                    "description": "URL to browse or download the sources.",
+                    "format": "uri"
+                },
+                "docs": {
+                    "type": "string",
+                    "description": "URL to the documentation.",
+                    "format": "uri"
+                },
+                "rss": {
+                    "type": "string",
+                    "description": "URL to the RSS feed.",
+                    "format": "uri"
+                }
+            }
+        },
+        "non-feature-branches": {
+            "type": ["array"],
+            "description": "A set of string or regex patterns for non-numeric branch names that will not be handled as feature branches.",
+            "items": {
+                "type": "string"
+            }
+        },
+        "abandoned": {
+            "type": ["boolean", "string"],
+            "description": "Indicates whether this package has been abandoned, it can be boolean or a package name/URL pointing to a recommended alternative. Defaults to false."
+        },
+        "_comment": {
+            "type": ["array", "string"],
+            "description": "A key to store comments in"
+        }
+    }
+}

--- a/tests/fixtures/schema/manifest.json.schema
+++ b/tests/fixtures/schema/manifest.json.schema
@@ -1,0 +1,170 @@
+{
+  "id": "manifest",
+  "type": "object",
+  "properties": {
+    "lang": {
+      "id": "lang",
+      "type": "string",
+      "description": "Language id, this will be used to generate links for issues, StackOverflow, etc."
+    },
+    "friendlyLang": {
+      "id": "friendlyLang",
+      "type": "string",
+      "description": "User friendly name of language, may be used as page title."
+    },
+    "libraryTitle": {
+      "id": "libraryTitle",
+      "type": "string",
+      "description": "The library's title."
+    },
+    "defaultService": {
+      "id": "defaultService",
+      "type": "string",
+      "description": "Custom service type to load by default."
+    },
+    "moduleName": {
+      "id": "moduleName",
+      "type": "string",
+      "description": "Name of the module used to link to Github repo"
+    },
+    "defaultModule": {
+      "id": "defaultModule",
+      "type": "string",
+      "description": "id of default module when using modular docs"
+    },
+    "markdown": {
+      "id": "markdown",
+      "type": "string",
+      "description": "id of syntax highlighting flavor for highlightjs. "
+    },
+    "versions": {
+      "id": "versions",
+      "type": "array",
+      "description": "List of all available versions the user can switch between.",
+      "items": {
+        "id": "version",
+        "type": "string",
+        "description": "Valid semver version string"
+      }
+    },
+    "content": {
+      "id": "content",
+      "type": "string",
+      "description": "Directory containing JSON/markdown content"
+    },
+    "home": {
+      "id": "home",
+      "type": "string",
+      "description": "Path to landing page content"
+    },
+    "package": {
+      "id": "package",
+      "type": "object",
+      "description": "Object describing package information",
+      "properties": {
+        "title": {
+          "id": "title",
+          "type": "string",
+          "description": "Name of the package manager"
+        },
+        "href": {
+          "id": "href",
+          "type": "string",
+          "description": "URL for the package"
+        }
+      },
+      "required": [
+        "title",
+        "href"
+      ]
+    },
+    "methodTypeSymbols": {
+      "id": "methodTypeSymbols",
+      "type": "array",
+      "description": "List of mappings from method types to display symbols",
+      "items": {
+        "id": "methodTypeSymbol",
+        "type": "object",
+        "description": "Maps a method type ('instance') to a symbol ('#')",
+        "properties": {
+          "type": {
+            "id": "type",
+            "type": "string",
+            "description": "The language-specific type name of the method"
+          },
+          "symbol": {
+            "id": "symbol",
+            "type": "string",
+            "description": "The language-specific symbol for the method type"
+          }
+        },
+        "required": [
+          "type",
+          "symbol"
+        ]
+      }
+    },
+    "modules": {
+      "id": "modules",
+      "type": "array",
+      "description": "List of modules and their versions",
+      "items": {
+        "id": "module",
+        "type": "object",
+        "description": "Information for individual module",
+        "properties": {
+          "id": {
+            "id": "id",
+            "type": "string",
+            "description": "id used within route parameter"
+          },
+          "name": {
+            "id": "name",
+            "type": "string",
+            "description": "Friendly name used for module switching dropdown"
+          },
+          "defaultService": {
+            "id": "defaultService",
+            "type": "string",
+            "description": "The id of the default service for the module"
+          },
+          "versions": {
+            "id": "versions",
+            "type": "array",
+            "description": "An array of all available versions for this module",
+            "items": {
+              "id": "version",
+              "type": "string",
+              "description": "The semver version string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "defaultService",
+          "versions"
+        ]
+      }
+    }
+  },
+  "required": [
+    "lang",
+    "friendlyLang",
+    "moduleName",
+    "markdown",
+    "content",
+    "home",
+    "package"
+  ],
+  "oneOf": [{
+    "required": [
+      "versions"
+    ]
+  }, {
+    "required": [
+      "defaultModule",
+      "modules"
+    ]
+  }]
+}

--- a/tests/fixtures/schema/toc.json.schema
+++ b/tests/fixtures/schema/toc.json.schema
@@ -1,0 +1,111 @@
+{
+  "id": "toc",
+  "type": "object",
+  "properties": {
+    "overview": {
+      "id": "overview",
+      "type": "string",
+      "description": "Optional content to be injected at the top of service pages"
+    },
+    "guides": {
+      "id": "guides",
+      "type": "array",
+      "description": "Table of contents for the Getting Started section",
+      "items": {
+        "id": "guide",
+        "type": "object",
+        "description": "Object that describes a Guide",
+        "properties": {
+          "title": {
+            "id": "title",
+            "type": "string",
+            "description": "Name of the guide as it should appear in the Navigation"
+          },
+          "id": {
+            "id": "id",
+            "type": "string",
+            "description": "Guide id used for routing and mapping JSON content"
+          },
+          "edit": {
+            "id": "edit",
+            "type": "string",
+            "description": "URL to Github edit page for supplied markdown"
+          },
+          "contents": {
+            "id": "contents",
+            "type": ["array", "string"],
+            "description": "List of markdown files to display",
+            "items": [
+              {
+                "id": "guide_url",
+                "type": "string",
+                "description": "Path to markdown file, if it does not begin with http(s), it's assumed to be a local file"
+              }
+            ]
+          }
+        },
+        "required": [
+          "title",
+          "id",
+          "contents"
+        ]
+      }
+    },
+    "services": {
+      "id": "services",
+      "type": "array",
+      "description": "Table of contents for the API section",
+      "items": {
+        "id": "service",
+        "type": "object",
+        "description": "Object that describes a service",
+        "properties": {
+          "title": {
+            "id": "title",
+            "type": "string",
+            "description": "Name of the service as it should appear in the side navigation"
+          },
+          "type": {
+            "id": "type",
+            "type": "string",
+            "description": "ID of type that maps JSON content"
+          },
+          "nav": {
+            "id": "nav",
+            "type": "array",
+            "description": "Concepts to be nested within the Service, e.g. Storage -> Bucket",
+            "items": {
+              "id": "sub-service",
+              "type": "object",
+              "description": "Object describing the sub-service",
+              "properties": {
+                "title": {
+                  "id": "title",
+                  "type": "string",
+                  "description": "Name of the sub-service as it should appear in the side navigation"
+                },
+                "type": {
+                  "id": "type",
+                  "type": "string",
+                  "description": "ID of type that maps JSON content"
+                }
+              },
+              "required": [
+                "title",
+                "type"
+              ]
+            }
+          }
+        },
+        "required": [
+          "title",
+          "type"
+        ]
+      }
+    }
+  },
+  "required": [
+    "guides",
+    "services"
+  ]
+}


### PR DESCRIPTION
We've got a few json files that are curated by hand, including composer.json, docs/toc.json and docs/manifest.json. If any changes to those files were invalid, it could cause serious problems until resolved.

This change adds a test case to check those three json files for valid JSON, and it also validates the contents against their respective schema documents. If any violations are found, the test will fail, giving us an early alert of potential problems in the documents.

This change adds `league/json-guard` as a dev dependency. Keep in mind that this dependency will not be installed by consuming applications.

I also added a group annotation to each test case in the root `tests` folder.