### PR TITLE
Add Symfony console command for doc generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ script:
 
 after_success:
     - bash <(curl -s https://codecov.io/bash)
-    - ./scripts/deploy-docs.sh
+    - ./dev/deploy-docs.sh

--- a/composer.json
+++ b/composer.json
@@ -48,10 +48,11 @@
     "require-dev": {
         "phpunit/phpunit": "4.8.*",
         "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/phpdocumentor": "2.8.*",
-        "symfony/console": "2.*",
+        "phpdocumentor/reflection": "^3.0",
+        "symfony/console": "^3.0",
         "league/json-guard": "^0.3",
-        "james-heinrich/getid3": "^1.9"
+        "james-heinrich/getid3": "^1.9",
+        "erusev/parsedown": "^1.6"
     },
     "suggest": {
         "google/gax": "Required to support gRPC",
@@ -63,7 +64,12 @@
             "Google\\Cloud\\": "src"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Google\\Cloud\\Dev\\": "dev/src"
+        }
+    },
     "scripts": {
-        "docs": "php scripts/docs.php"
+        "google-cloud": "dev/google-cloud"
     }
 }

--- a/dev/deploy-docs.sh
+++ b/dev/deploy-docs.sh
@@ -5,7 +5,7 @@ set -ev
 function pushDocs () {
   echo "doc dir before generation:"
   find docs
-  composer docs
+  composer google-cloud docs
   echo "doc dir after generation:"
   find docs
   git submodule add -q -f -b gh-pages https://${GH_OAUTH_TOKEN}@github.com/${GH_OWNER}/${GH_PROJECT_NAME} ghpages

--- a/dev/google-cloud
+++ b/dev/google-cloud
@@ -1,0 +1,36 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Google\Cloud\Dev\DocGenerator\Command\Docs;
+use Google\Cloud\Dev\Release\Command\Release;
+use Symfony\Component\Console\Application;
+
+if (!class_exists(Application::class)) {
+    throw new RuntimeException(
+        'Symfony Console Component not installed. ' .
+        'run "composer install" or "composer update", making sure not to ' .
+        'exclude dev dependencies, and try again.'
+    );
+}
+
+$app = new Application;
+$app->add(new Release(__DIR__));
+$app->add(new Docs(__DIR__));
+$app->run();

--- a/dev/readme.md
+++ b/dev/readme.md
@@ -1,0 +1,10 @@
+# Google Cloud PHP Development Scripts
+
+Google Cloud PHP includes a Symfony Console application in `dev/google-cloud`
+to automate certain development and maintenance tasks. The console app can be
+easily invoked by running `composer google-cloud` at the command line.
+
+## Commands
+
+* `composer google-cloud release <version>` Create a new release of Google Cloud PHP.
+* `composer google-cloud docs [<source] [<output>]` Generate Google Cloud PHP documentation.

--- a/dev/src/DocGenerator/Command/Docs.php
+++ b/dev/src/DocGenerator/Command/Docs.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\DocGenerator\Command;
+
+use Google\Cloud\Dev\DocGenerator\DocGenerator;
+use Google\Cloud\Dev\DocGenerator\GuideGenerator;
+use Google\Cloud\Dev\DocGenerator\TypeGenerator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RecursiveRegexIterator;
+use RegexIterator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Docs extends Command
+{
+    const DEFAULT_OUTPUT_DIR = 'docs/json/master';
+    const DEFAULT_SOURCE_DIR = 'src';
+
+    private $cliBasePath;
+
+    public function __construct($cliBasePath)
+    {
+        $this->cliBasePath = $cliBasePath;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->setName('docs')
+            ->setDescription('Generate Documentation')
+            ->addArgument('source', InputArgument::OPTIONAL, 'The source directory to traverse and parse')
+            ->addArgument('output', InputArgument::OPTIONAL, 'The directory to output files into');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $paths = [
+            'source' => ($input->getArgument('source'))
+                ? $this->cliBasePath .'/../'. $input->getArgument('source')
+                : $this->cliBasePath .'/../'. self::DEFAULT_SOURCE_DIR,
+
+            'output' => ($input->getArgument('output'))
+                ? $this->cliBasePath .'/../'. $input->getArgument('output')
+                : $this->cliBasePath .'/../'. self::DEFAULT_OUTPUT_DIR
+        ];
+
+        $types = new TypeGenerator($paths['output']);
+
+        $sourceFiles = $this->getFilesList($paths['source']);
+        $docs = new DocGenerator($types, $sourceFiles, $paths['output'], $this->cliBasePath);
+        $docs->generate();
+
+        $types->write();
+    }
+
+    private function getFilesList($source)
+    {
+        $directoryIterator = new RecursiveDirectoryIterator($source);
+        $iterator = new RecursiveIteratorIterator($directoryIterator);
+        $regexIterator = new RegexIterator($iterator, '/^.+\.php|^.+\.md$/i', RecursiveRegexIterator::GET_MATCH);
+        $files = [];
+
+        foreach ($regexIterator as $item) {
+            array_push($files, $item[0]);
+        }
+
+        return $files;
+    }
+}

--- a/dev/src/DocGenerator/DocGenerator.php
+++ b/dev/src/DocGenerator/DocGenerator.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\DocGenerator;
+
+use Google\Cloud\Dev\DocGenerator\Parser\CodeParser;
+use Google\Cloud\Dev\DocGenerator\Parser\MarkdownParser;
+use phpDocumentor\Reflection\DocBlock\Description;
+use phpDocumentor\Reflection\DocBlock\Tag\SeeTag;
+use phpDocumentor\Reflection\FileReflector;
+
+/**
+ * Parses given files and builds documentation for our common docs site.
+ */
+class DocGenerator
+{
+    private $types;
+    private $files;
+    private $outputPath;
+    private $executionPath;
+
+    /**
+     * @param array $files
+     */
+    public function __construct(TypeGenerator $types, array $files, $outputPath, $executionPath)
+    {
+        $this->types = $types;
+        $this->files = $files;
+        $this->outputPath = $outputPath;
+        $this->executionPath = $executionPath;
+    }
+
+    /**
+     * Generates JSON documentation from provided files.
+     *
+     * @return void
+     */
+    public function generate()
+    {
+        $types = [];
+
+        foreach ($this->files as $file) {
+
+            $currentFile = substr(str_replace($this->executionPath, '', $file), 3);
+            $isPhp = strrpos($file, '.php') == strlen($file) - strlen('.php');
+
+            if ($isPhp) {
+                $fileReflector = new FileReflector($file);
+                $parser = new CodeParser($file, $currentFile, $fileReflector);
+            } else {
+                $content = file_get_contents($file);
+                $parser = new MarkdownParser($currentFile, $content);
+            }
+
+            $document = $parser->parse();
+
+            $writer = new Writer(json_encode($document), $this->outputPath);
+            $writer->write(substr($currentFile, 4));
+
+            $this->types->addType([
+                'id' => $document['id'],
+                'title' => $document['title'],
+                'contents' => $document['id'] . '.json'
+            ]);
+        }
+    }
+}

--- a/dev/src/DocGenerator/DocGenerator.php
+++ b/dev/src/DocGenerator/DocGenerator.php
@@ -51,8 +51,6 @@ class DocGenerator
      */
     public function generate()
     {
-        $types = [];
-
         foreach ($this->files as $file) {
 
             $currentFile = substr(str_replace($this->executionPath, '', $file), 3);

--- a/dev/src/DocGenerator/Parser/CodeParser.php
+++ b/dev/src/DocGenerator/Parser/CodeParser.php
@@ -15,62 +15,32 @@
  * limitations under the License.
  */
 
-require __DIR__ . '/../vendor/autoload.php';
+namespace Google\Cloud\Dev\DocGenerator\Parser;
 
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\Tag\SeeTag;
 use phpDocumentor\Reflection\FileReflector;
 
-/**
- * Parses given files and builds documentation for our common docs site.
- */
-class DocGenerator
+class CodeParser implements ParserInterface
 {
-    private $currentFile;
-    private $files;
-    private $outputPath;
+    private $path;
+    private $outputName;
+    private $reflector;
+    private $markdown;
 
-    /**
-     * @param array $files
-     */
-    public function __construct(array $files, $outputPath)
+    public function __construct($path, $outputName, FileReflector $reflector)
     {
-        $this->files = $files;
-        $this->outputPath = $outputPath;
+        $this->path = $path;
+        $this->outputName;
+        $this->reflector = $reflector;
         $this->markdown = \Parsedown::instance();
     }
 
-    /**
-     * Generates JSON documentation from provided files.
-     *
-     * @return void
-     */
-    public function generate()
+    public function parse()
     {
-        $types = [];
-
-        foreach ($this->files as $file) {
-            $this->currentFile = substr(str_replace(__DIR__, '', $file), 3);
-            $jsonOutputPath = $this->buildOutputPath();
-            $fileReflector = new FileReflector($file);
-            $fileReflector->process();
-            $document = $this->buildDocument($this->getReflector($fileReflector));
-
-            $types[] = [
-                'id' => $document['id'],
-                'title' => $document['title'],
-                'contents' => $document['id'] . '.json'
-            ];
-
-            if (!is_dir(dirname($jsonOutputPath))) {
-                mkdir(dirname($jsonOutputPath), 0777, true);
-            }
-
-            file_put_contents($jsonOutputPath, json_encode($document));
-        }
-
-        file_put_contents($this->outputPath . '/types.json', json_encode($types));
+        $this->reflector->process();
+        return $this->buildDocument($this->getReflector($this->reflector));
     }
 
     private function getReflector($fileReflector)
@@ -87,7 +57,7 @@ class DocGenerator
             return $fileReflector->getTraits()[0];
         }
 
-        throw new \Exception('Could not get reflector for '. $this->currentFile);
+        throw new \Exception('Could not get reflector for '. $this->outputName);
     }
 
     private function buildDocument($reflector)
@@ -218,7 +188,7 @@ class DocGenerator
             'id' => $method->getName(),
             'type' => $method->getName() === '__construct' ? 'constructor' : 'instance',
             'name' => $method->getName(),
-            'source' => $this->currentFile . '#L' . $method->getLineNumber(),
+            'source' => $this->outputName . '#L' . $method->getLineNumber(),
             'description' => $this->buildDescription($docBlock, $split['description']),
             'examples' => $this->buildExamples($split['examples']),
             'resources' => $this->buildResources($resources),
@@ -251,7 +221,7 @@ class DocGenerator
             'id' => $magicMethod->getMethodName(),
             'type' => $magicMethod->getMethodName() === '__construct' ? 'constructor' : 'instance',
             'name' => $magicMethod->getMethodName(),
-            'source' => $this->currentFile,
+            'source' => $this->outputName,
             'description' => $this->buildDescription($docBlock, $docText),
             'examples' => $this->buildExamples($examples),
             'resources' => $this->buildResources($resources),
@@ -509,11 +479,7 @@ class DocGenerator
 
     private function buildOutputPath()
     {
-        $pathInfo = pathinfo($this->currentFile);
-        $servicePath = substr($pathInfo['dirname'] . '/' . $pathInfo['filename'] . '.json', 4);
-        $servicePath = strtolower($servicePath);
-
-        return $this->outputPath . $servicePath;
+        echo $content;exit;
     }
 }
 

--- a/dev/src/DocGenerator/Parser/CodeParser.php
+++ b/dev/src/DocGenerator/Parser/CodeParser.php
@@ -126,6 +126,7 @@ class CodeParser implements ParserInterface
             $content = implode('', $parsedContents);
         }
 
