### PR TITLE
New Storage functionality

### DIFF
--- a/src/Storage/Connection/ConnectionInterface.php
+++ b/src/Storage/Connection/ConnectionInterface.php
@@ -86,6 +86,16 @@ interface ConnectionInterface
     /**
      * @param array $args
      */
+    public function rewriteObject(array $args = []);
+
+    /**
+     * @param array $args
+     */
+    public function composeObject(array $args = []);
+
+    /**
+     * @param array $args
+     */
     public function getObject(array $args = []);
 
     /**

--- a/src/Storage/Connection/Rest.php
+++ b/src/Storage/Connection/Rest.php
@@ -152,6 +152,22 @@ class Rest implements ConnectionInterface
     /**
      * @param array $args
      */
+    public function rewriteObject(array $args = [])
+    {
+        return $this->send('objects', 'rewrite', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function composeObject(array $args = [])
+    {
+        return $this->send('objects', 'compose', $args);
+    }
+
+    /**
+     * @param array $args
+     */
     public function getObject(array $args = [])
     {
         return $this->send('objects', 'get', $args);

--- a/src/Storage/EncryptionTrait.php
+++ b/src/Storage/EncryptionTrait.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage;
+
+use InvalidArgumentException;
+
+/**
+ * Trait which provides helper methods for customer-supplied encryption.
+ */
+trait EncryptionTrait
+{
+    /**
+     * @var array
+     */
+    private $copySourceEncryptionHeaderNames = [
+        'algorithm' => 'x-goog-copy-source-encryption-algorithm',
+        'key' => 'x-goog-copy-source-encryption-key',
+        'keySHA256' => 'x-goog-copy-source-encryption-key-sha256'
+    ];
+
+    /**
+     * @var array
+     */
+    private $encryptionHeaderNames = [
+        'algorithm' => 'x-goog-encryption-algorithm',
+        'key' => 'x-goog-encryption-key',
+        'keySHA256' => 'x-goog-encryption-key-sha256'
+    ];
+
+    /**
+     * Formats options for customer-supplied encryption headers.
+     *
+     * @param array $options
+     * @return array
+     * @throws \InvalidArgumentException
+     * @access private
+     */
+    public function formatEncryptionHeaders(array $options)
+    {
+        $encryptionHeaders = [];
+        $useCopySourceHeaders = isset($options['useCopySourceHeaders']) ? $options['useCopySourceHeaders'] : false;
+        $key = isset($options['encryptionKey']) ? $options['encryptionKey'] : null;
+        $keySHA256 = isset($options['encryptionKeySHA256']) ? $options['encryptionKeySHA256'] : null;
+        $destinationKey = isset($options['destinationEncryptionKey']) ? $options['destinationEncryptionKey'] : null;
+        $destinationKeySHA256 = isset($options['destinationEncryptionKeySHA256'])
+            ? $options['destinationEncryptionKeySHA256']
+            : null;
+
+        unset($options['useCopySourceHeaders']);
+        unset($options['encryptionKey']);
+        unset($options['encryptionKeySHA256']);
+        unset($options['destinationEncryptionKey']);
+        unset($options['destinationEncryptionKeySHA256']);
+
+        $encryptionHeaders = $this->buildHeaders($key, $keySHA256, $useCopySourceHeaders, false)
+            + $this->buildHeaders($destinationKey, $destinationKeySHA256, false, true);
+
+        if (!empty($encryptionHeaders)) {
+            if (isset($options['httpOptions']['headers'])) {
+                $options['httpOptions']['headers'] += $encryptionHeaders;
+            } else {
+                $options['httpOptions']['headers'] = $encryptionHeaders;
+            }
+        }
+
+        return $options;
+    }
+
+    /**
+     * Builds out customer-supplied encryption headers.
+     *
+     * @param string $key
+     * @param string $keySHA256
+     * @param bool $useCopySourceHeaders
+     * @param bool $isDestination
+     * @return array
+     * @throws \InvalidArgumentException
+     */
+    private function buildHeaders($key, $keySHA256, $useCopySourceHeaders, $isDestination)
+    {
+        if ($key && $keySHA256) {
+            $headerNames = $useCopySourceHeaders
+                ? $this->copySourceEncryptionHeaderNames
+                : $this->encryptionHeaderNames;
+
+            return [
+                $headerNames['algorithm'] => 'AES256',
+                $headerNames['key'] => base64_encode($key),
+                $headerNames['keySHA256'] => base64_encode($keySHA256)
+            ];
+        } elseif ($key || $keySHA256) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'When providing either %s or %s both must be supplied.',
+                    $isDestination ? 'a destinationEncryptionKey' : 'an encryptionKey',
+                    $isDestination ? 'a destinationEncryptionKeySHA256' : 'an encryptionKeySHA256'
+                )
+            );
+        }
+
+        return [];
+    }
+}

