### PR TITLE
Datastore query and lookup improvements

### DIFF
--- a/src/Datastore/DatastoreClient.php
+++ b/src/Datastore/DatastoreClient.php
@@ -104,11 +104,6 @@ class DatastoreClient
     private $entityMapper;
 
     /**
-     * @var string
-     */
-    private $namespaceId;
-
-    /**
      * Create a Datastore client.
      *
      * @param array $config [optional] {
@@ -154,8 +149,6 @@ class DatastoreClient
             $config['namespaceId'],
             $this->entityMapper
         );
-
-        $this->namespaceId = $config['namespaceId'];
     }
 
     /**
@@ -828,17 +821,13 @@ class DatastoreClient
      * $query = $datastore->query();
      * ```
      *
-     * @param array $options [optional] {
-     *     Query Options
-     *
-     *     @type array $query [Query](https://cloud.google.com/datastore/reference/rest/v1/projects/runQuery#query)
-     * }
+     * @param array $query [Query](https://cloud.google.com/datastore/reference/rest/v1/projects/runQuery#query)
      * @return Query
      */
-    public function query(array $options = [])
+    public function query(array $query = [])
     {
-        return new Query($this->projectId, $this->entityMapper, $options + [
-            'namespaceId' => $this->namespaceId
+        return new Query($this->entityMapper, [
+            'query' => $query
         ]);
     }
 

--- a/src/Datastore/DatastoreClient.php
+++ b/src/Datastore/DatastoreClient.php
@@ -104,6 +104,11 @@ class DatastoreClient
     private $entityMapper;
 
     /**
+     * @var string
+     */
+    private $namespaceId;
+
+    /**
      * Create a Datastore client.
      *
      * @param array $config [optional] {
@@ -149,6 +154,8 @@ class DatastoreClient
             $config['namespaceId'],
             $this->entityMapper
         );
+
+        $this->namespaceId = $config['namespaceId'];
     }
 
     /**
@@ -828,7 +835,9 @@ class DatastoreClient
      */
     public function query(array $options = [])
     {
-        return new Query($this->entityMapper, $options);
+        return new Query($this->projectId, $this->entityMapper, $options + [
+            'namespaceId' => $this->namespaceId
+        ]);
     }
 
     /**

--- a/src/Datastore/DatastoreClient.php
+++ b/src/Datastore/DatastoreClient.php
@@ -751,7 +751,7 @@ class DatastoreClient
      * }
      * ```
      *
-     * @param Key $key $key The identifier to use to locate a desired entity.
+     * @param Key $key The identifier to use to locate a desired entity.
      * @param array $options [optional] {
      *     Configuration Options
      *

--- a/src/Datastore/DatastoreClient.php
+++ b/src/Datastore/DatastoreClient.php
@@ -804,6 +804,8 @@ class DatastoreClient
      *           If an array is given, it must be an associative array, where
      *           the key is a Kind and the value is the name of a subclass of
      *           {@see Google\Cloud\Datastore\Entity}.
+     *     @type bool $sort If set to true, results in each set will be sorted
+     *           to match the order given in $keys. **Defaults to** `false`.
      * }
      * @return array Returns an array with keys [`found`, `missing`, and `deferred`].
      *         Members of `found` will be instance of

--- a/src/Datastore/EntityMapper.php
+++ b/src/Datastore/EntityMapper.php
@@ -82,6 +82,7 @@ class EntityMapper
             'meanings' => $meanings
         ];
     }
+
     /**
      * Translate an Entity to a datastore representation.
      *

--- a/src/Datastore/Key.php
+++ b/src/Datastore/Key.php
@@ -141,25 +141,42 @@ class Key implements JsonSerializable
      * $key->pathElement('Person', 'Jane');
      * ```
      *
+     * ```
+     * // In cases where the identifier type is ambiguous, you can choose the
+     * // type to be used.
+     *
+     * $key->pathElement('Robots', '1337', [
+     *     'identifierType' => Key::TYPE_NAME
+     * ]);
+     * ```
+     *
      * @see https://cloud.google.com/datastore/reference/rest/v1/Key#PathElement PathElement
      *
      * @param string $kind The kind.
      * @param string|int $identifier [optional] The name or ID of the object.
-     * @param string $identifierType [optional] If omitted, the type will be determined
-     *        internally. Setting this to either `Key::TYPE_ID` or
-     *        `Key::TYPE_NAME` will force the pathElement identifier type.
+     * @param array $options {
+     *     Configuration Options
+     *
+     *     @type string $identifierType [optional] If omitted, the type will be
+     *           determined internally. Setting this to either `Key::TYPE_ID` or
+     *           `Key::TYPE_NAME` will force the pathElement identifier type.
+     * }
      * @return Key
      * @throws InvalidArgumentException
      */
-    public function pathElement($kind, $identifier = null, $identifierType = null)
+    public function pathElement($kind, $identifier = null, array $options = [])
     {
+        $options += [
+            'identifierType' => null
+        ];
+
         if (!empty($this->path) && $this->state() !== Key::STATE_NAMED) {
             throw new InvalidArgumentException(
                 'Cannot add pathElement because the previous element is missing an id or name'
             );
         }
 
-        $pathElement = $this->normalizeElement($kind, $identifier, $identifierType);
+        $pathElement = $this->normalizeElement($kind, $identifier, $options['identifierType']);
 
         $this->path[] = $pathElement;
 
@@ -174,18 +191,35 @@ class Key implements JsonSerializable
      * $key->ancestor('Person', 'Bob');
      * ```
      *
+     * ```
+     * // In cases where the identifier type is ambiguous, you can choose the
+     * // type to be used.
+     *
+     * $key->ancestor('Robots', '1337', [
+     *     'identifierType' => Key::TYPE_NAME
+     * ]);
+     * ```
+     *
      * @see https://cloud.google.com/datastore/reference/rest/v1/Key#PathElement PathElement
      *
      * @param string $kind The kind.
      * @param string|int $identifier The name or ID of the object.
-     * @param string $identifierType [optional] If omitted, the type will be determined
-     *        internally. Setting this to either `Key::TYPE_ID` or
-     *        `Key::TYPE_NAME` will force the pathElement identifier type.
+     * @param array $options {
+     *     Configuration Options
+     *
+     *     @type string $identifierType [optional] If omitted, the type will be
+     *           determined internally. Setting this to either `Key::TYPE_ID` or
+     *           `Key::TYPE_NAME` will force the pathElement identifier type.
+     * }
      * @return Key
      */
-    public function ancestor($kind, $identifier, $identifierType = null)
+    public function ancestor($kind, $identifier, array $options = [])
     {
-        $pathElement = $this->normalizeElement($kind, $identifier, $identifierType);
+        $options = [
+            'identifierType' => null
+        ];
+
+        $pathElement = $this->normalizeElement($kind, $identifier, $options['identifierType']);
 
         array_unshift($this->path, $pathElement);
 
@@ -200,7 +234,7 @@ class Key implements JsonSerializable
      * Example:
      * ```
      * $parent = $datastore->key('Person', 'Dad');
-     * $key->ancestoryKey($parent);
+     * $key->ancestorKey($parent);
      * ```
      *
      * @param Key $key The ancestor Key.

--- a/src/Datastore/Operation.php
+++ b/src/Datastore/Operation.php
@@ -283,8 +283,7 @@ class Operation
     /**
      * Lookup records by key
      *
-     * @codingStandardsIgnoreStart
-     * @param Key[] $key The identifiers to look up.
+     * @param Key[] $keys The identifiers to look up.
      * @param array $options [optional] {
      *     Configuration Options
      *
@@ -298,18 +297,20 @@ class Operation
      *           If an array is given, it must be an associative array, where
      *           the key is a Kind and the value is the name of a subclass of
      *           {@see Google\Cloud\Datastore\Entity}.
+     *     @type bool $sort If set to true, results in each set will be sorted
+     *           to match the order given in $keys. **Defaults to** `false`.
      * }
      * @return array Returns an array with keys [`found`, `missing`, and `deferred`].
      *         Members of `found` will be instance of
      *         {@see Google\Cloud\Datastore\Entity}. Members of `missing` and
      *         `deferred` will be instance of {@see Google\Cloud\Datastore\Key}.
      * @throws InvalidArgumentException
-     * @codingStandardsIgnoreEnd
      */
     public function lookup(array $keys, array $options = [])
     {
         $options += [
-            'className' => null
+            'className' => null,
+            'sort' => false
         ];
 
         $this->validateBatch($keys, Key::class, function ($key) {
@@ -333,6 +334,10 @@ class Operation
                 $res['found'],
                 $options['className']
             );
+
+            if ($options['sort']) {
+                $result['found'] = $this->sortEntities($result['found'], $keys);
+            }
         }
 
         if (isset($res['missing'])) {
@@ -664,5 +669,31 @@ class Operation
         return array_filter([
             'readOptions' => $readOptions
         ]);
+    }
+
+    /**
+     * Sort entities into the order given in $keys.
+     *
+     * @param Entity[] $entities
+     * @param Key[] $keys
+     * @return Entity[]
+     */
+    private function sortEntities(array $entities, array $keys)
+    {
+        $res = [];
+        foreach ($keys as $key) {
+            $path = $key->path();
+
+            foreach ($entities as $arrayKey => $entity) {
+                $entityPath = $entity->key()->path();
+
+                if ($path === $entityPath) {
+                    $res[] = $entity;
+                    unset($entities[$arrayKey]);
+                }
+            }
+        }
+
+        return $res;
     }
 }

--- a/src/Datastore/Operation.php
+++ b/src/Datastore/Operation.php
@@ -104,13 +104,8 @@ class Operation
      */
     public function key($kind, $identifier = null, array $options = [])
     {
-        $options += [
-            'identifierType' => null,
-            'namespaceId' => $this->namespaceId
-        ];
-
         $key = new Key($this->projectId, $options);
-        $key->pathElement($kind, $identifier, $options['identifierType']);
+        $key->pathElement($kind, $identifier, $options);
 
         return $key;
     }

--- a/src/Datastore/Query/Query.php
+++ b/src/Datastore/Query/Query.php
@@ -190,7 +190,7 @@ class Query implements QueryInterface
     }
 
     /**
-     * Set the query to return only keys (no properties)
+     * Set the query to return only keys (no properties).
      *
      * Example:
      * ```
@@ -331,7 +331,7 @@ class Query implements QueryInterface
     }
 
     /**
-     * Specify an order for the query
+     * Specify an order for the query.
      *
      * Example:
      * ```

--- a/src/Datastore/Transaction.php
+++ b/src/Datastore/Transaction.php
@@ -396,6 +396,8 @@ class Transaction
      *           If an array is given, it must be an associative array, where
      *           the key is a Kind and the value is the name of a subclass of
      *           {@see Google\Cloud\Datastore\Entity}.
+     *     @type bool $sort If set to true, results in each set will be sorted
+     *           to match the order given in $keys. **Defaults to** `false`.
      * }
      * @return array Returns an array with keys [`found`, `missing`, and `deferred`].
      *         Members of `found` will be instance of

--- a/tests/Datastore/KeyTest.php
+++ b/tests/Datastore/KeyTest.php
@@ -129,7 +129,7 @@ class KeyTest extends \PHPUnit_Framework_TestCase
     public function testPathElementForceType()
     {
         $key = new Key('foo');
-        $key->pathElement('Robots', '1000', Key::TYPE_NAME);
+        $key->pathElement('Robots', '1000', ['identifierType' => Key::TYPE_NAME]);
         $key->pathElement('Robots', '1000');
 
         $this->assertEquals(['kind' => 'Robots', 'name' => '1000'], $key->keyObject()['path'][0]);
@@ -142,7 +142,7 @@ class KeyTest extends \PHPUnit_Framework_TestCase
     public function testPathElementInvalidIdentifierType()
     {
         $key = new Key('foo');
-        $key->pathElement('Robots', '1000', 'nothanks');
+        $key->pathElement('Robots', '1000', ['identifierType' => 'nothanks']);
     }
 
     public function testNormalizedPath()
@@ -182,7 +182,7 @@ class KeyTest extends \PHPUnit_Framework_TestCase
     public function testJsonSerialize()
     {
         $key = new Key('foo');
-        $key->pathElement('Robots', '1000', Key::TYPE_NAME);
+        $key->pathElement('Robots', '1000', ['identifierType' => Key::TYPE_NAME]);
 
         $this->assertEquals($key->jsonSerialize(), $key->keyObject());
     }

--- a/tests/Datastore/OperationTest.php
+++ b/tests/Datastore/OperationTest.php
@@ -302,6 +302,60 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         $this->operation->lookup([$k]);
     }
 
+    public function testLookupWithSort()
+    {
+        $keys = [
+            new Key('test-project', [
+                'path' => [['kind' => 'Kind', 'id' => '2']]
+            ]),
+            new Key('test-project', [
+                'path' => [['kind' => 'Kind', 'id' => '1']]
+            ])
+        ];
+
+        $body = json_decode(file_get_contents(__DIR__ .'/../fixtures/datastore/entity-batch-lookup.json'), true);
+        $this->connection->lookup(Argument::any())->willReturn([
+            'found' => $body
+        ]);
+
+        $this->operation->setConnection($this->connection->reveal());
+
+        $res = $this->operation->lookup($keys, [
+            'sort' => true
+        ]);
+
+        $found = $res['found'];
+
+        $this->assertEquals('2', $found[0]->key()->path()[0]['id']);
+        $this->assertEquals('1', $found[1]->key()->path()[0]['id']);
+    }
+
+    public function testLookupWithoutSort()
+    {
+        $keys = [
+            new Key('test-project', [
+                'path' => [['kind' => 'Kind', 'id' => '2']]
+            ]),
+            new Key('test-project', [
+                'path' => [['kind' => 'Kind', 'id' => '1']]
+            ])
+        ];
+
+        $body = json_decode(file_get_contents(__DIR__ .'/../fixtures/datastore/entity-batch-lookup.json'), true);
+        $this->connection->lookup(Argument::any())->willReturn([
+            'found' => $body
+        ]);
+
+        $this->operation->setConnection($this->connection->reveal());
+
+        $res = $this->operation->lookup($keys);
+
+        $found = $res['found'];
+
+        $this->assertEquals('2', $found[1]->key()->path()[0]['id']);
+        $this->assertEquals('1', $found[0]->key()->path()[0]['id']);
+    }
+
     /**
      * @expectedException InvalidArgumentException
      */

--- a/tests/Datastore/Query/QueryTest.php
+++ b/tests/Datastore/Query/QueryTest.php
@@ -32,14 +32,12 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->mapper = new EntityMapper('foo', true);
-        $this->query = new Query('foo', $this->mapper);
+        $this->query = new Query($this->mapper);
     }
 
     public function testConstructorOptions()
     {
-        $query = new Query('foo', $this->mapper, [
-            'query' => ['foo' => 'bar']
-        ]);
+        $query = new Query($this->mapper, ['foo' => 'bar']);
 
         $this->assertEquals($query->queryObject(), ['foo' => 'bar']);
     }
@@ -161,6 +159,114 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->query->filter('propname', 'foo', 12);
     }
 
