### PR TITLE
Queries now STOP once the limit has been reached.

### DIFF
--- a/src/Datastore/Operation.php
+++ b/src/Datastore/Operation.php
@@ -405,7 +405,7 @@ class Operation
                     yield $result;
                 }
 
-                if ($query->canPaginate() && $res['batch']['moreResults'] !== 'NO_MORE_RESULTS') {
+                if ($query->canPaginate() && $res['batch']['moreResults'] === 'NOT_FINISHED') {
                     $query->start($res['batch']['endCursor']);
                 } else {
                     $moreResults = false;

--- a/tests/fixtures/datastore/query-results.json
+++ b/tests/fixtures/datastore/query-results.json
@@ -82,7 +82,7 @@
           }
         ],
         "endCursor": "1234",
-        "moreResults": "MORE_RESULTS_AFTER_CURSOR"
+        "moreResults": "NOT_FINISHED"
       }
     }, {
       "batch": {


### PR DESCRIPTION
Semantically, limiting query results should be a hard limit rather than a results-per-page limit. This change will cause `Operation::runQuery()` to respect limits and endCursors rather than continuing past the limits set by the user.

Once improvements to the Iterator are released, we should return the endCursor to the user along with the moreResultsType value (i.e. `MORE_RESULTS_AFTER_LIMIT`, `MORE_RESULTS_AFTER_CURSOR`) and allow them to fetch as they see fit.