### PR TITLE
Prepare v0.11.1

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -6,6 +6,7 @@
     "defaultService": "servicebuilder",
     "markdown": "php",
     "versions": [
+        "v0.11.1",
         "v0.11.0",
         "v0.10.2",
         "v0.10.1",

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -47,7 +47,7 @@ use Google\Cloud\Vision\VisionClient;
  */
 class ServiceBuilder
 {
-    const VERSION = '0.11.0';
+    const VERSION = '0.11.1';
 
     /**
      * @var array Configuration options to be used between clients.


### PR DESCRIPTION
## Google Cloud PHP v0.11.1

**NOTE**: This patch fixes a regression introduced in the previous release. If
you are upgrading from a version older than v0.11.0, please take a moment to
review the v0.11.0 release notes, as there are some backward incompatabilities
you should be aware of.

### What's Fixed?

* Fixed a regression in Datastore in which a namespace ID was not passed into
  new Key instances causing errors on Queries and lookups which did not return
  a record. (#204)