### PR TITLE
Added downloadAsStream method to StorageObject

### DIFF
--- a/src/Storage/StorageObject.php
+++ b/src/Storage/StorageObject.php
@@ -589,6 +589,40 @@ class StorageObject
     }
 
     /**
+     * Download an object as a stream.
+     *
+     * Example:
+     * ```
+     * $stream = $object->downloadAsStream();
+     * echo $stream->getContents();
+     * ```
+     *
+     * @param array $options [optional] {
+     *     Configuration Options.
+     *
+     *     @type string $encryptionKey An AES-256 customer-supplied encryption
+     *           key. It will be neccesary to provide this when a key was used
+     *           during the object's creation. If provided one must also include
+     *           an `encryptionKeySHA256`.
+     *     @type string $encryptionKeySHA256 The SHA256 hash of the
+     *           customer-supplied encryption key. It will be neccesary to
+     *           provide this when a key was used during the object's creation.
+     *           If provided one must also include an `encryptionKey`.
+     * }
+     * @return StreamInterface
+     */
+    public function downloadAsStream(array $options = [])
+    {
+        return $this->connection->downloadObject(
+            $this->formatEncryptionHeaders(
+                $options
+                + $this->encryptionData
+                + $this->identity
+            )
+        );
+    }
+
+    /**
      * Retrieves the object's details. If no object data is cached a network
      * request will be made to retrieve it.
      *

--- a/src/Storage/StorageObject.php
+++ b/src/Storage/StorageObject.php
@@ -536,13 +536,7 @@ class StorageObject
      */
     public function downloadAsString(array $options = [])
     {
-        return (string) $this->connection->downloadObject(
-            $this->formatEncryptionHeaders(
-                $options
-                + $this->encryptionData
-                + $this->identity
-            )
-        );
+        return (string) $this->downloadAsStream($options);
     }
 
     /**
@@ -573,13 +567,7 @@ class StorageObject
         $destination = Psr7\stream_for(fopen($path, 'w'));
 
         Psr7\copy_to_stream(
-            $this->connection->downloadObject(
-                $this->formatEncryptionHeaders(
-                    $options
-                    + $this->encryptionData
-                    + $this->identity
-                )
-            ),
+            $this->downloadAsStream($options),
             $destination
         );
 


### PR DESCRIPTION
This let's retrieve the body of the `StorageObject` as a stream. Inspired by PSR-7 response method `getBody`. This method returns a PSR-7 `StreamInterface` which enables the user to decide whether they want to write stream to another stream or get the contents as a string.
I also propose to remove `downloadAsString` and `downloadToFile` in the next major release since the functionality of these methods is easily achieved using `getBody` and having the other methods can be confusing.