--- a/src/Storage/StorageObject.php
+++ b/src/Storage/StorageObject.php
@@ -451,7 +451,7 @@ class StorageObject
      * ```
      *
      * @param string $name The new name.
-     * @param array $options {
+     * @param array $options [optional] {
      *     Configuration options.
      *
      *     @type string $predefinedAcl Access controls to apply to the

--- a/src/Storage/StorageObject.php
+++ b/src/Storage/StorageObject.php
@@ -28,6 +28,8 @@ use Psr\Http\Message\StreamInterface;
  */
 class StorageObject
 {
+    use EncryptionTrait;
+
     /**
      * @var Acl ACL for the object.
      */
@@ -37,6 +39,11 @@ class StorageObject
      * @var ConnectionInterface Represents a connection to Cloud Storage.
      */
     private $connection;
+
+    /**
+     * @var array The object's encryption data.
+     */
+    private $encryptionData;
 
     /**
      * @var array The object's identity.
@@ -55,17 +62,31 @@ class StorageObject
      * @param string $bucket The name of the bucket the object is contained in.
      * @param string $generation [optional] The generation of the object.
      * @param array $info [optional] The object's metadata.
+     * @param string $encryptionKey [optional] An AES-256 customer-supplied
+     *        encryption key.
+     * @param string $encryptionKeySHA256 [optional] The SHA256 hash of the
+     *        customer-supplied encryption key.
      */
-    public function __construct(ConnectionInterface $connection, $name, $bucket, $generation = null, array $info = null)
-    {
+    public function __construct(
+        ConnectionInterface $connection,
+        $name,
+        $bucket,
+        $generation = null,
+        array $info = null,
+        $encryptionKey = null,
+        $encryptionKeySHA256 = null
+    ) {
         $this->connection = $connection;
         $this->info = $info;
+        $this->encryptionData = [
+            'encryptionKey' => $encryptionKey,
+            'encryptionKeySHA256' => $encryptionKeySHA256
+        ];
         $this->identity = [
             'bucket' => $bucket,
             'object' => $name,
             'generation' => $generation
         ];
-
         $this->acl = new Acl($this->connection, 'objectAccessControls', $this->identity);
     }
 
@@ -213,6 +234,7 @@ class StorageObject
      * $copiedObject = $object->copy($otherBucket, [
      *     'name' => 'newFile.txt'
      * ]);
+     * ```
      *
      * @see https://cloud.google.com/storage/docs/json_api/v1/objects/copy Objects copy API documentation.
      *
@@ -227,6 +249,14 @@ class StorageObject
      *           `authenticatedRead`, `bucketOwnerFullControl`,
      *           `bucketOwnerRead`, `private`, `projectPrivate`, and
      *           `publicRead`.
+     *     @type string $encryptionKey An AES-256 customer-supplied encryption
+     *           key. It will be neccesary to provide this when a key was used
+     *           during the object's creation. If provided one must also include
+     *           an `encryptionKeySHA256`.
+     *     @type string $encryptionKeySHA256 The SHA256 hash of the
+     *           customer-supplied encryption key. It will be neccesary to
+     *           provide this when a key was used during the object's creation.
+     *           If provided one must also include an `encryptionKey`.
      *     @type string $ifGenerationMatch Makes the operation conditional on
      *           whether the destination object's current generation matches the
      *           given value.