+    public function testOperatorConstantsDefault()
+    {
+        $this->query->filter('propName', Query::OP_DEFAULT, 'val');
+        $res = $this->query->queryObject();
+
+        $filters = $res['filter']['compositeFilter']['filters'];
+        $this->assertEquals('EQUAL', $filters[0]['propertyFilter']['op']);
+    }
+
+    public function testOperatorConstantsLessThan()
+    {
+        $this->query->filter('propName', Query::OP_LESS_THAN, 'val');
+        $res = $this->query->queryObject();
+
+        $filters = $res['filter']['compositeFilter']['filters'];
+        $this->assertEquals('LESS_THAN', $filters[0]['propertyFilter']['op']);
+    }
+
+    public function testOperatorConstantsLessThanOrEqual()
+    {
+        $this->query->filter('propName', Query::OP_LESS_THAN_OR_EQUAL, 'val');
+        $res = $this->query->queryObject();
+
+        $filters = $res['filter']['compositeFilter']['filters'];
+        $this->assertEquals('LESS_THAN_OR_EQUAL', $filters[0]['propertyFilter']['op']);
+    }
+
+    public function testOperatorConstantsGreaterThan()
+    {
+        $this->query->filter('propName', Query::OP_GREATER_THAN, 'val');
+        $res = $this->query->queryObject();
+
+        $filters = $res['filter']['compositeFilter']['filters'];
+        $this->assertEquals('GREATER_THAN', $filters[0]['propertyFilter']['op']);
+    }
+
+    public function testOperatorConstantsGreaterThanOrEqual()
+    {
+        $this->query->filter('propName', Query::OP_GREATER_THAN_OR_EQUAL, 'val');
+        $res = $this->query->queryObject();
+
+        $filters = $res['filter']['compositeFilter']['filters'];
+        $this->assertEquals('GREATER_THAN_OR_EQUAL', $filters[0]['propertyFilter']['op']);
+    }
+
+    public function testOperatorConstantsEquals()
+    {
+        $this->query->filter('propName', Query::OP_EQUALS, 'val');
+        $res = $this->query->queryObject();
+
+        $filters = $res['filter']['compositeFilter']['filters'];
+        $this->assertEquals('EQUAL', $filters[0]['propertyFilter']['op']);
+    }
+
+    public function testOperatorConstantsHasAncestor()
+    {
+        $this->query->filter('propName', Query::OP_HAS_ANCESTOR, 'val');
+        $res = $this->query->queryObject();
+
+        $filters = $res['filter']['compositeFilter']['filters'];
+        $this->assertEquals('HAS_ANCESTOR', $filters[0]['propertyFilter']['op']);
+    }
+
+    public function testShortOperatorLessThan()
+    {
+        $this->query->filter('propName', '<', 'val');
+        $res = $this->query->queryObject();
+
+        $filters = $res['filter']['compositeFilter']['filters'];
+        $this->assertEquals('LESS_THAN', $filters[0]['propertyFilter']['op']);
+    }
+
+    public function testShortOperatorLessThanOrEqual()
+    {
+        $this->query->filter('propName', '<=', 'val');
+        $res = $this->query->queryObject();
+
+        $filters = $res['filter']['compositeFilter']['filters'];
+        $this->assertEquals('LESS_THAN_OR_EQUAL', $filters[0]['propertyFilter']['op']);
+    }
+
+    public function testShortOperatorGreaterThan()
+    {
+        $this->query->filter('propName', '>', 'val');
+        $res = $this->query->queryObject();
+
+        $filters = $res['filter']['compositeFilter']['filters'];
+        $this->assertEquals('GREATER_THAN', $filters[0]['propertyFilter']['op']);
+    }
+
+    public function testShortOperatorGreaterThanOrEqual()
+    {
+        $this->query->filter('propName', '>=', 'val');
+        $res = $this->query->queryObject();
+
+        $filters = $res['filter']['compositeFilter']['filters'];
+        $this->assertEquals('GREATER_THAN_OR_EQUAL', $filters[0]['propertyFilter']['op']);
+    }
+
+    public function testShortOperatorEquals()
+    {
+        $this->query->filter('propName', '=', 'val');
+        $res = $this->query->queryObject();
+
+        $filters = $res['filter']['compositeFilter']['filters'];
+        $this->assertEquals('EQUAL', $filters[0]['propertyFilter']['op']);
+    }
+
     public function testOrder()
     {
         $direction = 'DESCENDING';
@@ -205,26 +311,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Kind', $res['filter']['compositeFilter']['filters'][0]['propertyFilter']['value']['keyValue']['path'][0]['kind']);
         $this->assertEquals('Name', $res['filter']['compositeFilter']['filters'][0]['propertyFilter']['value']['keyValue']['path'][0]['name']);
         $this->assertEquals('foo', $res['filter']['compositeFilter']['filters'][0]['propertyFilter']['value']['keyValue']['partitionId']['projectId']);
-    }
-
-    public function testHasAncestorWithKindAndId()
-    {
-        $this->query->hasAncestor('Kind', 'Name');
-
-        $res = $this->query->queryObject();
-
-        $this->assertEquals('__key__', $res['filter']['compositeFilter']['filters'][0]['propertyFilter']['property']['name']);
-        $this->assertEquals('Kind', $res['filter']['compositeFilter']['filters'][0]['propertyFilter']['value']['keyValue']['path'][0]['kind']);
-        $this->assertEquals('Name', $res['filter']['compositeFilter']['filters'][0]['propertyFilter']['value']['keyValue']['path'][0]['name']);
-        $this->assertEquals('foo', $res['filter']['compositeFilter']['filters'][0]['propertyFilter']['value']['keyValue']['partitionId']['projectId']);
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testHasAncestorKindWithNoId()
-    {
-        $this->query->hasAncestor('Kind');
     }
 
     public function testDistinctOn()

--- a/tests/fixtures/datastore/entity-batch-lookup.json
+++ b/tests/fixtures/datastore/entity-batch-lookup.json
@@ -5,7 +5,7 @@
                 "path": [
                     {
                         "kind": "Kind",
-                        "id": 1
+                        "id": "1"
                     }
                 ],
                 "partitionId": []
@@ -23,7 +23,7 @@
                 "path": [
                     {
                         "kind": "Kind",
-                        "id": 2
+                        "id": "2"
                     }
                 ],
                 "partitionId": []


### PR DESCRIPTION
Fixes #187, #186, #175.

Lookup sort only applies when $options['sort'] is set to `true`, and only sorts found entities.