### PR TITLE
Flatten lookupBatch sort to improve performance.

### DIFF
--- a/src/Datastore/Operation.php
+++ b/src/Datastore/Operation.php
@@ -679,20 +679,18 @@ class Operation
      */
     private function sortEntities(array $entities, array $keys)
     {
-        $res = [];
+        $map = [];
+        foreach ($entities as $entity) {
+            $map[(string) $entity->key()] = $entity;
+        }
+
+        $ret = [];
         foreach ($keys as $key) {
-            $path = $key->path();
-
-            foreach ($entities as $arrayKey => $entity) {
-                $entityPath = $entity->key()->path();
-
-                if ($path === $entityPath) {
-                    $res[] = $entity;
-                    unset($entities[$arrayKey]);
-                }
+            if (isset($map[(string) $key])) {
+                $ret[] = $map[(string) $key];
             }
         }
 
-        return $res;
+        return $ret;
     }
 }

--- a/tests/fixtures/datastore/entity-lookup-bigsort.json
+++ b/tests/fixtures/datastore/entity-lookup-bigsort.json
@@ -1,0 +1,51 @@
+{
+    "entities": [
+        {
+            "entity": {"key": {"path": [{"kind": "Kind","id": "1"}],"partitionId": []}}
+        },
+        {
+            "entity": {"key": {"path": [{"kind": "Kind","id": "2"}],"partitionId": []}}
+        },
+        {
+            "entity": {"key": {"path": [{"kind": "Kind","id": "3"}],"partitionId": []}}
+        },
+        {
+            "entity": {"key": {"path": [{"kind": "Kind","id": "4"}],"partitionId": []}}
+        },
+        {
+            "entity": {"key": {"path": [{"kind": "Kind","id": "5"}],"partitionId": []}}
+        },
+        {
+            "entity": {"key": {"path": [{"kind": "Kind","id": "6"}],"partitionId": []}}
+        },
+        {
+            "entity": {"key": {"path": [{"kind": "Kind","id": "7"}],"partitionId": []}}
+        },
+        {
+            "entity": {"key": {"path": [{"kind": "Kind","id": "8"}],"partitionId": []}}
+        },
+        {
+            "entity": {"key": {"path": [{"kind": "Kind","id": "9"}],"partitionId": []}}
+        },
+        {
+            "entity": {"key": {"path": [{"kind": "Kind","id": "10"}],"partitionId": []}}
+        },
+        {
+            "entity": {"key": {"path": [{"kind": "Kind","id": "11"}],"partitionId": []}}
+        }
+    ],
+    "missing": [],
+    "keys": [
+        {"path": [{"kind": "Kind","id": "11"}],"partitionId": []},
+        {"path": [{"kind": "Kind","id": "10"}],"partitionId": []},
+        {"path": [{"kind": "Kind","id": "9"}],"partitionId": []},
+        {"path": [{"kind": "Kind","id": "8"}],"partitionId": []},
+        {"path": [{"kind": "Kind","id": "7"}],"partitionId": []},
+        {"path": [{"kind": "Kind","id": "6"}],"partitionId": []},
+        {"path": [{"kind": "Kind","id": "5"}],"partitionId": []},
+        {"path": [{"kind": "Kind","id": "4"}],"partitionId": []},
+        {"path": [{"kind": "Kind","id": "3"}],"partitionId": []},
+        {"path": [{"kind": "Kind","id": "2"}],"partitionId": []},
+        {"path": [{"kind": "Kind","id": "1"}],"partitionId": []}
+    ]
+}


### PR DESCRIPTION
Added tests to make sure results come back properly when sort is enabled and disabled, and that the sort still works when results are missing.

@tmatsuo running this against your example suite before merge would be much appreciated!