@@ -256,35 +286,229 @@ class StorageObject
      */
     public function copy($destination, array $options = [])
     {
-        if (!is_string($destination) && !($destination instanceof Bucket)) {
-            throw new \InvalidArgumentException(
-                '$destination must be either a string or an instance of Bucket.'
-            );
-        }
+        $key = isset($options['encryptionKey']) ? $options['encryptionKey'] : null;
+        $keySHA256 = isset($options['encryptionKeySHA256']) ? $options['encryptionKeySHA256'] : null;
 
-        $destAcl = isset($options['predefinedAcl']) ? $options['predefinedAcl'] : null;
-        $destObject = isset($options['name']) ? $options['name'] : $this->identity['object'];
-        $destBucket = $destination instanceof Bucket ? $destination->name() : $destination;
-
-        unset($options['name']);
-        unset($options['predefinedAcl']);
-
-        $response = $this->connection->copyObject(array_filter([
-            'destinationBucket' => $destBucket,
-            'destinationObject' => $destObject,
-            'destinationPredefinedAcl' => $destAcl,
-            'sourceBucket' => $this->identity['bucket'],
-            'sourceObject' => $this->identity['object'],
-            'sourceGeneration' => $this->identity['generation']
-        ]) + $options);
+        $response = $this->connection->copyObject(
+            $this->formatDestinationRequest($destination, $options)
+        );
 
         return new StorageObject(
             $this->connection,
             $response['name'],
             $response['bucket'],
             $response['generation'],
-            $response
+            $response,
+            $key,
+            $keySHA256
         );
+    }
+
+    /**
+     * Rewrite the object to a destination bucket.
+     *
+     * This method copies data using multiple requests so large objects can be
+     * copied with a normal length timeout per request rather than one very long
+     * timeout for a single request.
+     *
+     * Please note that if the destination bucket is the same as the source
+     * bucket and a new name is not provided the source object will be replaced
+     * with the copy of itself.
+     *
+     * Example:
+     * ```
+     * // Provide your destination bucket as a string and retain the source
+     * // object's name.
+     * $rewrittenObject = $object->rewrite('otherBucket');
+     * ```
+     *
+     * ```
+     * // Provide your destination bucket as a bucket object and choose a new
+     * // name for the copied object.
+     * $otherBucket = $storage->bucket('otherBucket');
+     * $rewrittenObject = $object->rewrite($otherBucket, [
+     *     'name' => 'newFile.txt'
+     * ]);
+     * ```
+     *
+     * ```
+     * // Rotate customer-supplied encryption keys.
+     * $key = file_get_contents(__DIR__ . '/key.txt');
+     * $hash = hash('SHA256', $key, true);
+     * $destinationKey = openssl_random_pseudo_bytes(32); // Make sure to remember your key.
+     * $destinationHash = hash('SHA256', $destinationKey, true);
+     *
+     * $rewrittenObject = $object->rewrite('otherBucket', [
+     *     'encryptionKey' => $key,
+     *     'encryptionKeySHA256' => $hash,
+     *     'destinationEncryptionKey' => $destinationKey,
+     *     'destinationEncryptionKeySHA256' => $destinationHash
+     * ]);
+     * ```
+     *
+     * @see https://cloud.google.com/storage/docs/json_api/v1/objects/rewrite Objects rewrite API documentation.
+     * @see https://cloud.google.com/storage/docs/encryption#customer-supplied Customer-supplied encryption keys.
+     *
+     * @param Bucket|string $destination The destination bucket.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type string $name The name of the destination object. **Defaults
+     *           to** the name of the source object.
+     *     @type string $predefinedAcl Access controls to apply to the
+     *           destination object. Acceptable values include
+     *           `authenticatedRead`, `bucketOwnerFullControl`,
+     *           `bucketOwnerRead`, `private`, `projectPrivate`, and
+     *           `publicRead`.
+     *     @type string $maxBytesRewrittenPerCall The maximum number of bytes
+     *           that will be rewritten per rewrite request. Most callers
+     *           shouldn't need to specify this parameter - it is primarily in
+     *           place to support testing. If specified the value must be an
+     *           integral multiple of 1 MiB (1048576). Also, this only applies
+     *           to requests where the source and destination span locations
+     *           and/or storage classes.
+     *     @type string $encryptionKey An AES-256 customer-supplied encryption
+     *           key. It will be neccesary to provide this when a key was used
+     *           during the object's creation. If provided one must also include
+     *           an `encryptionKeySHA256`.
+     *     @type string $encryptionKeySHA256 The SHA256 hash of the
+     *           customer-supplied encryption key. It will be neccesary to
+     *           provide this when a key was used during the object's creation.
+     *           If provided one must also include an `encryptionKey`.
+     *     @type string $destinationEncryptionKey An AES-256 customer-supplied
+     *           encryption key that will be used to encrypt the rewritten
+     *           object. If provided one must also include a
+     *           `destinationEncryptionKeySHA256`.
+     *     @type string $destinationEncryptionKeySHA256 The SHA256 hash of the
+     *           customer-supplied destination encryption key. If provided one
+     *           must also include a `destinationEncryptionKey`.
+     *     @type string $ifGenerationMatch Makes the operation conditional on
+     *           whether the destination object's current generation matches the
+     *           given value.
+     *     @type string $ifGenerationNotMatch Makes the operation conditional on
+     *           whether the destination object's current generation does not
+     *           match the given value.
+     *     @type string $ifMetagenerationMatch Makes the operation conditional
+     *           on whether the destination object's current metageneration
+     *           matches the given value.
+     *     @type string $ifMetagenerationNotMatch Makes the operation
+     *           conditional on whether the destination object's current
+     *           metageneration does not match the given value.
+     *     @type string $ifSourceGenerationMatch Makes the operation conditional
+     *           on whether the source object's current generation matches the
+     *           given value.
+     *     @type string $ifSourceGenerationNotMatch Makes the operation
+     *           conditional on whether the source object's current generation
+     *           does not match the given value.
+     *     @type string $ifSourceMetagenerationMatch Makes the operation
+     *           conditional on whether the source object's current
+     *           metageneration matches the given value.
+     *     @type string $ifSourceMetagenerationNotMatch Makes the operation
+     *           conditional on whether the source object's current
+     *           metageneration does not match the given value.
+     * }
+     * @return StorageObject
+     * @throws \InvalidArgumentException
+     */
+    public function rewrite($destination, array $options = [])
+    {
+        $options['useCopySourceHeaders'] = true;
+        $destinationKey = isset($options['destinationEncryptionKey']) ? $options['destinationEncryptionKey'] : null;
+        $destinationKeySHA256 = isset($options['destinationEncryptionKeySHA256'])
+            ? $options['destinationEncryptionKeySHA256']
+            : null;
+
+        $options = $this->formatDestinationRequest($destination, $options);
+
+        do {
+            $response = $this->connection->rewriteObject($options);
+            $options['rewriteToken'] = isset($response['rewriteToken']) ? $response['rewriteToken'] : null;
+        } while ($options['rewriteToken']);
+
+        return new StorageObject(
+            $this->connection,
+            $response['resource']['name'],
+            $response['resource']['bucket'],
+            $response['resource']['generation'],
+            $response['resource'],
+            $destinationKey,
+            $destinationKeySHA256
+        );
+    }
+
+    /**
+     * Renames the object.
+     *
+     * Please note that there is no atomic rename provided by the Storage API.
+     * This method is for convenience and is a set of sequential calls to copy
+     * and delete. Upon success the source object's metadata will be cleared,
+     * please use the returned object instead.
+     *
+     * Example:
+     * ```
+     * $object2 = $object->rename('object2.txt');
+     * echo $object2->name();
+     * ```
+     *
+     * @param string $name The new name.
+     * @param array $options {
+     *     Configuration options.
+     *
+     *     @type string $predefinedAcl Access controls to apply to the
+     *           destination object. Acceptable values include
+     *           `authenticatedRead`, `bucketOwnerFullControl`,
+     *           `bucketOwnerRead`, `private`, `projectPrivate`, and
+     *           `publicRead`.
+     *     @type string $encryptionKey An AES-256 customer-supplied encryption
+     *           key. It will be neccesary to provide this when a key was used
+     *           during the object's creation. If provided one must also include
+     *           an `encryptionKeySHA256`.
+     *     @type string $encryptionKeySHA256 The SHA256 hash of the
+     *           customer-supplied encryption key. It will be neccesary to
+     *           provide this when a key was used during the object's creation.
+     *           If provided one must also include an `encryptionKey`.
+     *     @type string $ifGenerationMatch Makes the operation conditional on
+     *           whether the destination object's current generation matches the
+     *           given value.
+     *     @type string $ifGenerationNotMatch Makes the operation conditional on
+     *           whether the destination object's current generation does not
+     *           match the given value.
+     *     @type string $ifMetagenerationMatch Makes the operation conditional
+     *           on whether the destination object's current metageneration
+     *           matches the given value.
+     *     @type string $ifMetagenerationNotMatch Makes the operation
+     *           conditional on whether the destination object's current
+     *           metageneration does not match the given value.
+     *     @type string $ifSourceGenerationMatch Makes the operation conditional
+     *           on whether the source object's current generation matches the
+     *           given value.
+     *     @type string $ifSourceGenerationNotMatch Makes the operation
+     *           conditional on whether the source object's current generation
+     *           does not match the given value.
+     *     @type string $ifSourceMetagenerationMatch Makes the operation
+     *           conditional on whether the source object's current
+     *           metageneration matches the given value.
+     *     @type string $ifSourceMetagenerationNotMatch Makes the operation
+     *           conditional on whether the source object's current
+     *           metageneration does not match the given value.
+     * }
+     * @return StorageObject The renamed object.
+     */
+    public function rename($name, array $options = [])
+    {
+        $copiedObject = $this->copy($this->identity['bucket'], [
+            'name' => $name
+        ] + $options);
+
+        $this->delete(
+            array_intersect_key($options, [
+                'httpOptions' => null,
+                'retries' => null
+            ])
+        );
+        $this->info = [];
+
+        return $copiedObject;
     }
 
     /**
@@ -293,15 +517,32 @@ class StorageObject
      * Example:
      * ```
      * $string = $object->downloadAsString();
-     * file_put_contents($string, 'my-file.txt');
+     * file_put_contents($string, __DIR__ . '/my-file.txt');
      * ```
      *
-     * @param array $options [optional] Configuration Options.
+     * @param array $options [optional] {
+     *     Configuration Options.
+     *
+     *     @type string $encryptionKey An AES-256 customer-supplied encryption
+     *           key. It will be neccesary to provide this when a key was used
+     *           during the object's creation. If provided one must also include
+     *           an `encryptionKeySHA256`.
+     *     @type string $encryptionKeySHA256 The SHA256 hash of the
+     *           customer-supplied encryption key. It will be neccesary to
+     *           provide this when a key was used during the object's creation.
+     *           If provided one must also include an `encryptionKey`.
+     * }
      * @return string
      */
     public function downloadAsString(array $options = [])
     {
-        return (string) $this->connection->downloadObject($options + $this->identity);
+        return (string) $this->connection->downloadObject(
+            $this->formatEncryptionHeaders(
+                $options
+                + $this->encryptionData
+                + $this->identity
+            )
+        );
     }
 
     /**
@@ -309,11 +550,22 @@ class StorageObject
      *
      * Example:
      * ```
-     * $object->downloadToFile('my-file.txt');
+     * $object->downloadToFile(__DIR__ . '/my-file.txt');
      * ```
      *
-     * @param string $path Path to download file to.
-     * @param array $options [optional] Configuration Options.
+     * @param string $path Path to download the file to.
+     * @param array $options [optional] {
+     *     Configuration Options.
+     *
+     *     @type string $encryptionKey An AES-256 customer-supplied encryption
+     *           key. It will be neccesary to provide this when a key was used
+     *           during the object's creation. If provided one must also include
+     *           an `encryptionKeySHA256`.
+     *     @type string $encryptionKeySHA256 The SHA256 hash of the
+     *           customer-supplied encryption key. It will be neccesary to
+     *           provide this when a key was used during the object's creation.
+     *           If provided one must also include an `encryptionKey`.
+     * }
      * @return StreamInterface
      */
     public function downloadToFile($path, array $options = [])
