### PR TITLE
Check if stream is seekable when downloading object to path

### DIFF
--- a/src/Storage/StorageObject.php
+++ b/src/Storage/StorageObject.php
@@ -583,7 +583,9 @@ class StorageObject
             $destination
         );
 
-        $destination->seek(0);
+        if ($destination->isSeekable()) {
+            $destination->seek(0);
+        }
 
         return $destination;
     }


### PR DESCRIPTION
The destination path can also be `php://output`, then the file is streamed directly to output. However, that is not seekable and an exception is thrown.
Perhaps the method name is not accurate anymore then - something like `downloadToPath` might be more appropriate.