### PR TITLE
Add release incrementor support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
         "symfony/console": "^3.0",
         "league/json-guard": "^0.3",
         "james-heinrich/getid3": "^1.9",
-        "erusev/parsedown": "^1.6"
+        "erusev/parsedown": "^1.6",
+        "vierbergenlars/php-semver": "^3.0"
     },
     "suggest": {
         "google/gax": "Required to support gRPC",

--- a/dev/readme.md
+++ b/dev/readme.md
@@ -6,5 +6,5 @@ easily invoked by running `composer google-cloud` at the command line.
 
 ## Commands
 
-* `composer google-cloud release <version>` Create a new release of Google Cloud PHP.
+* `composer google-cloud release <major|minor|patch|version-number>` Create a new release of Google Cloud PHP.
 * `composer google-cloud docs [<source] [<output>]` Generate Google Cloud PHP documentation.


### PR DESCRIPTION
You can now create releases by specifying the release type:

* `composer google-cloud release major` (v0.8.1 -> v1.0.0)
* `composer google-cloud release minor` (v0.8.1 -> v0.9.0)
* `composer google-cloud release patch` (v0.8.1 -> v0.8.2)
* `composer google-cloud release v0.8.2` (v0.8.1 -> v0.8.2)

It also no longer matters if you specify `v` at the beginning of a version. Given versions will be validated and sanitized as needed, and a `\RuntimeException` will be thrown if the version is hopelessly mangled.