+        $content = str_ireplace('[optional]', '', $content);
         return $this->markdown->parse($content);
     }
 
@@ -322,7 +323,7 @@ class CodeParser implements ParserInterface
                 'name' => $varName,
                 'description' => $this->buildDescription($param->getDocBlock(), $description),
                 'types' => $this->handleTypes($param->getTypes()),
-                'optional' => null, // @todo
+                'optional' => (strpos(trim(strtolower($description)), '[optional]') === 0),
                 'nullable' => null // @todo
             ];
 
@@ -475,11 +476,6 @@ class CodeParser implements ParserInterface
             'description' => $parts[0],
             'examples' => $examples
         ];
-    }
-
-    private function buildOutputPath()
-    {
-        echo $content;exit;
     }
 }
 

--- a/dev/src/DocGenerator/Parser/MarkdownParser.php
+++ b/dev/src/DocGenerator/Parser/MarkdownParser.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\DocGenerator\Parser;
+
+use Parsedown;
+use DOMDocument;
+
+class MarkdownParser implements ParserInterface
+{
+    private $currentFile;
+    private $content;
+    private $markdown;
+
+    public function __construct($currentFile, $content)
+    {
+        $this->currentFile = $currentFile;
+        $this->content = $content;
+        $this->markdown = Parsedown::instance();
+    }
+
+    public function parse()
+    {
+        $html = $this->markdown->parse($this->content);
+
+        $doc = new DOMDocument;
+        $doc->loadHTML($html);
+
+        $headings = $doc->getElementsByTagName('h1');
+        $heading = $headings->item(0);
+
+        $heading->parentNode->removeChild($heading);
+
+        $pathinfo = pathinfo($this->currentFile);
+        return [
+            'id' => substr($pathinfo['dirname'] .'/'. $pathinfo['filename'], 5),
+            'type' => 'guide',
+            'title' => $heading->textContent,
+            'name' => $heading->textContent,
+            'description' => $doc->getElementsByTagName('body')[0]->textContent,
+            'methods' => []
+        ];
+    }
+}

