### PR TITLE
Renamed `complete key` to `named key` and add documentation

### DIFF
--- a/src/Datastore/DatastoreClient.php
+++ b/src/Datastore/DatastoreClient.php
@@ -226,7 +226,7 @@ class DatastoreClient
      *
      * Entities are created with a Datastore Key, or by specifying a Kind. Kinds
      * are only allowed for insert operations. For any other case, you must
-     * specify a complete key. If a kind is given, an ID will be automatically
+     * specify a named key. If a kind is given, an ID will be automatically
      * allocated for the entity upon insert. Additionally, if your entity
      * requires a complex key elementPath, you must create the key separately.
      *

--- a/src/Datastore/Operation.php
+++ b/src/Datastore/Operation.php
@@ -177,7 +177,7 @@ class Operation
      *
      * Entities are created with a Datastore Key, or by specifying a Kind. Kinds
      * are only allowed for insert operations. For any other case, you must
-     * specify a complete key. If a kind is given, an ID will be automatically
+     * specify a named key. If a kind is given, an ID will be automatically
      * allocated for the entity upon insert. Additionally, if your entity
      * requires a complex key elementPath, you must create the key separately.
      *
@@ -251,7 +251,7 @@ class Operation
     public function allocateIds(array $keys, array $options = [])
     {
         // Validate the given keys. First check types, then state of each.
-        // The API will throw a 400 if the key is complete, but it's an easy
+        // The API will throw a 400 if the key is named, but it's an easy
         // check we can handle before going to the API to save a request.
         // @todo replace with json schema
         $this->validateBatch($keys, Key::class, function ($key) {
@@ -313,7 +313,7 @@ class Operation
         ];
 
         $this->validateBatch($keys, Key::class, function ($key) {
-            if ($key->state() !== Key::STATE_COMPLETE) {
+            if ($key->state() !== Key::STATE_NAMED) {
                 throw new InvalidArgumentException(sprintf(
                     'Given $key is in an invalid state. Can only lookup records when given a complete key. ' .
                     'Given path was %s',
@@ -451,7 +451,7 @@ class Operation
     /**
      * Patch any incomplete keys in the given array of entities
      *
-     * Any incomplete keys will be allocated an ID. Complete keys in the input
+     * Any incomplete keys will be allocated an ID. Named keys in the input
      * will remain unchanged.
      *
      * @param Entity[] $entities A list of entities

--- a/tests/Datastore/KeyTest.php
+++ b/tests/Datastore/KeyTest.php
@@ -95,7 +95,7 @@ class KeyTest extends \PHPUnit_Framework_TestCase
 
         $ancestor = $this->prophesize(Key::class);
         $ancestor->path()->willReturn($ancestorPath);
-        $ancestor->state()->willReturn(Key::STATE_COMPLETE);
+        $ancestor->state()->willReturn(Key::STATE_NAMED);
 
         $key = new Key('foo', [
             'path' => [
@@ -187,7 +187,7 @@ class KeyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($key->jsonSerialize(), $key->keyObject());
     }
 
-    public function testStateComplete()
+    public function testStateNamed()
     {
         $key = new Key('foo', [
             'path' => [
@@ -195,7 +195,7 @@ class KeyTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
-        $this->assertEquals($key->state(), key::STATE_COMPLETE);
+        $this->assertEquals($key->state(), key::STATE_NAMED);
     }
 
     public function testStateIncomplete()

--- a/tests/Datastore/OperationTest.php
+++ b/tests/Datastore/OperationTest.php
@@ -166,14 +166,14 @@ class OperationTest extends \PHPUnit_Framework_TestCase
 
         $res = $this->operation->allocateIds($keys);
 
-        $this->assertEquals($res[0]->state(), Key::STATE_COMPLETE);
+        $this->assertEquals($res[0]->state(), Key::STATE_NAMED);
         $this->assertEquals($res[0]->path()[0]['id'], '1');
     }
 
     /**
      * @expectedException InvalidArgumentException
      */
-    public function testAllocateIdsCompleteKey()
+    public function testAllocateIdsNamedKey()
     {
         $keys = [
             $this->operation->key('foo', 'Bar')
@@ -450,8 +450,8 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Entity::class, $res[0]);
         $this->assertInstanceOf(Entity::class, $res[1]);
 
-        $this->assertEquals($res[0]->key()->state(), Key::STATE_COMPLETE);
-        $this->assertEquals($res[1]->key()->state(), Key::STATE_COMPLETE);
+        $this->assertEquals($res[0]->key()->state(), Key::STATE_NAMED);
+        $this->assertEquals($res[1]->key()->state(), Key::STATE_NAMED);
     }
 
     public function testMutate()
@@ -559,7 +559,7 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         $this->operation->setConnection($this->connection->reveal());
 
         $k = $this->prophesize(Key::class);
-        $k->state()->willReturn(Key::STATE_COMPLETE);
+        $k->state()->willReturn(Key::STATE_NAMED);
 
         $entity = $this->operation->lookup([$k->reveal()]);
         $this->assertInstanceOf(Entity::class, $entity['found'][0]);
@@ -581,7 +581,7 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         $this->operation->setConnection($this->connection->reveal());
 
         $k = $this->prophesize(Key::class);
-        $k->state()->willReturn(Key::STATE_COMPLETE);
+        $k->state()->willReturn(Key::STATE_NAMED);
 
         $entity = $this->operation->lookup([$k->reveal()]);
         $this->assertInstanceOf(Entity::class, $entity['found'][0]);
@@ -602,7 +602,7 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         $this->operation->setConnection($this->connection->reveal());
 
         $k = $this->prophesize(Key::class);
-        $k->state()->willReturn(Key::STATE_COMPLETE);
+        $k->state()->willReturn(Key::STATE_NAMED);
 
         $entity = $this->operation->lookup([$k->reveal()], [
             'className' => [
@@ -628,7 +628,7 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         $this->operation->setConnection($this->connection->reveal());
 
         $k = $this->prophesize(Key::class);
-        $k->state()->willReturn(Key::STATE_COMPLETE);
+        $k->state()->willReturn(Key::STATE_NAMED);
 
         $entity = $this->operation->lookup([$k->reveal()], [
             'className' => [
@@ -649,7 +649,7 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         $this->operation->setConnection($this->connection->reveal());
 
         $k = $this->prophesize(Key::class);
-        $k->state()->willReturn(Key::STATE_COMPLETE);
+        $k->state()->willReturn(Key::STATE_NAMED);
         $this->operation->lookup([$k->reveal()], [
             'transaction' => '1234'
         ]);
@@ -667,7 +667,7 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         $this->operation->setConnection($this->connection->reveal());
 
         $k = $this->prophesize(Key::class);
-        $k->state()->willReturn(Key::STATE_COMPLETE);
+        $k->state()->willReturn(Key::STATE_NAMED);
         $this->operation->lookup([$k->reveal()]);
     }
 
@@ -683,7 +683,7 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         $this->operation->setConnection($this->connection->reveal());
 
         $k = $this->prophesize(Key::class);
-        $k->state()->willReturn(Key::STATE_COMPLETE);
+        $k->state()->willReturn(Key::STATE_NAMED);
         $this->operation->lookup([$k->reveal()], [
             'readConsistency' => 'test'
         ]);


### PR DESCRIPTION
If you're using `Key::STATE_COMPLETE`, you should update to `Key::STATE_NAMED`. The former constant still exists for now, but it may be removed in the future.

If you're checking the underlying constant value (i.e. `$key->state() === 'complete'`), this is a BC break. 😢  