### PR TITLE
Prepare v0.10.1

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -6,6 +6,7 @@
     "defaultService": "servicebuilder",
     "markdown": "php",
     "versions": [
+        "v0.10.1",
         "v0.10.0",
         "v0.9.0",
         "v0.8.0",

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -47,7 +47,7 @@ use Google\Cloud\Vision\VisionClient;
  */
 class ServiceBuilder
 {
-    const VERSION = '0.10.0';
+    const VERSION = '0.10.1';
 
     /**
      * @var array Configuration options to be used between clients.


### PR DESCRIPTION
## Google Cloud PHP v0.10.1

### What's Fixed?

* Incorrect projection path in Datastore Query Builder has been fixed. (#188)
* Mistake in Query order constants has been fixed.  (#191)
* Bug preventing source code links has been fixed. (#197)