### PR TITLE
Refactor PubSub encoding and messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ $subscription = $pubSub->subscription('my_subscription');
 $messages = $subscription->pull();
 
 foreach ($messages as $message) {
-    echo $message['message']['data'] . "\n";
+    echo $message->data() . "\n";
+    echo $message->attribute('location');
 }
 ```
 

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -113,6 +113,10 @@
             "title": "PubSub",
             "type": "pubsub/pubsubclient",
             "nav": [{
+                "title": "Message",
+                "type": "pubsub/message"
+            },
+            {
                 "title": "Subscription",
                 "type": "pubsub/subscription"
             },

--- a/src/PubSub/IncomingMessageTrait.php
+++ b/src/PubSub/IncomingMessageTrait.php
@@ -23,7 +23,7 @@ use Google\Cloud\PubSub\Connection\ConnectionInterface;
 trait IncomingMessageTrait
 {
     /**
-     * Create a Message instance from an incoming message
+     * Create a Message instance from an incoming message.
      *
      * @param array $message The message data
      * @param ConnectionInterface $connection The service connection.

--- a/src/PubSub/IncomingMessageTrait.php
+++ b/src/PubSub/IncomingMessageTrait.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\PubSub;
+
+use Google\Cloud\Exception\GoogleException;
+use Google\Cloud\PubSub\Connection\ConnectionInterface;
+
+trait IncomingMessageTrait
+{
+    /**
+     * Create a Message instance from an incoming message
+     *
+     * @param array $message The message data
+     * @param ConnectionInterface $connection The service connection.
+     * @param string $projectId The current project ID.
+     * @param bool $encode Whether to base64_encode.
+     * @return Message
+     */
+    private function messageFactory(array $message, ConnectionInterface $connection, $projectId, $encode)
+    {
+        if (!isset($message['message'])) {
+            throw new GoogleException('Invalid message data.');
+        }
+
+        if (isset($message['message']['data']) && $encode) {
+            $message['message']['data'] = base64_decode($message['message']['data']);
+        }
+
+        $subscription = null;
+        if (isset($message['subscription'])) {
+            $subscription = new Subscription(
+                $connection,
+                $projectId,
+                $message['subscription'],
+                null,
+                $encode
+            );
+        }
+
+        return new Message($message['message'], [
+            'ackId' => (isset($message['ackId'])) ? $message['ackId'] : null,
+            'subscription' => $subscription
+        ]);
+    }
+}

--- a/src/PubSub/Message.php
+++ b/src/PubSub/Message.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\PubSub;
+
+/**
+ * Represents a PubSub Message
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\ServiceBuilder;
+ *
+ * $cloud = new ServiceBuilder();
+ * $pubsub = $cloud->pubsub();
+ * $subscription = $pubsub->subscription('my-new-subscription');
+ *
+ * $messages = $subscription->pull();
+ * foreach ($messages as $message) {
+ *     print_R($message);break;
+ * }
+ * ```
+ */
+class Message
+{
+    /**
+     * @var array
+     */
+    private $message;
+
+    /**
+     * @var string
+     */
+    private $ackId;
+
+    /**
+     * @var Subscription
+     */
+    private $subscription;
+
+    /**
+     * @param array $message See
+     *        [PubsubMessage](https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage).
+     * @param array $metadata {
+     *     Message metadata
+     *
+     *     @type string $ackId The message ackId. This is only set when messages
+     *           are pulled from the PubSub service.
+     *     @type Subscription $subscription The subscription the message was
+     *           obtained from. This is only set when messages are delivered by
+     *           pushDelivery.
+     */
+    public function __construct(array $message, array $metadata)
+    {
+        $this->message = $message + [
+            'data' => null,
+            'messageId' => null,
+            'publishTime' => null,
+            'attributes' => []
+        ];
+
+        $metadata += [
+            'ackId' => null,
+            'subscription' => null
+        ];
+
+        $this->ackId = $metadata['ackId'];
+        $this->subscription = $metadata['subscription'];
+    }
+
+    /**
+     * The message payload
+     *
+     * Example:
+     * ```
+     * echo $message->data();
+     * ```
+     *
+     * @return string
+     */
+    public function data()
+    {
+        return $this->message['data'];
+    }
+
+    /**
+     * Retrieve a single message attribute
+     *
+     * Example:
+     * ```
+     * echo $message->attribute('browser-name');
+     * ```
+     *
+     * @param string $key The attribute key
+     * @return string|null
+     */
+    public function attribute($key)
+    {
+        return (isset($this->message['attributes'][$key]))
+            ? $this->message['attributes'][$key]
+            : null;
+    }
+
+    /**
+     * Retrieve all message attributes
+     *
+     * Example:
+     * ```
+     * $attributes = $message->attributes();
+     * ```
+     *
+     * @return array
+     */
+    public function attributes()
+    {
+        return $this->message['attributes'];
+    }
+
+    /**
+     * Get the message ID
+     *
+     * The message ID is assigned by the server when the message is published.
+     * Guaranteed to be unique within the topic.
+     *
+     * Example:
+     * ```
+     * echo $message->id();
+     * ```
+     *
+     * @return string
+     */
+    public function id()
+    {
+        return $this->message['messageId'];
+    }
+
+    /**
+     * Get the message published time
+     *
+     * Example:
+     * ```
+     * $time = $message->publishTime();
+     * ```
+     *
+     * @return DateTimeImmutable
+     */
+    public function publishTime()
+    {
+        return ($this->message['publishTime'])
+            ? new \DateTimeImmutable($this->message['publishTime'])
+            : null;
+    }
+
+    /**
+     * Get the message ackId
+     *
+     * This is only set when message is obtained via
+     * {@see Google\Cloud\PubSub\Subscription::pull()}.
+     *
+     * Example:
+     * ```
+     * echo $message->ackId();
+     * ```
+     *
+     * @return string
+     */
+    public function ackId()
+    {
+        return $this->ackId;
+    }
+
+    /**
+     * Get the subcription through which the message was obtained
+     *
+     * This is only set when the message is obtained via push delivery.
+     *
+     * Example:
+     * ```
+     * echo "Subscription Name: ". $message->subscription()->name();
+     * ```
+     *
+     * @return Subscription
+     */
+    public function subscription()
+    {
+        return $this->subscription;
+    }
+
+    /**
+     * Get the message data
+     *
+     * Available keys are `ackId`, `subscription` and `message`.
+     *
+     * Example:
+     * ```
+     * $info = $message->info();
+     * ```
+     *
+     * @return array
+     */
+    public function info()
+    {
+        return [
+            'ackId' => $this->ackId,
+            'subscription' => $this->subscription,
+            'message' => $this->message
+        ];
+    }
+}

