### PR TITLE
Standardize documentation and add some missing examples

### DIFF
--- a/src/BigQuery/BigQueryClient.php
+++ b/src/BigQuery/BigQueryClient.php
@@ -25,6 +25,22 @@ use Google\Cloud\ClientTrait;
  * Google Cloud BigQuery client. Allows you to create, manage, share and query
  * data. Find more information at
  * [Google Cloud BigQuery Docs](https://cloud.google.com/bigquery/what-is-bigquery).
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\ServiceBuilder;
+ *
+ * $cloud = new ServiceBuilder();
+ *
+ * $bigQuery = $cloud->bigQuery();
+ * ```
+ *
+ * ```
+ * // BigQueryClient can be instantiated directly.
+ * use Google\Cloud\BigQuery\BigQueryClient;
+ *
+ * $bigQuery = new BigQueryClient();
+ * ```
  */
 class BigQueryClient
 {
@@ -41,15 +57,6 @@ class BigQueryClient
 
     /**
      * Create a BigQuery client.
-     *
-     * Example:
-     * ```
-     * use Google\Cloud\BigQuery\BigQueryClient;
-     *
-     * $bigQuery = new BigQueryClient([
-     *     'projectId' => 'myAwesomeProject'
-     * ]);
-     * ```
      *
      * @param array $config {
      *     Configuration options.

--- a/src/BigQuery/QueryResults.php
+++ b/src/BigQuery/QueryResults.php
@@ -23,6 +23,10 @@ use Google\Cloud\Exception\GoogleException;
 /**
  * QueryResults represent the result of a BigQuery SQL query. Read more at the
  * [Query Response API Documentation](https://cloud.google.com/bigquery/docs/reference/v2/jobs/query#response).
+ *
+ * This class should be not instantiated directly, but as a result of
+ * calling {@see Google\Cloud\BigQuery\BigQueryClient::runQuery()} or
+ * {@see Google\Cloud\BigQuery\Job::queryResults()}.
  */
 class QueryResults
 {
@@ -47,10 +51,6 @@ class QueryResults
     private $reloadOptions;
 
     /**
-     * This class should be not instantiated directly, but as a result of
-     * calling {@see Google\Cloud\BigQuery\BigQueryClient::runQuery()} or
-     * {@see Google\Cloud\BigQuery\Job::queryResults()}.
-     *
      * @param ConnectionInterface $connection Represents a connection to
      *        BigQuery.
      * @param string $jobId The job's ID.

--- a/src/Compute/Metadata.php
+++ b/src/Compute/Metadata.php
@@ -27,12 +27,14 @@ use Google\Cloud\Compute\Metadata\Readers\StreamReader;
  *
  * You can get the GCE metadata values very easily like:
  *
+ * ```
  * use Google\Cloud\Compute\Metadata;
  *
  * $metadata = new Metadata();
  * $project_id = $metadata->getProjectId();
  *
  * $val = $metadata->getProjectMetadata($key);
+ * ```
  */
 class Metadata
 {
@@ -55,7 +57,9 @@ class Metadata
     }
 
     /**
-     * A method to replace the reader implementation.
+     * Replace the default reader implementation
+     *
+     * @param mixed $reader The reader implementation
      */
     public function setReader($reader)
     {
@@ -63,7 +67,14 @@ class Metadata
     }
 
     /**
-     * This method retrieves a single metadata value for a given path.
+     * Fetch a metadata item by its path
+     *
+     * Example:
+     * ```
+     * $projectId = $reader->get('project/project-id');
+     * ```
+     *
+     * @param string $path The path of the item to retrieve.
      */
     public function get($path)
     {
@@ -71,18 +82,34 @@ class Metadata
     }
 
     /**
-     * This method detects the project id and returns it.
+     * Detect and return the project ID
+     *
+     * Example:
+     * ```
+     * $projectId = $reader->getProjectId();
+     * ```
+     *
+     * @return string
      */
     public function getProjectId()
     {
         if (! isset($this->projectId)) {
             $this->projectId = $this->reader->read('project/project-id');
         }
+
         return $this->projectId;
     }
 
     /**
-     * This method fetches the project custom metadta and returns it.
+     * Fetch an item from the project metadata
+     *
+     * Example:
+     * ```
+     * $foo = $reader->getProjectMetadata('foo');
+     * ```
+     *
+     * @param string $key The metadata key
+     * @return string
      */
     public function getProjectMetadata($key)
     {
@@ -91,7 +118,15 @@ class Metadata
     }
 
     /**
-     * This method fetches the instance custom metadta and returns it.
+     * Fetch an item from the instance metadata
+     *
+     * Example:
+     * ```
+     * $foo = $reader->getInstanceMetadata('foo');
+     * ```
+     *
+     * @param string $key The instance metadata key
+     * @return string
      */
     public function getInstanceMetadata($key)
     {

--- a/src/Datastore/DatastoreClient.php
+++ b/src/Datastore/DatastoreClient.php
@@ -39,20 +39,16 @@ use InvalidArgumentException;
  * ```
  * use Google\Cloud\ServiceBuilder;
  *
- * $cloud = new ServiceBuilder([
- *     'projectId' => 'my-awesome-project'
- * ]);
+ * $cloud = new ServiceBuilder();
  *
  * $datastore = $cloud->datastore();
  * ```
  *
  * ```
- * // The Datastore client can also be instantianted directly.
+ * // DatastoreClient can be instantiated directly.
  * use Google\Cloud\Datastore\DatastoreClient;
  *
- * $datastore = new DatastoreClient([
- *     'projectId' => 'my-awesome-project'
- * ]);
+ * $datastore = new DatastoreClient();
  * ```
  *
  * ```

--- a/src/Iam/PolicyBuilder.php
+++ b/src/Iam/PolicyBuilder.php
@@ -21,6 +21,15 @@ use InvalidArgumentException;
 
 /**
  * Helper class for creating valid IAM policies
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\Iam\PolicyBuilder;
+ *
+ * $builder = new PolicyBuilder();
+ * $builder->addBinding('roles/admin', [ 'user:admin@domain.com' ]);
+ * $result = $builder->result();
+ * ```
  */
 class PolicyBuilder
 {
@@ -43,15 +52,6 @@ class PolicyBuilder
 
     /**
      * Create a PolicyBuilder.
-     *
-     * * Example:
-     * ```
-     * use Google\Cloud\Iam\PolicyBuilder;
-     *
-     * $builder = new PolicyBuilder();
-     * $builder->addBinding('roles/admin', [ 'user:admin@domain.com' ]);
-     * $result = $builder->result();
-     * ```
      *
      * @param  array $policy A policy array
      * @throws InvalidArgumentException

--- a/src/Logging/Logger.php
+++ b/src/Logging/Logger.php
@@ -21,6 +21,16 @@ use Google\Cloud\Logging\Connection\ConnectionInterface;
 
 /**
  * A logger used to write entries to Google Stackdriver Logging.
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\ServiceBuilder;
+ *
+ * $cloud = new ServiceBuilder();
+ * $logging = $cloud->logging();
+ *
+ * $logger = $logging->logger('my-log');
+ * ```
  */
 class Logger
 {

--- a/src/Logging/LoggingClient.php
+++ b/src/Logging/LoggingClient.php
@@ -26,6 +26,21 @@ use Google\Cloud\Logging\Connection\Rest;
  * monitor, and alert on log data and events from Google Cloud Platform and
  * Amazon Web Services. Find more information at
  * [Google Stackdriver Logging docs](https://cloud.google.com/logging/docs/).
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\ServiceBuilder;
+ *
+ * $cloud = new ServiceBuilder();
+ * $logging = $cloud->logging();
+ * ```
+ *
+ * ```
+ * // LoggingClient can be instantiated directly.
+ * use Google\Cloud\Logging\LoggingClient;
+ *
+ * $logging = new LoggingClient();
+ * ```
  */
 class LoggingClient
 {
@@ -47,15 +62,6 @@ class LoggingClient
 
     /**
      * Create a Logging client.
-     *
-     * Example:
-     * ```
-     * use Google\Cloud\Logging\LoggingClient;
-     *
-     * $logging = new LoggingClient([
-     *     'projectId' => 'myAwesomeProject'
-     * ]);
-     * ```
      *
      * @param array $config {
      *     Configuration options.

--- a/src/Logging/Metric.php
+++ b/src/Logging/Metric.php
@@ -24,6 +24,16 @@ use Google\Cloud\Logging\Connection\ConnectionInterface;
  * A metric counts the number of log entries that match a given filter. You can
  * use these metrics to create charts and alerting policies in
  * [Stackdriver Monitoring](https://cloud.google.com/monitoring/docs).
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\ServiceBuilder;
+ *
+ * $cloud = new ServiceBuilder();
+ * $logging = $cloud->logging();
+ *
+ * $metric = $logging->metric('my-metric');
+ * ```
  */
 class Metric
 {

--- a/src/Logging/PsrLogger.php
+++ b/src/Logging/PsrLogger.php
@@ -23,6 +23,21 @@ use Psr\Log\LogLevel;
 
 /**
  * A PSR-3 compliant logger used to write entries to Google Stackdriver Logging.
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\ServiceBuilder;
+ *
+ * $cloud = new ServiceBuilder();
+ * $logging = $cloud->logging();
+ *
+ * $psrLogger = $logging->psrLogger('my-log', [
+ *     'type' => 'gcs_bucket',
+ *     'labels' => [
+ *         'bucket_name' => 'my-bucket'
+ *     ]
+ * ]);
+ * ```
  */
 class PsrLogger implements LoggerInterface
 {

--- a/src/Logging/Sink.php
+++ b/src/Logging/Sink.php
@@ -22,6 +22,21 @@ use Google\Cloud\Logging\Connection\ConnectionInterface;
 
 /**
  * A sink is used to export log entries outside Stackdriver Logging.
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\ServiceBuilder;
+ *
+ * $cloud = new ServiceBuilder();
+ * $logging = $cloud->logging();
+ *
+ * $logging->createSink('my-sink', 'storage.googleapis.com/my-bucket');
+ * ```
+ *
+ * ```
+ * // To use an existing sink:
+ * $sink = $logging->sink('my-sink');
+ * ```
  */
 class Sink
 {

--- a/src/NaturalLanguage/NaturalLanguageClient.php
+++ b/src/NaturalLanguage/NaturalLanguageClient.php
@@ -28,6 +28,22 @@ use Google\Cloud\Storage\StorageObject;
  * and syntax analysis. Currently only English, Spanish, and Japanese textual
  * context are supported. Find more information at
  * [Google Cloud Natural Language docs](https://cloud.google.com/natural-language/docs/).
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\ServiceBuilder;
+ *
+ * $cloud = new ServiceBuilder();
+ *
+ * $language = $cloud->naturalLanguage();
+ * ```
+ *
+ * ```
+ * // NaturalLanguage can be instantiated directly.
+ * use Google\Cloud\NaturalLanguage\NaturalLanguageClient;
+ *
+ * $language = new NaturalLanguageClient();
+ * ```
  */
 class NaturalLanguageClient
 {
@@ -51,26 +67,6 @@ class NaturalLanguageClient
 
     /**
      * Create a NaturalLanguage client.
-     *
-     * Example:
-     * ```
-     * use Google\Cloud\ServiceBuilder;
-     *
-     * $cloud = new ServiceBuilder([
-     *     'projectId' => 'my-awesome-project'
-     * ]);
-     *
-     * $language = $cloud->naturalLanguage();
-     * ```
-     *
-     * ```
-     * // The NaturalLanguage client can also be instantianted directly.
-     * use Google\Cloud\NaturalLanguage\NaturalLanguageClient;
-     *
-     * $language = new NaturalLanguageClient([
-     *     'projectId' => 'my-awesome-project'
-     * ]);
-     * ```
      *
      * @param array $config {
      *     Configuration Options.

--- a/src/PubSub/PubSubClient.php
+++ b/src/PubSub/PubSubClient.php
@@ -25,6 +25,25 @@ use InvalidArgumentException;
  * Google Cloud Pub/Sub client. Allows you to send and receive
  * messages between independent applications. Find more information at
  * [Google Cloud Pub/Sub docs](https://cloud.google.com/pubsub/docs/).
+ *
+ * The [PUBSUB_EMULATOR_HOST](https://cloud.google.com/pubsub/emulator#env) environment variable
+ * from the gcloud SDK is honored, otherwise the actual API endpoint will be used.
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\ServiceBuilder;
+ *
+ * $cloud = new ServiceBuilder();
+ *
+ * $pubsub = $cloud->pubsub();
+ * ```
+ *
+ * ```
+ * // PubSubClient can be instantiated directly.
+ * use Google\Cloud\PubSub\PubSubClient;
+ *
+ * $pubsub = new PubSubClient();
+     * ```
  */
 class PubSubClient
 {
@@ -40,27 +59,6 @@ class PubSubClient
 
     /**
      * Create a PubSub client.
-     *
-     * The [PUBSUB_EMULATOR_HOST](https://cloud.google.com/pubsub/emulator#env) environment variable
-     * from the gcloud SDK is honored, otherwise the actual API endpoint will be used.
-     *
-     * Example:
-     * ```
-     * use Google\Cloud\ServiceBuilder;
-     *
-     * $cloud = new ServiceBuilder([
-     *     'projectId' => 'my-awesome-project'
-     * ]);
-     *
-     * $pubsub = $cloud->pubsub();
-     *
-     * // The PubSub client can also be instantianted directly.
-     * use Google\Cloud\PubSub\PubSubClient;
-     *
-     * $pubsub = new PubSubClient([
-     *     'projectId' => 'my-awesome-project'
-     * ]);
-     * ```
      *
      * @param array $config {
      *     Configuration Options.

--- a/src/PubSub/Subscription.php
+++ b/src/PubSub/Subscription.php
@@ -26,6 +26,32 @@ use InvalidArgumentException;
 /**
  * A named resource representing the stream of messages from a single, specific
  * topic, to be delivered to the subscribing application.
+ *
+ * Subscriptions are created by {@see Google\Cloud\PubSub\PubSubClient}
+ * or {@see Google\Cloud\PubSub\Topic}.
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\ServiceBuilder;
+ *
+ * $cloud = new ServiceBuilder();
+ *
+ * $pubsub = $cloud->pubsub();
+ *
+ * $subscription = $pubsub->subscription(
+ *     'my-new-subscription',
+ *     'my-topic-name'
+ * );
+ * ```
+ *
+ * ```
+ * // Create subscription through a topic
+ * use Google\Cloud\ServiceBuilder;
+ *
+ * $topic = $pubsub->topic('my-topic-name');
+ *
+ * $subscription = $topic->subscription('my-new-subscription');
+ * ```
  */
 class Subscription
 {
@@ -65,48 +91,6 @@ class Subscription
 
     /**
      * Create a Subscription.
-     *
-     * The idiomatic way to use this class is through the PubSubClient or Topic,
-     * but you can instantiate it directly as well.
-     *
-     * Example:
-     * ```
-     * // Create subscription through a topic
-     * use Google\Cloud\ServiceBuilder;
-     *
-     * $cloud = new ServiceBuilder([
-     *     'projectId' => 'my-awesome-project'
-     * ]);
-     *
-     * $pubsub = $cloud->pubsub();
-     *
-     * $topic = $pubsub->topic('my-topic-name');
-     *
-     * $subscription = $topic->subscription('my-new-subscription');
-     *
-     * // Create subscription through PubSubClient
-     *
-     * use Google\Cloud\PubSub\PubSubClient;
-     *
-     * $pubsub = new PubSubClient([
-     *     'projectId' => 'my-awesome-project'
-     * ]);
-     *
-     * $subscription = $pubsub->subscription(
-     *     'my-new-subscription',
-     *     'my-topic-name'
-     * );
-     *
-     * // Create subscription directly
-     * use Google\Cloud\Pubsub\Subscription;
-     *
-     * $subscription = new Subscription(
-     *     $connection
-     *     'my-new-subscription',
-     *     'my-topic-name',
-     *     'my-awesome-project'
-     * );
-     * ```
      *
      * @param  ConnectionInterface $connection The service connection object
      * @param  string $name The subscription name

--- a/src/PubSub/Topic.php
+++ b/src/PubSub/Topic.php
@@ -25,6 +25,22 @@ use InvalidArgumentException;
 
 /**
  * A named resource to which messages are sent by publishers.
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\ServiceBuilder;
+ *
+ * $client = new ServiceBuilder();
+ *
+ * $pubsub = $client->pubsub();
+ *
+ * $topic = $pubsub->topic('my-topic-name');
+ * ```
+ *
+ * ```
+ * // You can also pass a fully-qualified topic name:
+ * $topic = $pubsub->topic('projects/my-awesome-project/topics/my-topic-name');
+ * ```
  */
 class Topic
 {
@@ -57,33 +73,6 @@ class Topic
 
     /**
      * Create a PubSub topic.
-     *
-     * Example:
-     * ```
-     * use Google\Cloud\ServiceBuilder;
-     *
-     * // The idiomatic way to get a Topic instance would be through PubSubClient:
-     *
-     * $client = new ServiceBuilder([
-     *     'projectId' => 'my-awesome-project'
-     * ]);
-     *
-     * $pubsub = $client->pubsub();
-     * $topic = $pubsub->topic('my-topic-name');
-     *
-     * // But you can instantiate the topic directly if you want!
-     *
-     * use Google\Cloud\PubSub\Topic;
-     *
-     * $topic = new Topic($connection, 'my-topic-name', 'my-awesome-project');
-     *
-     * // You can also pass a fully-qualified topic name:
-     * $topic = new Topic(
-     *     $connection,
-     *     'projects/my-awesome-project/topics/my-topic-name',
-     *     'my-awesome-project'
-     * );
-     * ```
      *
      * @param  ConnectionInterface $connection A connection to the Google Cloud
      *         Platform service

--- a/src/Speech/SpeechClient.php
+++ b/src/Speech/SpeechClient.php
@@ -38,6 +38,22 @@ use Google\Cloud\Storage\StorageObject;
  * ```sh
  * $ composer require james-heinrich/getid3
  * ```
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\ServiceBuilder;
+ *
+ * $cloud = new ServiceBuilder();
+ *
+ * $speech = $cloud->speech();
+ * ```
+ *
+ * ```
+ * // SpeechClient can be instantiated directly.
+ * use Google\Cloud\Speech\SpeechClient;
+ *
+ * $speech = new SpeechClient();
+ * ```
  */
 class SpeechClient
 {
@@ -52,26 +68,6 @@ class SpeechClient
 
     /**
      * Create a Speech client.
-     *
-     * Example:
-     * ```
-     * use Google\Cloud\ServiceBuilder;
-     *
-     * $cloud = new ServiceBuilder([
-     *     'projectId' => 'my-awesome-project'
-     * ]);
-     *
-     * $speech = $cloud->speech();
-     * ```
-     *
-     * ```
-     * // The Speech client can also be instantianted directly.
-     * use Google\Cloud\Speech\SpeechClient;
-     *
-     * $speech = new SpeechClient([
-     *     'projectId' => 'my-awesome-project'
-     * ]);
-     * ```
      *
      * @param array $config {
      *     Configuration Options.

--- a/src/Storage/StorageClient.php
+++ b/src/Storage/StorageClient.php
@@ -25,6 +25,22 @@ use Google\Cloud\Storage\Connection\Rest;
  * Google Cloud Storage client. Allows you to store and retrieve data on
  * Google's infrastructure. Find more information at
  * [Google Cloud Storage API docs](https://developers.google.com/storage).
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\ServiceBuilder;
+ *
+ * $cloud = new ServiceBuilder();
+ *
+ * $storage = $cloud->storage();
+ * ```
+ *
+ * ```
+ * // StorageClient can be instantiated directly.
+ * use Google\Cloud\Storage\StorageClient;
+ *
+ * $storage = new StorageClient();
+ * ```
  */
 class StorageClient
 {
@@ -41,15 +57,6 @@ class StorageClient
 
     /**
      * Create a Storage client.
-     *
-     * Example:
-     * ```
-     * use Google\Cloud\Storage\StorageClient;
-     *
-     * $storage = new StorageClient([
-     *     'projectId' => 'myAwesomeProject'
-     * ]);
-     * ```
      *
      * @param array $config {
      *     Configuration options.

--- a/src/Translate/TranslateClient.php
+++ b/src/Translate/TranslateClient.php
@@ -36,6 +36,26 @@ use Google\Cloud\Translate\Connection\Rest;
  * service account or application default credentials. Follow the
  * [before you begin](https://cloud.google.com/translate/v2/translating-text-with-rest#before-you-begin)
  * instructions to learn how to generate a key.
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\ServiceBuilder;
+ *
+ * $cloud = new ServiceBuilder([
+ *     'key' => 'YOUR_KEY'
+ * ]);
+ *
+ * $translate = $cloud->translate();
+ * ```
+ *
+ * ```
+ * // TranslateClient can be instantiated directly.
+ * use Google\Cloud\Translate\TranslateClient;
+ *
+ * $translate = new TranslateClient([
+ *     'key' => 'YOUR_KEY'
+ * ]);
+ * ```
  */
 class TranslateClient
 {
@@ -55,26 +75,6 @@ class TranslateClient
 
     /**
      * Create a Translate client.
-     *
-     * Example:
-     * ```
-     * use Google\Cloud\ServiceBuilder;
-     *
-     * $cloud = new ServiceBuilder([
-     *     'key' => 'YOUR_KEY'
-     * ]);
-     *
-     * $translate = $cloud->translate();
-     * ```
-     *
-     * ```
-     * // The Translate client can also be instantianted directly.
-     * use Google\Cloud\Translate\TranslateClient;
-     *
-     * $translate = new TranslateClient([
-     *     'key' => 'YOUR_KEY'
-     * ]);
-     * ```
      *
      * @param array $config {
      *     Configuration Options.

--- a/src/Vision/Image.php
+++ b/src/Vision/Image.php
@@ -52,6 +52,71 @@ use InvalidArgumentException;
  * ]);
  * ```
  *
+ * ```
+ * // Images can be directly instantiated.
+ * use Google\Cloud\Vision\Image;
+ *
+ * $imageResource = fopen(__DIR__ .'/assets/family-photo.jpg', 'r');
+ * $image = new Image($imageResource, [
+ *     'FACE_DETECTION'
+ * ]);
+ * ```
+ *
+ * ```
+ * // Image data can be given as a string
+ * $fileContents = file_get_contents(__DIR__ .'/assets/family-photo.jpg');
+ * $image = $vision->image($fileContents, [
+ *    'FACE_DETECTION'
+ * ]);
+ * ```
+ *
+ * ```
+ * // Files stored in Google Cloud Storage can be used.
+ * $file = $cloud->storage()->bucket('my-test-bucket')->object('family-photo.jpg');
+ * $image = $vision->image($file, [
+ *     'FACE_DETECTION'
+ * ]);
+ * ```
+ *
+ * ```
+ * // This example sets a maximum results limit on one feature and provides some image context.
+ *
+ * $imageResource = fopen(__DIR__ .'/assets/family-photo.jpg', 'r');
+ * $image = $vision->image($imageResource, [
+ *     'FACE_DETECTION',
+ *     'LOGO_DETECTION'
+ * ], [
+ *     'maxResults' => [
+ *         'FACE_DETECTION' => 1
+ *     ],
+ *     'imageContext' => [
+ *         'latLongRect' => [
+ *             'minLatLng' => [
+ *                 'latitude' => '-45.0',
+ *                 'longitude' => '-45.0'
+ *             ],
+ *             'maxLatLng' => [
+ *                 'latitude' => '45.0',
+ *                 'longitude' => '45.0'
+ *             ]
+ *         ]
+ *     ]
+ * ]);
+ * ```
+ *
+ * ```
+ * // The client library also offers shortcut names which can be used in place of the longer feature names.
+ * $image = new Image($imageResource, [
+ *     'faces',          // Corresponds to `FACE_DETECTION`
+ *     'landmarks',      // Corresponds to `LANDMARK_DETECTION`
+ *     'logos',          // Corresponds to `LOGO_DETECTION`
+ *     'labels',         // Corresponds to `LABEL_DETECTION`
+ *     'text',           // Corresponds to `TEXT_DETECTION`
+ *     'safeSearch',     // Corresponds to `SAFE_SEARCH_DETECTION`
+ *     'imageProperties'  // Corresponds to `IMAGE_PROPERTIES`
+ * ]);
+ * ```
+ *
  * @see https://cloud.google.com/vision/docs/image-best-practices Best Practices
  * @see https://cloud.google.com/vision/docs/pricing Pricing
  */
@@ -97,73 +162,6 @@ class Image
 
     /**
      * Create an image with all required configuration.
-     *
-     * Example:
-     * ```
-     * use Google\Cloud\Vision\Image;
-     *
-     * $imageResource = fopen(__DIR__ .'/assets/family-photo.jpg', 'r');
-     * $image = new Image($imageResource, [
-     *     'FACE_DETECTION'
-     * ]);
-     * ```
-     *
-     * ```
-     * // Image data can be given as a string
-     *
-     * $fileContents = file_get_contents(__DIR__ .'/assets/family-photo.jpg');
-     * $image = new Image($fileContents, [
-     *    'FACE_DETECTION'
-     * ]);
-     * ```
-     *
-     * ```
-     * // Files stored in Google Cloud Storage can be used.
-     *
-     * $file = $cloud->storage()->bucket('my-test-bucket')->object('family-photo.jpg');
-     * $image = $vision->image($file, [
-     *     'FACE_DETECTION'
-     * ]);
-     * ```
-     *
-     * ```
-     * // This example sets a maximum results limit on one feature and provides some image context.
-     *
-     * $imageResource = fopen(__DIR__ .'/assets/family-photo.jpg', 'r');
-     * $image = $vision->image($imageResource, [
-     *     'FACE_DETECTION',
-     *     'LOGO_DETECTION'
-     * ], [
-     *     'maxResults' => [
-     *         'FACE_DETECTION' => 1
-     *     ],
-     *     'imageContext' => [
-     *         'latLongRect' => [
-     *             'minLatLng' => [
-     *                 'latitude' => '-45.0',
-     *                 'longitude' => '-45.0'
-     *             ],
-     *             'maxLatLng' => [
-     *                 'latitude' => '45.0',
-     *                 'longitude' => '45.0'
-     *             ]
-     *         ]
-     *     ]
-     * ]);
-     * ```
-     *
-     * ```
-     * // The client library also offers shortcut names which can be used in place of the longer feature names.
-     * $image = new Image($imageResource, [
-     *     'faces',          // Corresponds to `FACE_DETECTION`
-     *     'landmarks',      // Corresponds to `LANDMARK_DETECTION`
-     *     'logos',          // Corresponds to `LOGO_DETECTION`
-     *     'labels',         // Corresponds to `LABEL_DETECTION`
-     *     'text',           // Corresponds to `TEXT_DETECTION`
-     *     'safeSearch',     // Corresponds to `SAFE_SEARCH_DETECTION`
-     *     'imageProperties'  // Corresponds to `IMAGE_PROPERTIES`
-     * ]);
-     * ```
      *
      * @param  resource|string|StorageObject $image An image to configure with
      *         the given settings. This parameter will accept a resource, a

--- a/src/Vision/VisionClient.php
+++ b/src/Vision/VisionClient.php
@@ -35,6 +35,13 @@ use InvalidArgumentException;
  *
  * $vision = $cloud->vision();
  * ```
+ *
+ * ```
+ * // VisionClient can be instantiated directly.
+ * use Google\Cloud\Vision\VisionClient;
+ *
+ * $vision = new VisionClient();
+ * ```
  */
 class VisionClient
 {
@@ -49,13 +56,6 @@ class VisionClient
 
     /**
      * Create a Vision client.
-     *
-     * Example:
-     * ```
-     * use Google\Cloud\Vision\VisionClient;
-     *
-     * $vision = new VisionClient();
-     * ```
      *
      * @param array $config {
      *     Configuration Options.


### PR DESCRIPTION
Mostly moving examples of obtaining an instance from the constructor to the class level. Some other standardizations, chiefly removing the config array (this will be required in the future for integration tests).