### PR TITLE
Prepare v0.11.0

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -6,6 +6,7 @@
     "defaultService": "servicebuilder",
     "markdown": "php",
     "versions": [
+        "v0.11.0",
         "v0.10.2",
         "v0.10.1",
         "v0.10.0",

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -47,7 +47,7 @@ use Google\Cloud\Vision\VisionClient;
  */
 class ServiceBuilder
 {
-    const VERSION = '0.10.2';
+    const VERSION = '0.11.0';
 
     /**
      * @var array Configuration options to be used between clients.


### PR DESCRIPTION
## Google Cloud PHP v0.11.0

This release includes a number of backwards-compatibility breaks. Please read
the release notes carefully if you are using Google Cloud Datastore or Google
Cloud Pub/Sub in your application. BC breaks are denoted by the prefix
:heavy_exclamation_mark: **BREAKING CHANGE**.

### What's New?

* Incoming PubSub messages are now represented as an instance of
  `Google\Cloud\PubSub\Message` rather than as a simple array. (#168)
* `Google\Cloud\PubSub\PubSubClient::consume()` has been added to facilitate the
  conversion of messages send via Push Delivery to an instance of
  `Google\Cloud\PubSub\Message`. (#168)
* Datastore batch lookups now support sorting entities in the `found` result to
  match the order in which keys were supplied. Set `$options['sort']` to `true`
  to enable sorting. (#189)
* Datastore Queries now support Keys-Only queries by calling the `keysOnly()`
  method on `Google\Cloud\Datastore\Query\Query`. (#189)
* Datastore Queries now offer simpler support for ancestor filters. We've added
  `Google\Cloud\Datastore\Query\Query::hasAncestor(Key $key)` to facilitate
  filtering by ancestor key. (#189)

### What's Updated?

#### Pub/Sub

* :heavy_exclamation_mark: **BREAKING CHANGE**
  `Google\Cloud\PubSub\Subscription::pull()` now returns
  `Generator<Google\Cloud\PubSub\Message>`. (#168)
* :heavy_exclamation_mark: **BREAKING CHANGE**
  `Google\Cloud\PubSub\Subscription::acknowledge() and
  `Google\Cloud\PubSub\Subscription::modifyAckDeadline()` now accept an instance
  of `Google\Cloud\PubSub\Message` as their first argument. (#168)
* :heavy_exclamation_mark: **BREAKING CHANGE**
  `Google\Cloud\PubSub\Subscription::acknowledgeBatch()` and
  `Google\Cloud\PubSub\Subscription::modifyAckDeadlineBatch()` now accept
  `Google\Cloud\PubSub\Message[]` as their first argument. (#168)
* :heavy_exclamation_mark: **BREAKING CHANGE** Incoming message data is now
  decoded internally. There is no need to call `base64_decode()` to read the
  message data. (#168)
* :heavy_exclamation_mark: **BREAKING CHANGE** The constructor signatures for
  `Google\Cloud\PubSub\Subscription` and `Google\Cloud\PubSub\Topic` have
  changed. If you are directly instantiating these classes, please update your
  code to use `Google\Cloud\PubSub\PubSubClient::topic()`,
  `Google\Cloud\PubSub\PubSubClient::subscription()` or
  `Google\Cloud\PubSub\Topic::subscription()` as required. (#168)

#### Datastore

* :heavy_exclamation_mark: **BREAKING CHANGE**
  The signatures of `Google\Cloud\Datastore\Key::ancestor()` and
  `Google\Cloud\Datastore\Key::pathElement()` have changed. If you
  need to specify an identifierType, it must not be done as a member of
  `$options`. (#189)
* :heavy_exclamation_mark: **BREAKING CHANGE** The signature of
  `Google\Cloud\Datastore\DatastoreClient::query()` has changed. Query objects
  are now provided as the first argument, rather than as a member of `$options`,
  which has been removed. (#189)

### What's Fixed?

* A bug preventing `Google\Cloud\Storage\Bucket::object()` from working properly
  with customer supplied encryption keys has been fixed. (#202)