--- a/dev/src/DocGenerator/Parser/ParserInterface.php
+++ b/dev/src/DocGenerator/Parser/ParserInterface.php
@@ -15,16 +15,9 @@
  * limitations under the License.
  */
 
-require __DIR__ . '/DocGenerator.php';
+namespace Google\Cloud\Dev\DocGenerator\Parser;
 
-$directoryIterator = new RecursiveDirectoryIterator(__DIR__ . '/../src');
-$iterator = new RecursiveIteratorIterator($directoryIterator);
-$regexIterator = new RegexIterator($iterator, '/^.+\.php$/i', RecursiveRegexIterator::GET_MATCH);
-$files = [];
-
-foreach ($regexIterator as $item) {
-    array_push($files, $item[0]);
+interface ParserInterface
+{
+    public function parse();
 }
-
-$generator = new DocGenerator($files, __DIR__ . '/../docs/json/master');
-$generator->generate();

--- a/dev/src/DocGenerator/TypeGenerator.php
+++ b/dev/src/DocGenerator/TypeGenerator.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\DocGenerator;
+
+use Google\Cloud\Dev\DocGenerator\File;
+use Google\Cloud\Dev\DocGenerator\Writer;
+
+class TypeGenerator
+{
+    private $types = [];
+
+    private $outputPath;
+
+    public function __construct($outputPath)
+    {
+        $this->outputPath = $outputPath;
+    }
+
+    public function addType(array $type)
+    {
+        $this->types[] = $type;
+    }
+
+    public function write()
+    {
+        $writer = new Writer(json_encode($this->types), $this->outputPath);
+        $writer->write('types.json');
+    }
+}

--- a/dev/src/DocGenerator/Writer.php
+++ b/dev/src/DocGenerator/Writer.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\DocGenerator;
+
+class Writer
+{
+    private $content;
+    private $outputPath;
+
+    public function __construct($content, $outputPath)
+    {
+        $this->content = $content;
+        $this->outputPath = $outputPath;
+    }
+
+    public function write($currentFile)
+    {
+        $path = $this->buildOutputPath($currentFile);
+
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0777, true);
+        }
+
+        file_put_contents($path, $this->content);
+    }
+
+    private function buildOutputPath($currentFile)
+    {
+        $pathInfo = pathinfo($currentFile);
+        $servicePath = $pathInfo['dirname'] . '/' . $pathInfo['filename'] . '.json';
+
+        if (strpos($servicePath, '/') !== 0) {
+            $servicePath = '/' . $servicePath;
+        }
+
+        $servicePath = strtolower($servicePath);
+
+        return $this->outputPath . $servicePath;
+    }
+}