@@ -321,7 +573,13 @@ class StorageObject
         $destination = Psr7\stream_for(fopen($path, 'w'));
 
         Psr7\copy_to_stream(
-            $this->connection->downloadObject($options + $this->identity),
+            $this->connection->downloadObject(
+                $this->formatEncryptionHeaders(
+                    $options
+                    + $this->encryptionData
+                    + $this->identity
+                )
+            ),
             $destination
         );
 
@@ -345,6 +603,16 @@ class StorageObject
      * @param array $options [optional] {
      *     Configuration options.
      *
+     *     @type string $encryptionKey An AES-256 customer-supplied encryption
+     *           key. It will be neccesary to provide this when a key was used
+     *           during the object's creation in order to retrieve the MD5 hash
+     *           and CRC32C checksum. If provided one must also include an
+     *           `encryptionKeySHA256`.
+     *     @type string $encryptionKeySHA256 The SHA256 hash of the
+     *           customer-supplied encryption key. It will be neccesary to
+     *           provide this when a key was used during the object's creation
+     *           in order to retrieve the MD5 hash and CRC32C checksum. If
+     *           provided one must also include an `encryptionKey`.
      *     @type string $ifGenerationMatch Makes the operation conditional on
      *           whether the object's current generation matches the given
      *           value.
@@ -386,6 +654,16 @@ class StorageObject
      * @param array $options [optional] {
      *     Configuration options.
      *
+     *     @type string $encryptionKey An AES-256 customer-supplied encryption
+     *           key. It will be neccesary to provide this when a key was used
+     *           during the object's creation in order to retrieve the MD5 hash
+     *           and CRC32C checksum. If provided one must also include an
+     *           `encryptionKeySHA256`.
+     *     @type string $encryptionKeySHA256 The SHA256 hash of the
+     *           customer-supplied encryption key. It will be neccesary to
+     *           provide this when a key was used during the object's creation
+     *           in order to retrieve the MD5 hash and CRC32C checksum. If
+     *           provided one must also include an `encryptionKey`.
      *     @type string $ifGenerationMatch Makes the operation conditional on
      *           whether the object's current generation matches the given
      *           value.
@@ -405,7 +683,13 @@ class StorageObject
      */
     public function reload(array $options = [])
     {
-        return $this->info = $this->connection->getObject($options + $this->identity);
+        return $this->info = $this->connection->getObject(
+            $this->formatEncryptionHeaders(
+                $options
+                + $this->encryptionData
+                + $this->identity
+            )
+        );
     }
 
     /**
@@ -436,5 +720,36 @@ class StorageObject
     public function identity()
     {
         return $this->identity;
+    }
+
+    /**
+     * Formats a destination based request, such as copy or rewrite.
+     *
+     * @param string|Bucket $destination The destination bucket.
+     * @param array $options Options to configure.
+     * @return array
+     */
+    private function formatDestinationRequest($destination, array $options)
+    {
+        if (!is_string($destination) && !($destination instanceof Bucket)) {
+            throw new \InvalidArgumentException(
+                '$destination must be either a string or an instance of Bucket.'
+            );
+        }
+
+        $destAcl = isset($options['predefinedAcl']) ? $options['predefinedAcl'] : null;
+        $destObject = isset($options['name']) ? $options['name'] : $this->identity['object'];
+
+        unset($options['name']);
+        unset($options['predefinedAcl']);
+
+        return array_filter([
+            'destinationBucket' => $destination instanceof Bucket ? $destination->name() : $destination,
+            'destinationObject' => $destObject,
+            'destinationPredefinedAcl' => $destAcl,
+            'sourceBucket' => $this->identity['bucket'],
+            'sourceObject' => $this->identity['object'],
+            'sourceGeneration' => $this->identity['generation']
+        ]) + $this->formatEncryptionHeaders($options + $this->encryptionData);
     }
 }

--- a/tests/Storage/Connection/RestTest.php
+++ b/tests/Storage/Connection/RestTest.php
@@ -89,7 +89,9 @@ class RestTest extends \PHPUnit_Framework_TestCase
             ['deleteObject'],
             ['getObject'],
             ['listObjects'],
-            ['patchObject']
+            ['patchObject'],
+            ['rewriteObject'],
+            ['composeObject']
         ];
     }
 