--- a/src/PubSub/Message.php
+++ b/src/PubSub/Message.php
@@ -18,7 +18,7 @@
 namespace Google\Cloud\PubSub;
 
 /**
- * Represents a PubSub Message
+ * Represents a PubSub Message.
  *
  * Example:
  * ```
@@ -30,7 +30,7 @@ namespace Google\Cloud\PubSub;
  *
  * $messages = $subscription->pull();
  * foreach ($messages as $message) {
- *     print_R($message);break;
+ *     print_r($message);
  * }
  * ```
  */
@@ -82,7 +82,7 @@ class Message
     }
 
     /**
-     * The message payload
+     * The message payload.
      *
      * Example:
      * ```
@@ -97,7 +97,7 @@ class Message
     }
 
     /**
-     * Retrieve a single message attribute
+     * Retrieve a single message attribute.
      *
      * Example:
      * ```
@@ -115,7 +115,7 @@ class Message
     }
 
     /**
-     * Retrieve all message attributes
+     * Retrieve all message attributes.
      *
      * Example:
      * ```
@@ -130,7 +130,7 @@ class Message
     }
 
     /**
-     * Get the message ID
+     * Get the message ID.
      *
      * The message ID is assigned by the server when the message is published.
      * Guaranteed to be unique within the topic.
@@ -148,14 +148,14 @@ class Message
     }
 
     /**
-     * Get the message published time
+     * Get the message published time.
      *
      * Example:
      * ```
      * $time = $message->publishTime();
      * ```
      *
-     * @return DateTimeImmutable
+     * @return \DateTimeImmutable
      */
     public function publishTime()
     {
@@ -165,7 +165,7 @@ class Message
     }
 
     /**
-     * Get the message ackId
+     * Get the message ackId.
      *
      * This is only set when message is obtained via
      * {@see Google\Cloud\PubSub\Subscription::pull()}.
@@ -183,7 +183,7 @@ class Message
     }
 
     /**
-     * Get the subcription through which the message was obtained
+     * Get the subcription through which the message was obtained.
      *
      * This is only set when the message is obtained via push delivery.
      *
@@ -200,7 +200,7 @@ class Message
     }
 
     /**
-     * Get the message data
+     * Get the message data.
      *
      * Available keys are `ackId`, `subscription` and `message`.
      *

--- a/src/RequestWrapper.php
+++ b/src/RequestWrapper.php
@@ -294,7 +294,11 @@ class RequestWrapper
     private function getExceptionMessage(\Exception $ex)
     {
         if ($ex instanceof RequestException && $ex->hasResponse()) {
-            return (string) $ex->getResponse()->getBody();
+            $res = (string) $ex->getResponse()->getBody();
+            json_decode($res);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                return $res;
+            }
         }
 
         return $ex->getMessage();

--- a/tests/PubSub/IncomingMessageTraitTest.php
+++ b/tests/PubSub/IncomingMessageTraitTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\PubSub;
+
+use Google\Cloud\PubSub\Connection\ConnectionInterface;
+use Google\Cloud\PubSub\IncomingMessageTrait;
+use Google\Cloud\PubSub\Message;
+use Google\Cloud\PubSub\Subscription;
+
+/**
+ * @group pubsub
+ */
+class IncomingMessageTraitTest extends \PHPUnit_Framework_TestCase
+{
+    private $stub;
+
+    public function setUp()
+    {
+        $this->stub = new IncomingMessageTraitStub($this->prophesize(ConnectionInterface::class)->reveal());
+    }
+
+    public function testMessageFactory()
+    {
+        $message = $this->stub->call([
+            'message' => [
+                'data' => 'hello world'
+            ]
+        ]);
+
+        $this->assertInstanceOf(Message::class, $message);
+        $this->assertEquals('hello world', $message->data());
+    }
+
+    /**
+     * @expectedException Google\Cloud\Exception\GoogleException
+     */
+    public function testInvalidMessage()
+    {
+        $this->stub->call([]);
+    }
+
+    public function testDecodeMessage()
+    {
+        $message = $this->stub->call([
+            'message' => [
+                'data' => base64_encode('hello world')
+            ]
+        ], true);
+
+        $this->assertEquals('hello world', $message->data());
+    }
+
+    public function testMessageWithSubscription()
+    {
+        $message = $this->stub->call([
+            'message' => [
+                'data' => base64_encode('hello world')
+            ],
+            'subscription' => 'projects/project-id/subscriptions/foo'
+        ], true);
+
+        $this->assertInstanceOf(Subscription::class, $message->subscription());
+        $this->assertEquals('projects/project-id/subscriptions/foo', $message->subscription()->name());
+    }
+}
+
+class IncomingMessageTraitStub
+{
+    use IncomingMessageTrait;
+
+    private $connection;
+
+    public function __construct($connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function call($message, $encode = false)
+    {
+        return $this->messageFactory($message, $this->connection, 'project-id', $encode);
+    }
+}

--- a/tests/PubSub/MessageTest.php
+++ b/tests/PubSub/MessageTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\PubSub;
+
+use Google\Cloud\PubSub\Message;
+use Google\Cloud\PubSub\Subscription;
+
+/**
+ * @group pubsub
+ */
+class MessageTest extends \PHPUnit_Framework_TestCase
+{
+    private $message;
+
+    private $time = '2016-09-27T13:21:30.242Z';
+
+    public function setUp()
+    {
+        $this->message = new Message([
+            'data' => 'hello world',
+            'messageId' => 1,
+            'publishTime' => $this->time,
+            'attributes' => [
+                'foo' => 'bar'
+            ]
+        ], [
+            'ackId' => 1234,
+            'subscription' => $this->prophesize(Subscription::class)->reveal()
+        ]);
+    }
+
+    public function testData()
+    {
+        $this->assertEquals('hello world', $this->message->data());
+    }
+
+    public function testAttribute()
+    {
+        $this->assertEquals('bar', $this->message->attribute('foo'));
+    }
+
+    public function testAttributeNull()
+    {
+        $this->assertNull($this->message->attribute('nothanks'));
+    }
+
+    public function testAttributes()
+    {
+        $this->assertEquals(['foo' => 'bar'], $this->message->attributes());
+    }
+
+    public function testId()
+    {
+        $this->assertEquals(1, $this->message->id());
+    }
+
+    public function testPublishTime()
+    {
+        $this->assertInstanceOf(\DateTimeImmutable::class, $this->message->publishTime());
+        $this->assertEquals(new \DateTimeImmutable($this->time), $this->message->publishTime());
+    }
+
+    public function testAckId()
+    {
+        $this->assertEquals(1234, $this->message->ackId());
+    }
+
+    public function testSubscription()
+    {
+        $this->assertInstanceOf(Subscription::class, $this->message->subscription());
+    }
+
+    public function testInfo()
+    {
+        $this->assertTrue(is_array($this->message->info()));
+        $this->assertTrue(is_array($this->message->info()['message']));
+        $this->assertInstanceOf(Subscription::class, $this->message->info()['subscription']);
+        $this->assertEquals(1234, $this->message->info()['ackId']);
+    }
+}


### PR DESCRIPTION
This change improves PubSub by standardizing how message payload encoding is handled for Rest and gRPC transports, and by easing the handling and acknowledgement of incoming messages.

It introduces some breaking changes to the library.

* Added `Message` to represent incoming messages.
* Added `PubSubClient::consume()` method. This method can be used by pushDelivery servers to convert an HTTP request into an instance of `Message`.
* `Subscription::pull()` now returns `Generator<Message>`.
* `Subscription::acknowledge()` and `Subscription::modifyAckDeadline()` now accept an instance of `Message` as their first argument.
* `Subscription::acknowledgeBatch()` and `Subscription::modifyAckDeadlineBatch()` now accept `Message[]` as their first argument.
* Whether message payloads should be encoded and decoded is now determined in the constructor of `PubSubClient`. This is currently set to `true`. When gRPC transport is implemented, this value should be determined based on which transport is used.
* Incoming message payloads are now decoded internally if necessary. This eliminates the need for users to determine whether to decode message payloads.
* The constructor signatures for `Topic` and `Subscription` have changed. I fixed the argument order to be more consistent with everything else, and I added an `$encode` argument. I had previously removed documentation instructing users on directly instantiating either of those classes, as it kind of goes against the spirit of how the library should be used.

I also did a bit of cleanup in the documentation to make the examples more inline with those in other services, and fixed a couple mistakes I found along the way.