--- a/dev/src/Release/Command/Release.php
+++ b/dev/src/Release/Command/Release.php
@@ -1,26 +1,41 @@
-#!/usr/bin/env php
 <?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-require __DIR__ . '/../vendor/autoload.php';
+namespace Google\Cloud\Dev\Release\Command;
 
-use Symfony\Component\Console\Application;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-if (!class_exists(Application::class)) {
-    throw new RuntimeException(
-        'Symfony Console Component not installed. ' .
-        'run "composer install" or "composer update", making sure not to ' .
-        'exclude dev dependencies, and try again.'
-    );
-}
-
-class ReleaseGenerator extends Command
+class Release extends Command
 {
     const PATH_MANIFEST = 'docs/manifest.json';
     const PATH_SERVICE_BUILDER = 'src/ServiceBuilder.php';
+
+    private $cliBasePath;
+
+    public function __construct($cliBasePath)
+    {
+        $this->cliBasePath = $cliBasePath;
+
+        parent::__construct();
+    }
 
     protected function configure()
     {
@@ -57,7 +72,7 @@ class ReleaseGenerator extends Command
 
     private function addToManifest($version)
     {
-        $path = __DIR__ .'/../'. self::PATH_MANIFEST;
+        $path = $this->cliBasePath .'/../'. self::PATH_MANIFEST;
         if (!file_exists($path)) {
             throw new RuntimeException('Manifest file not found at '. $path);
         }
@@ -79,7 +94,7 @@ class ReleaseGenerator extends Command
 
     private function updateServiceBuilder($version)
     {
-        $path = __DIR__ .'/../'. self::PATH_SERVICE_BUILDER;
+        $path = $this->cliBasePath .'/../'. self::PATH_SERVICE_BUILDER;
         if (!file_exists($path)) {
             throw new RuntimeException('ServiceBuilder not found at '. $path);
         }
@@ -97,9 +112,3 @@ class ReleaseGenerator extends Command
         }
     }
 }
-
-$release = new ReleaseGenerator;
-
-$app = new Application;
-$app->add($release);
-$app->run();


### PR DESCRIPTION
The main goal of this PR is to clean up the way docs are generated now, and to allow us to parse markdown files in `src` into files which can be included in the docs site. For instance, `src/PubSub/README.md` would become accessible in the docs site as `docs/master/pubsub/readme`. This will allow us to provide additional documentation, such as core concepts, API overviews and more without being tied to relating it to a specific file.

* Replaced dependency on `phpDocumentor/phpDocumentor` with `phpDocumentor/reflection`.
* Replaced `composer docs` with `composer google-cloud [release|docs]`.
* Renamed `scripts/` to `dev/`.
* Renamed `scripts/release-generator` to `dev/google-cloud`.
* Moved `scripts/docs.php` into the console app.
* Refactored `scripts/DocGenerator` into multiple files inside of `dev/src/DocGenerator`.

I've been playing with this on and off for a couple of months when I've got a spare moment, and I'm interested to get some feedback on whether this direction makes sense. Please let me know what you think!