--- a/tests/Storage/EncryptionTraitTest.php
+++ b/tests/Storage/EncryptionTraitTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Storage;
+
+use Google\Cloud\Storage\EncryptionTrait;
+
+/**
+ * @group storage
+ */
+class EncryptionTraitTest extends \PHPUnit_Framework_TestCase
+{
+    private $trait;
+
+    public function setUp()
+    {
+        $this->trait = $this->getObjectForTrait(EncryptionTrait::class);
+    }
+
+    /**
+     * @dataProvider encryptionProvider
+     */
+    public function testFormatEncryptionHeaders($expectedOptions, $options)
+    {
+        $this->assertEquals(
+            $expectedOptions,
+            $this->trait->formatEncryptionHeaders($options)
+        );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testFormatEncryptionHeadersThrowsExceptionWithoutBothKeyAndHash()
+    {
+        $this->trait->formatEncryptionHeaders([
+            'encryptionKey' => 'abcd'
+        ]);
+    }
+
+    public function encryptionProvider()
+    {
+        $key = 'abcd';
+        $hash = '1234';
+        $destinationKey = 'efgh';
+        $destinationHash = '5678';
+
+        return [
+            [
+                [
+                    'httpOptions' => [
+                        'headers' => $this->getEncryptionHeaders($key, $hash)
+                    ]
+                ],
+                [
+                    'encryptionKey' => $key,
+                    'encryptionKeySHA256' => $hash
+                ]
+            ],
+            [
+                [
+                    'httpOptions' => [
+                        'headers' => array_merge(
+                            $this->getEncryptionHeaders($destinationKey, $destinationHash),
+                            $this->getCopySourceEncryptionHeaders($key, $hash)
+                        )
+                    ]
+                ],
+                [
+                    'useCopySourceHeaders' => true,
+                    'encryptionKey' => $key,
+                    'encryptionKeySHA256' => $hash,
+                    'destinationEncryptionKey' => $destinationKey,
+                    'destinationEncryptionKeySHA256' => $destinationHash
+                ]
+            ],
+            [
+                [
+                    'httpOptions' => [
+                        'headers' => $this->getEncryptionHeaders($key, $hash) + ['hey' => 'dont clobber me']
+                    ]
+                ],
+                [
+                    'encryptionKey' => $key,
+                    'encryptionKeySHA256' => $hash,
+                    'httpOptions' => [
+                        'headers' => [
+                            'hey' => 'dont clobber me'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    private function getEncryptionHeaders($key, $hash)
+    {
+        return [
+            'x-goog-encryption-algorithm' => 'AES256',
+            'x-goog-encryption-key' => base64_encode($key),
+            'x-goog-encryption-key-sha256' => base64_encode($hash)
+        ];
+    }
+
+    private function getCopySourceEncryptionHeaders($key, $hash)
+    {
+        return [
+            'x-goog-copy-source-encryption-algorithm' => 'AES256',
+            'x-goog-copy-source-encryption-key' => base64_encode($key),
+            'x-goog-copy-source-encryption-key-sha256' => base64_encode($hash)
+        ];
+    }
+}


### PR DESCRIPTION
Closes https://github.com/GoogleCloudPlatform/google-cloud-php/issues/144

New public methods implemented:
- `Bucket`
    - `public function compose(array $sourceObjects, $name, array $options = []) : StorageObject`
- `StorageObject`
    - `public function rewrite($destination, array $options = []) : StorageObject`
    - `public function rename($name, array $options = []) : StorageObject`

Additionally, while it was possible to provide [customer-supplied encryption keys](https://cloud.google.com/storage/docs/encryption#customer-supplied) previously, there is now better support and it is more clearly documented.