### PR TITLE
Change return value of VisionClient::annotateBatch()

### DIFF
--- a/scripts/DocGenerator.php
+++ b/scripts/DocGenerator.php
@@ -101,9 +101,14 @@ class DocGenerator
 
         $docBlock = $reflector->getDocBlock();
 
-        $magicMethods = array_filter($docBlock->getTags(), function ($tag) {
-            return ($tag->getName() === 'method');
-        });
+        $magic = [];
+        if ($docBlock && $docBlock->getTags()) {
+            $magicMethods = array_filter($docBlock->getTags(), function ($tag) {
+                return ($tag->getName() === 'method');
+            });
+
+            $magic = $this->buildMagicMethods($magicMethods, $name);
+        }
 
         $methods = $reflector->getMethods();
 
@@ -123,7 +128,7 @@ class DocGenerator
             'resources' => $this->buildResources($docBlock->getTagsByName('see')),
             'methods' => array_merge(
                 $this->buildMethods($methods, $name),
-                $this->buildMagicMethods($magicMethods, $name)
+                $magic
             )
         ];
     }

--- a/src/ClientTrait.php
+++ b/src/ClientTrait.php
@@ -125,8 +125,8 @@ trait ClientTrait
             return $config['keyFile']['project_id'];
         }
 
-        if (GCECredentials::onGce($config['httpHandler'])) {
-            $metadata = new Metadata();
+        if ($this->onGce($config['httpHandler'])) {
+            $metadata = $this->getMetaData();
             $projectId = $metadata->getProjectId();
             if ($projectId) {
                 return $projectId;
@@ -137,5 +137,27 @@ trait ClientTrait
             'No project ID was provided, ' .
             'and we were unable to detect a default project ID.'
         );
+    }
+
+    /**
+     * Abstract the GCECredentials call so we can mock it in the unit tests!
+     *
+     * @codeCoverageIgnore
+     * @return bool
+     */
+    protected function onGce($httpHandler)
+    {
+        return GCECredentials::onGce($httpHandler);
+    }
+
+    /**
+     * Abstract the Metadata instantiation for unit testing
+     *
+     * @codeCoverageIgnore
+     * @return Metadata
+     */
+    protected function getMetaData()
+    {
+        return new Metadata;
     }
 }

--- a/src/Datastore/Operation.php
+++ b/src/Datastore/Operation.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Datastore;
 use Google\Cloud\Datastore\Connection\ConnectionInterface;
 use Google\Cloud\Datastore\Connection\Rest;
 use Google\Cloud\Datastore\Query\QueryInterface;
+use Google\Cloud\ValidateTrait;
 use InvalidArgumentException;
 
 /**
@@ -36,6 +37,7 @@ use InvalidArgumentException;
 class Operation
 {
     use DatastoreTrait;
+    use ValidateTrait;
 
     /**
      * @var ConnectionInterface
@@ -645,34 +647,5 @@ class Operation
         return [
             'readConsistency' => $options['readConsistency']
         ];
-    }
-
-    /**
-     * Check that each member of $input array is of type $type.
-     *
-     * @param array $input The input to validate.
-     * @param string $type The type to check..
-     * @param callable An additional check for each element of $input.
-     *        This will be run count($input) times, so use with care.
-     * @return void
-     * @throws InvalidArgumentException
-     */
-    private function validateBatch(
-        array $input,
-        $type,
-        callable $additionalCheck = null
-    ) {
-        foreach ($input as $element) {
-            if (!($element instanceof $type)) {
-                throw new InvalidArgumentException(sprintf(
-                    'Each member of input array must be an instance of %s',
-                    $type
-                ));
-            }
-
-            if ($additionalCheck) {
-                $additionalCheck($element);
-            }
-        }
     }
 }

--- a/src/ValidateTrait.php
+++ b/src/ValidateTrait.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud;
+
+use InvalidArgumentException;
+
+/**
+ * Methods for validating and verifying data
+ */
+trait ValidateTrait
+{
+    /**
+     * Check that each member of $input array is of type $type.
+     *
+     * @param array $input The input to validate.
+     * @param string $type The type to check.
+     * @param callable An additional check for each element of $input.
+     *        This will be run count($input) times, so use with care.
+     * @return void
+     * @throws InvalidArgumentException
+     */
+    private function validateBatch(
+        array $input,
+        $type,
+        callable $additionalCheck = null
+    ) {
+        foreach ($input as $element) {
+            if (!($element instanceof $type)) {
+                throw new InvalidArgumentException(sprintf(
+                    'Each member of input array must be an instance of %s',
+                    $type
+                ));
+            }
+
+            if ($additionalCheck) {
+                $additionalCheck($element);
+            }
+        }
+    }
+}

--- a/tests/ValidateTraitTest.php
+++ b/tests/ValidateTraitTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests;
+
+use Google\Cloud\ValidateTrait;
+
+/**
+ * @group root
+ */
+class ValidateTraitTest extends \PHPUnit_Framework_TestCase
+{
+    private $stub;
+
+    public function setUp()
+    {
+        $this->stub = new ValidateTraitStub;
+    }
+
+    public function testValidateBatch()
+    {
+        $input = [
+            (object)[],
+            (object)[],
+            (object)[],
+        ];
+
+        $this->stub->v($input, \stdClass::class);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testValidateBatchInvalidInput()
+    {
+        $input = [
+            (object)[],
+            (object)[],
+            (object)[],
+            $this->stub
+        ];
+
+        $this->stub->v($input, \stdClass::class);
+    }
+
+    public function testAdditionalCheckCalled()
+    {
+        $called = 0;
+        $input = [
+            (object)[],
+            (object)[],
+            (object)[],
+        ];
+
+        $this->stub->v($input, \stdClass::class, function ($input) use (&$called) {
+            $called++;
+        });
+
+        $this->assertEquals(count($input), $called);
+    }
+}
+
+class ValidateTraitStub
+{
+    use ValidateTrait;
+
+    public function v(array $input, $type, callable $check = null)
+    {
+        return $this->validateBatch($input, $type, $check);
+    }
+}

--- a/tests/Vision/VisionClientTest.php
+++ b/tests/Vision/VisionClientTest.php
@@ -86,9 +86,7 @@ class VisionClientTest extends \PHPUnit_Framework_TestCase
 
         $res = $this->client->annotateBatch([$image]);
 
-        $this->assertInstanceOf(\Generator::class, $res);
-
-        $res = iterator_to_array($res);
+        $this->assertTrue(is_array($res));
 
         $this->assertInstanceOf(Annotation::class, $res[0]);
         $this->assertInstanceOf(Annotation::class, $res[1]);


### PR DESCRIPTION
This PR started out as me changing the return value of VisionClient::annotateBatch(). It had been a generator, but that didn't make a ton of sense, because the number of annotations should always be equal to the number of input images. This'll be **a breaking change**.

Then I did a bit of other work and included it here. I can pull back on things if needed.

* DocGenerator threw an error that I hadn't seen before. May have been an update in the phpdoc lib. In any case, I added logic to keep it quiet.
* I abstracted the GCE projectId detection a bit so that I could unit test that code block. I also unit tested that code block.
* I moved `Google\Cloud\Datastore\Operation::validateBatch()` to a new trait called `Google\Cloud\ValidateTrait` so that we can use it elsewhere. I implemented it in one spot in Vision, but it's a very common case, so handling it once and using it everywhere makes sense.
* 