### PR TITLE
introduce gRPC support for pub/sub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 language: php
 
-sudo: false
+sudo: required
+dist: trusty
 
 matrix:
     include:
-        - php: 5.5
-        - php: 5.6
+        - php: 5.5.38
+        - php: 5.6.25
         - php: 7.0
         - php: hhvm
-          sudo: required
-          dist: trusty
           group: edge
     fast_finish: true
 
 before_script:
+    - pecl install grpc || echo 'Failed to install grpc'
     - composer install
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": ">=5.5",
         "rize/uri-template": "~0.3",
         "google/auth": "0.10",
-        "guzzlehttp/guzzle": "~5.2|~6.0",
+        "guzzlehttp/guzzle": "^5.3|^6.0",
         "guzzlehttp/psr7": "^1.2",
         "monolog/monolog": "~1",
         "psr/http-message": "1.0.*"
@@ -53,7 +53,9 @@
         "league/json-guard": "^0.3",
         "james-heinrich/getid3": "^1.9",
         "erusev/parsedown": "^1.6",
-        "vierbergenlars/php-semver": "^3.0"
+        "vierbergenlars/php-semver": "^3.0",
+        "google/proto-client-php": "^0.4",
+        "google/gax": "^0.3"
     },
     "suggest": {
         "google/gax": "Required to support gRPC",

--- a/src/BigQuery/BigQueryClient.php
+++ b/src/BigQuery/BigQueryClient.php
@@ -66,6 +66,7 @@ class BigQueryClient
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
+     *           Only valid for requests sent over REST.
      *     @type string $keyFile The contents of the service account
      *           credentials .json file retrieved from the Google Developers
      *           Console.

--- a/src/ClientTrait.php
+++ b/src/ClientTrait.php
@@ -62,8 +62,6 @@ trait ClientTrait
                     'composer require google/proto-client-php'
                 );
             }
-
-            return $transport;
         }
 
         return $transport;

--- a/src/Datastore/Connection/Rest.php
+++ b/src/Datastore/Connection/Rest.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Datastore\Connection;
 
 use Google\Cloud\RequestBuilder;
 use Google\Cloud\RequestWrapper;
+use Google\Cloud\EmulatorTrait;
 use Google\Cloud\RestTrait;
 use Google\Cloud\UriTrait;
 
@@ -28,6 +29,7 @@ use Google\Cloud\UriTrait;
  */
 class Rest implements ConnectionInterface
 {
+    use EmulatorTrait;
     use RestTrait;
     use UriTrait;
 

--- a/src/Datastore/DatastoreClient.php
+++ b/src/Datastore/DatastoreClient.php
@@ -114,6 +114,7 @@ class DatastoreClient
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
+     *           Only valid for requests sent over REST.
      *     @type string $keyFile The contents of the service account
      *           credentials .json file retrieved from the Google Developers
      *           Console.

--- a/src/EmulatorTrait.php
+++ b/src/EmulatorTrait.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud;
+
+use Google\Cloud\RequestBuilder;
+use Google\Cloud\RequestWrapper;
+
+/**
+ * Provides common logic for configuring the usage of an emualtor.
+ */
+trait EmulatorTrait
+{
+    /**
+     * When emulators are enabled, use them as the service host
+     *
+     * @param string $baseUri
+     * @param string $emulatorHost [optional]
+     * @return string
+     */
+    public function getEmulatorBaseUri($baseUri, $emulatorHost = null)
+    {
+        if ($emulatorHost) {
+            $emulatorUriComponents = parse_url($emulatorHost);
+            $emulatorUriComponents = array_merge(['scheme' => 'http', 'port' => ''], $emulatorUriComponents);
+            $baseUri = "{$emulatorUriComponents['scheme']}://{$emulatorUriComponents['host']}";
+            $baseUri .= $emulatorUriComponents['port'] ? ":{$emulatorUriComponents['port']}/" : '/';
+        }
+
+        return $baseUri;
+    }
+}

--- a/src/ExponentialBackoff.php
+++ b/src/ExponentialBackoff.php
@@ -69,7 +69,7 @@ class ExponentialBackoff
         $retryAttempt = 0;
         $exception = null;
 
-        do {
+        while (true) {
             try {
                 return call_user_func_array($function, $arguments);
             } catch (\Exception $exception) {
@@ -79,10 +79,14 @@ class ExponentialBackoff
                     }
                 }
 
+                if ($retryAttempt >= $this->retries) {
+                    break;
+                }
+
                 $delayFunction($this->calculateDelay($retryAttempt));
                 $retryAttempt++;
             }
-        } while ($this->retries >= $retryAttempt);
+        }
 
         throw $exception;
     }

--- a/src/GrpcRequestWrapper.php
+++ b/src/GrpcRequestWrapper.php
@@ -58,21 +58,15 @@ class GrpcRequestWrapper
     ];
 
     /**
-     * @param array $options [optional] {
-     *     Configuration options.
+     * @param array $config [optional] {
+     *     Configuration options. Please see
+     *     {@see Google\Cloud\RequestWrapperTrait::setCommonDefaults()} for the other
+     *     available options.
      *
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
-     *     @type FetchAuthTokenInterface $credentialsFetcher A credentials
-     *           fetcher instance.
-     *     @type string $keyFile The contents of the service account
-     *           credentials .json file retrieved from the Google Developers
-     *           Console.
      *     @type array $grpcOptions gRPC specific configuration options passed
      *           off to the GAX library.
-     *     @type int $retries Number of retries for a failed request.
-     *           **Defaults to** `3`.
-     *     @type array $scopes Scopes to be used for the request.
      * }
      */
     public function __construct(array $config = [])
@@ -133,7 +127,7 @@ class GrpcRequestWrapper
      * Serializes a gRPC response.
      *
      * @param mixed $response
-     * @return array
+     * @return array|null
      */
     private function handleResponse($response)
     {
@@ -147,7 +141,7 @@ class GrpcRequestWrapper
             return $response->serialize(new PhpArray());
         }
 
-        return [];
+        return null;
     }
 
     /**

--- a/src/GrpcRequestWrapper.php
+++ b/src/GrpcRequestWrapper.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud;
+
+use DrSlump\Protobuf\Message;
+use Google\Auth\FetchAuthTokenInterface;
+use Google\Auth\HttpHandler\HttpHandlerFactory;
+use Google\Cloud\Exception;
+use Google\Cloud\PhpArray;
+use Google\Cloud\RequestWrapperTrait;
+use Google\GAX\ApiException;
+use Google\GAX\PagedListResponse;
+use Google\GAX\RetrySettings;
+use Grpc;
+
+/**
+ * The GrpcRequestWrapper is responsible for delivering gRPC requests.
+ */
+class GrpcRequestWrapper
+{
+    use RequestWrapperTrait;
+
+    /**
+     * @var callable A handler used to deliver Psr7 requests specifically for
+     * authentication.
+     */
+    private $authHttpHandler;
+
+    /**
+     * @var array gRPC specific configuration options passed off to the GAX
+     * library.
+     */
+    private $grpcOptions;
+
+    /**
+     * @var array gRPC retry codes.
+     */
+    private $grpcRetryCodes = [
+        Grpc\STATUS_UNKNOWN,
+        Grpc\STATUS_INTERNAL,
+        Grpc\STATUS_UNAVAILABLE,
+        Grpc\STATUS_DATA_LOSS
+    ];
+
+    /**
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type callable $authHttpHandler A handler used to deliver Psr7
+     *           requests specifically for authentication.
+     *     @type FetchAuthTokenInterface $credentialsFetcher A credentials
+     *           fetcher instance.
+     *     @type string $keyFile The contents of the service account
+     *           credentials .json file retrieved from the Google Developers
+     *           Console.
+     *     @type array $grpcOptions gRPC specific configuration options passed
+     *           off to the GAX library.
+     *     @type int $retries Number of retries for a failed request.
+     *           **Defaults to** `3`.
+     *     @type array $scopes Scopes to be used for the request.
+     * }
+     */
+    public function __construct(array $config = [])
+    {
+        $this->setCommonDefaults($config);
+        $config += [
+            'authHttpHandler' => null,
+            'grpcOptions' => []
+        ];
+
+        $this->authHttpHandler = $config['authHttpHandler'] ?: HttpHandlerFactory::build();
+        $this->grpcOptions = $config['grpcOptions'];
+    }
+
+    /**
+     * Deliver the request.
+     *
+     * @param callable $request The request to execute.
+     * @param array $args The arguments for the request.
+     * @param array $options [optional] {
+     *     Request options.
+     *
+     *     @type int $retries Number of retries for a failed request.
+     *           **Defaults to** `3`.
+     *     @type array $grpcOptions gRPC specific configuration options.
+     * }
+     * @return array
+     */
+    public function send(callable $request, array $args, array $options = [])
+    {
+        $retries = isset($options['retries']) ? $options['retries'] : $this->retries;
+        $grpcOptions = isset($options['grpcOptions']) ? $options['grpcOptions'] : $this->grpcOptions;
+        $backoff = new ExponentialBackoff($retries, function (\Exception $ex) {
+            $statusCode = $ex->getCode();
+
+            if (in_array($statusCode, $this->grpcRetryCodes)) {
+                return true;
+            }
+
+            return false;
+        });
+
+        if (!isset($grpcOptions['retrySettings'])) {
+            $grpcOptions['retrySettings'] = new RetrySettings(null, null);
+        }
+
+        $optionalArgs = &$args[count($args) - 1];
+        $optionalArgs += $grpcOptions;
+
+        try {
+            return $this->handleResponse($backoff->execute($request, $args));
+        } catch (\Exception $ex) {
+            throw $this->convertToGoogleException($ex);
+        }
+    }
+
+    /**
+     * Serializes a gRPC response.
+     *
+     * @param mixed $response
+     * @return array
+     */
+    private function handleResponse($response)
+    {
+        if ($response instanceof PagedListResponse) {
+            return $response->getPage()
+                ->getResponseObject()
+                ->serialize(new PhpArray());
+        }
+
+        if ($response instanceof Message) {
+            return $response->serialize(new PhpArray());
+        }
+
+        return [];
+    }
+
+    /**
+     * Convert a GAX exception to a Google Exception.
+     *
+     * @param ApiException $ex
+     * @return ServiceException
+     */
+    private function convertToGoogleException(ApiException $ex)
+    {
+        switch ($ex->getCode()) {
+            case Grpc\STATUS_INVALID_ARGUMENT:
+                $exception = Exception\BadRequestException::class;
+                break;
+
+            case Grpc\STATUS_NOT_FOUND:
+                $exception = Exception\NotFoundException::class;
+                break;
+
+            case Grpc\STATUS_ALREADY_EXISTS:
+                $exception = Exception\ConflictException::class;
+                break;
+
+            case Grpc\STATUS_UNKNOWN:
+                $exception = Exception\ServerException::class;
+                break;
+
+            case Grpc\STATUS_INTERNAL:
+                $exception = Exception\ServerException::class;
+                break;
+
+            default:
+                $exception = Exception\ServiceException::class;
+                break;
+        }
+
+        return new $exception($ex->getMessage(), $ex->getCode(), $ex);
+    }
+}

--- a/src/GrpcTrait.php
+++ b/src/GrpcTrait.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud;
+
+use Google\Cloud\GrpcRequestWrapper;
+
+/**
+ * Provides shared functionality for gRPC service implementations.
+ */
+trait GrpcTrait
+{
+    /**
+     * @var GrpcRequestWrapper Wrapper used to handle sending requests to the
+     * gRPC API.
+     */
+    private $requestWrapper;
+
+    /**
+     * Sets the request wrapper.
+     *
+     * @param GrpcRequestWrapper $requestWrapper
+     */
+    public function setRequestWrapper(GrpcRequestWrapper $requestWrapper)
+    {
+        $this->requestWrapper = $requestWrapper;
+    }
+
+    /**
+     * Delivers a request.
+     *
+     * @param callable $request
+     * @param array $args
+     * @return array
+     */
+    public function send(callable $request, array $args)
+    {
+        $requestOptions = $args[count($args) - 1];
+
+        return $this->requestWrapper->send($request, $args, array_intersect_key($requestOptions, [
+            'grpcOptions' => null,
+            'retries' => null
+        ]));
+    }
+
+    /**
+     * Pluck a value out of an array.
+     *
+     * @param string $name
+     * @param array $args
+     * @return string
+     */
+    public function pluck($name, array &$args)
+    {
+        $value = $args[$name];
+        unset($args[$name]);
+        return $value;
+    }
+}

--- a/src/GrpcTrait.php
+++ b/src/GrpcTrait.php
@@ -60,14 +60,20 @@ trait GrpcTrait
     /**
      * Pluck a value out of an array.
      *
-     * @param string $name
+     * @param string $key
      * @param array $args
      * @return string
      */
-    public function pluck($name, array &$args)
+    public function pluck($key, array &$args)
     {
-        $value = $args[$name];
-        unset($args[$name]);
+        if (!isset($args[$key])) {
+            throw new \InvalidArgumentException(
+                "Key $key does not exist in the provided array."
+            );
+        }
+
+        $value = $args[$key];
+        unset($args[$key]);
         return $value;
     }
 }

--- a/src/Logging/LoggingClient.php
+++ b/src/Logging/LoggingClient.php
@@ -71,6 +71,7 @@ class LoggingClient
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
+     *           Only valid for requests sent over REST.
      *     @type string $keyFile The contents of the service account
      *           credentials .json file retrieved from the Google Developers
      *           Console.

--- a/src/NaturalLanguage/NaturalLanguageClient.php
+++ b/src/NaturalLanguage/NaturalLanguageClient.php
@@ -76,6 +76,7 @@ class NaturalLanguageClient
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
+     *           Only valid for requests sent over REST.
      *     @type string $keyFile The contents of the service account
      *           credentials .json file retrieved from the Google Developers
      *           Console.

--- a/src/PhpArray.php
+++ b/src/PhpArray.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud;
+
+use DrSlump\Protobuf;
+
+/**
+ * Extend the Protobuf-PHP array codec to convert underscore keys
+ * to the camelcase type expected by the library.
+ */
+class PhpArray extends Protobuf\Codec\PhpArray
+{
+    protected function encodeMessage(Protobuf\Message $message)
+    {
+        $res = parent::encodeMessage($message);
+
+        return $this->transformKeys($res);
+    }
+
+    private function transformKeys(array $res)
+    {
+        $out = [];
+        foreach ($res as $key => $val) {
+            $newKey = lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $key))));
+
+            if (is_array($val)) {
+                $val = $this->transformKeys($val);
+            }
+
+            $out[$newKey] = $val;
+        }
+
+        return $out;
+    }
+}

--- a/src/PubSub/Connection/Grpc.php
+++ b/src/PubSub/Connection/Grpc.php
@@ -1,0 +1,368 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\PubSub\Connection;
+
+use Google\Auth\FetchAuthTokenCache;
+use Google\Auth\Cache\MemoryCacheItemPool;
+use Google\Cloud\EmulatorTrait;
+use Google\Cloud\PhpArray;
+use Google\Cloud\PubSub\V1\PublisherApi;
+use Google\Cloud\PubSub\V1\SubscriberApi;
+use Google\Cloud\GrpcRequestWrapper;
+use Google\Cloud\GrpcTrait;
+use Google\Cloud\ServiceBuilder;
+use Grpc\ChannelCredentials;
+use google\pubsub\v1\PubsubMessage;
+use google\pubsub\v1\PubsubMessage\AttributesEntry as MessageAttributesEntry;
+use google\pubsub\v1\PushConfig\AttributesEntry as PushConfigAttributesEntry;
+use google\pubsub\v1\PushConfig;
+
+/**
+ * Implementation of the
+ * [Google Pub/Sub gRPC API](https://cloud.google.com/pubsub/docs/reference/rpc/).
+ */
+class Grpc implements ConnectionInterface
+{
+    use EmulatorTrait;
+    use GrpcTrait;
+
+    const BASE_URI = 'https://pubsub.googleapis.com/';
+
+    /**
+     * @var PublisherApi
+     */
+    private $publisherApi;
+
+    /**
+     * @var SubscriberApi
+     */
+    private $subscriberApi;
+
+    /**
+     * @param array $config
+     */
+    public function __construct(array $config = [])
+    {
+        $this->setRequestWrapper(new GrpcRequestWrapper($config));
+        $grpcConfig = [
+            'credentialsLoader' => new FetchAuthTokenCache(
+                $this->requestWrapper->getCredentialsFetcher(),
+                null,
+                new MemoryCacheItemPool()
+            ),
+            'enableCaching' => false,
+            'appName' => 'gcloud-php',
+            'version' => ServiceBuilder::VERSION
+        ];
+        $emulatorHost = getenv('PUBSUB_EMULATOR_HOST');
+        $baseUri = $this->getEmulatorBaseUri(self::BASE_URI, $emulatorHost);
+
+        if ($emulatorHost) {
+            $grpcConfig += [
+                'serviceAddress' => parse_url($baseUri, PHP_URL_HOST),
+                'port' => parse_url($baseUri, PHP_URL_PORT),
+                'sslCreds' => ChannelCredentials::createInsecure()
+            ];
+        }
+
+        $this->publisherApi = new PublisherApi($grpcConfig);
+        $this->subscriberApi = new SubscriberApi($grpcConfig);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function createTopic(array $args)
+    {
+        return $this->send([$this->publisherApi, 'createTopic'], [
+            $this->pluck('name', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function getTopic(array $args)
+    {
+        return $this->send([$this->publisherApi, 'getTopic'], [
+            $this->pluck('topic', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function deleteTopic(array $args)
+    {
+        return $this->send([$this->publisherApi, 'deleteTopic'], [
+            $this->pluck('topic', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function listTopics(array $args)
+    {
+        return $this->send([$this->publisherApi, 'listTopics'], [
+            $this->pluck('project', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function publishMessage(array $args)
+    {
+        $pbMessages = [];
+        $messages = $this->pluck('messages', $args);
+
+        foreach ($messages as $message) {
+            $pbMessage = new PubsubMessage();
+            $pbMessage->setData($message['data']);
+
+            if (isset($message['attributes'])) {
+                foreach ($message['attributes'] as $attributeKey => $attributeValue) {
+                    $pbAttribute = new MessageAttributesEntry();
+                    $pbAttribute->setKey($attributeKey);
+                    $pbAttribute->setValue($attributeValue);
+
+                    $pbMessage->addAttributes($pbAttribute);
+                }
+            }
+
+            $pbMessages[] = $pbMessage;
+        }
+
+        return $this->send([$this->publisherApi, 'publish'], [
+            $this->pluck('topic', $args),
+            $pbMessages,
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function listSubscriptionsByTopic(array $args)
+    {
+        return $this->send([$this->publisherApi, 'listTopicSubscriptions'], [
+            $this->pluck('topic', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function createSubscription(array $args)
+    {
+        if (isset($args['pushConfig'])) {
+            $pbPushConfig = new PushConfig();
+            $pbPushConfig->setPushEndpoint($args['pushConfig']['pushEndpoint']);
+
+            if (isset($args['pushConfig']['attributes'])) {
+                foreach ($args['pushConfig']['attributes'] as $attributeKey => $attributeValue) {
+                    $pbAttribute = new PushConfigAttributesEntry();
+                    $pbAttribute->setKey($attributeKey);
+                    $pbAttribute->setValue($attributeValue);
+
+                    $pbPushConfig->addAttributes($pbAttribute);
+                }
+            }
+
+            $args['pushConfig'] = $pbPushConfig;
+        }
+
+        return $this->send([$this->subscriberApi, 'createSubscription'], [
+            $this->pluck('name', $args),
+            $this->pluck('topic', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function getSubscription(array $args)
+    {
+        return $this->send([$this->subscriberApi, 'getSubscription'], [
+            $this->pluck('subscription', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function listSubscriptions(array $args)
+    {
+        return $this->send([$this->subscriberApi, 'listSubscriptions'], [
+            $this->pluck('project', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function deleteSubscription(array $args)
+    {
+        return $this->send([$this->subscriberApi, 'deleteSubscription'], [
+            $this->pluck('subscription', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function modifyPushConfig(array $args)
+    {
+        $pushConfig = $this->pluck('pushConfig', $args);
+        $pbPushConfig = new PushConfig();
+        $pbPushConfig->setPushEndpoint($pushConfig['pushEndpoint']);
+
+        if (isset($pushConfig['attributes'])) {
+            foreach ($pushConfig['attributes'] as $attributeKey => $attributeValue) {
+                $pbAttribute = new PushConfigAttributesEntry();
+                $pbAttribute->setKey($attributeKey);
+                $pbAttribute->setValue($attributeValue);
+
+                $pbPushConfig->addAttributes($pbAttribute);
+            }
+        }
+
+        return $this->send([$this->subscriberApi, 'modifyPushConfig'], [
+            $this->pluck('subscription', $args),
+            $pbPushConfig,
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function pull(array $args)
+    {
+        return $this->send([$this->subscriberApi, 'pull'], [
+            $this->pluck('subscription', $args),
+            $this->pluck('maxMessages', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function modifyAckDeadline(array $args)
+    {
+        return $this->send([$this->subscriberApi, 'modifyAckDeadline'], [
+            $this->pluck('subscription', $args),
+            $this->pluck('ackIds', $args),
+            $this->pluck('ackDeadlineSeconds', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function acknowledge(array $args)
+    {
+        return $this->send([$this->subscriberApi, 'acknowledge'], [
+            $this->pluck('subscription', $args),
+            $this->pluck('ackIds', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function getTopicIamPolicy(array $args)
+    {
+        return $this->send([$this->publisherApi, 'getIamPolicy'], [
+            $this->pluck('resource', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function setTopicIamPolicy(array $args)
+    {
+        return $this->send([$this->publisherApi, 'setIamPolicy'], [
+            $this->pluck('resource', $args),
+            $this->pluck('policy', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function testTopicIamPermissions(array $args)
+    {
+        return $this->send([$this->publisherApi, 'testIamPermissions'], [
+            $this->pluck('resource', $args),
+            $this->pluck('permissions', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function getSubscriptionIamPolicy(array $args)
+    {
+        return $this->send([$this->subscriberApi, 'getIamPolicy'], [
+            $this->pluck('resource', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function setSubscriptionIamPolicy(array $args)
+    {
+        return $this->send([$this->subscriberApi, 'setIamPolicy'], [
+            $this->pluck('resource', $args),
+            $this->pluck('policy', $args),
+            $args
+        ]);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function testSubscriptionIamPermissions(array $args)
+    {
+        return $this->send([$this->subscriberApi, 'testIamPermissions'], [
+            $this->pluck('resource', $args),
+            $this->pluck('permissions', $args),
+            $args
+        ]);
+    }
+}

--- a/src/PubSub/Connection/Rest.php
+++ b/src/PubSub/Connection/Rest.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\PubSub\Connection;
 
 use Google\Cloud\RequestBuilder;
 use Google\Cloud\RequestWrapper;
+use Google\Cloud\EmulatorTrait;
 use Google\Cloud\RestTrait;
 use Google\Cloud\UriTrait;
 
@@ -31,6 +32,7 @@ use Google\Cloud\UriTrait;
  */
 class Rest implements ConnectionInterface
 {
+    use EmulatorTrait;
     use RestTrait;
     use UriTrait;
 

--- a/src/PubSub/PubSubClient.php
+++ b/src/PubSub/PubSubClient.php
@@ -18,7 +18,6 @@
 namespace Google\Cloud\PubSub;
 
 use Google\Cloud\ClientTrait;
-use Google\Cloud\Exception\GoogleException;
 use Google\Cloud\PubSub\Connection\Grpc;
 use Google\Cloud\PubSub\Connection\Rest;
 use InvalidArgumentException;

--- a/src/PubSub/PubSubClient.php
+++ b/src/PubSub/PubSubClient.php
@@ -18,6 +18,8 @@
 namespace Google\Cloud\PubSub;
 
 use Google\Cloud\ClientTrait;
+use Google\Cloud\Exception\GoogleException;
+use Google\Cloud\PubSub\Connection\Grpc;
 use Google\Cloud\PubSub\Connection\Rest;
 use InvalidArgumentException;
 
@@ -29,6 +31,26 @@ use InvalidArgumentException;
  * To enable the [Google Cloud Pub/Sub Emulator](https://cloud.google.com/pubsub/emulator),
  * set the [`PUBSUB_EMULATOR_HOST`](https://cloud.google.com/pubsub/emulator#env)
  * environment variable.
+ *
+ * This client supports transport over
+ * [REST](https://cloud.google.com/pubsub/docs/reference/rest/) or
+ * [gRPC](https://cloud.google.com/pubsub/docs/reference/rpc/).
+ *
+ * In order to enable gRPC support please make sure to install and enable
+ * the gRPC extension through PECL:
+ *
+ * ```sh
+ * $ pecl install grpc
+ * ```
+ *
+ * Afterwards, please install the following dependencies through composer:
+ *
+ * ```sh
+ * $ composer require google/gax && composer require google/proto-client-php
+ * ```
+ *
+ * Please take care in installing the same version of these libraries that are
+ * outlined in the project's composer.json suggest keyword.
  *
  * Example:
  * ```
@@ -87,6 +109,7 @@ class PubSubClient
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
+     *           Only valid for requests sent over REST.
      *     @type string $keyFile The contents of the service account
      *           credentials .json file retrieved from the Google Developers
      *           Console.
@@ -96,20 +119,26 @@ class PubSubClient
      *     @type int $retries Number of retries for a failed request.
      *           **Defaults to** `3`.
      *     @type array $scopes Scopes to be used for the request.
+     *     @type string $transport The transport type used for requests. May be
+     *           either `grpc` or `rest`. **Defaults to** `grpc` if gRPC support
+     *           is detected on the system.
      * }
      * @throws \InvalidArgumentException
      */
     public function __construct(array $config = [])
     {
+        $connectionType = $this->getConnectionType($config);
         if (!isset($config['scopes'])) {
             $config['scopes'] = [self::FULL_CONTROL_SCOPE];
         }
 
-        $this->connection = new Rest($this->configureAuthentication($config));
-
-        // When gRPC support is added, this value should be set to `false`
-        // when gRPC transport is chosen.
-        $this->encode = true;
+        if ($connectionType === 'grpc') {
+            $this->connection = new Grpc($this->configureAuthentication($config));
+            $this->encode = false;
+        } else {
+            $this->connection = new Rest($this->configureAuthentication($config));
+            $this->encode = true;
+        }
     }
 
     /**

--- a/src/PubSub/V1/PublisherApi.php
+++ b/src/PubSub/V1/PublisherApi.php
@@ -237,8 +237,7 @@ class PublisherApi
             'retryingOverride' => null,
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
             'appName' => 'gax',
-            'appVersion' => self::_GAX_VERSION,
-            'credentialsLoader' => null,
+            'appVersion' => self::_GAX_VERSION
         ];
         $options = array_merge($defaultOptions, $options);
 
@@ -284,7 +283,7 @@ class PublisherApi
         $this->scopes = $options['scopes'];
 
         $createStubOptions = [];
-        if (!empty($options['sslCreds'])) {
+        if (array_key_exists('sslCreds', $options)) {
             $createStubOptions['sslCreds'] = $options['sslCreds'];
         }
         $grpcCredentialsHelperOptions = array_diff_key($options, $defaultOptions);

--- a/src/PubSub/V1/SubscriberApi.php
+++ b/src/PubSub/V1/SubscriberApi.php
@@ -272,8 +272,7 @@ class SubscriberApi
             'retryingOverride' => null,
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
             'appName' => 'gax',
-            'appVersion' => self::_GAX_VERSION,
-            'credentialsLoader' => null,
+            'appVersion' => self::_GAX_VERSION
         ];
         $options = array_merge($defaultOptions, $options);
 
@@ -321,7 +320,7 @@ class SubscriberApi
         $this->scopes = $options['scopes'];
 
         $createStubOptions = [];
-        if (!empty($options['sslCreds'])) {
+        if (array_key_exists('sslCreds', $options)) {
             $createStubOptions['sslCreds'] = $options['sslCreds'];
         }
         $grpcCredentialsHelperOptions = array_diff_key($options, $defaultOptions);

--- a/src/RequestWrapper.php
+++ b/src/RequestWrapper.php
@@ -17,11 +17,10 @@
 
 namespace Google\Cloud;
 
-use Google\Auth\ApplicationDefaultCredentials;
-use Google\Auth\CredentialsLoader;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Cloud\Exception;
+use Google\Cloud\RequestWrapperTrait;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\RequestInterface;
@@ -33,6 +32,8 @@ use Psr\Http\Message\StreamInterface;
  */
 class RequestWrapper
 {
+    use RequestWrapperTrait;
+
     /**
      * @var string Access token used to sign requests.
      */
@@ -50,40 +51,22 @@ class RequestWrapper
     private $credentials;
 
     /**
-     * @var FetchAuthTokenInterface Fetches credentials.
-     */
-    private $credentialsFetcher;
-
-    /**
      * @var callable A handler used to deliver Psr7 requests.
      */
     private $httpHandler;
 
     /**
-     * @var callable HTTP client specific configuration options.
+     * @var array HTTP client specific configuration options.
      */
     private $httpOptions;
 
     /**
-     * @var array The contents of the service account
-     * credentials .json file retrieved from the Google Developers Console.
-     */
-    private $keyFile;
-
-    /**
-     * @var int Number of retries for a failed request. **Defaults to**  `3`.
-     */
-
-    private $retries;
-    /**
      * @var array
      */
-
     private $httpRetryCodes = [
         500,
         502,
-        503,
-        504
+        503
     ];
 
     /**
@@ -95,12 +78,7 @@ class RequestWrapper
     ];
 
     /**
-     * @var array Scopes to be used for the request.
-     */
-    private $scopes = [];
-
-    /**
-     * @var boolean $shouldSignRequest Whether to enable request signing.
+     * @var bool $shouldSignRequest Whether to enable request signing.
      */
     private $shouldSignRequest;
 
@@ -111,6 +89,8 @@ class RequestWrapper
      *     @type string $accessToken Access token used to sign requests.
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
+     *     @type FetchAuthTokenInterface $credentialsFetcher A credentials
+     *           fetcher instance.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
      *     @type string $keyFile The contents of the service account
      *           credentials .json file retrieved from the Google Developers
@@ -119,35 +99,24 @@ class RequestWrapper
      *     @type int $retries Number of retries for a failed request.
      *           **Defaults to** `3`.
      *     @type array $scopes Scopes to be used for the request.
-     *     @type boolean $shouldSignRequest Whether to enable request signing.
+     *     @type bool $shouldSignRequest Whether to enable request signing.
      * }
      */
     public function __construct(array $config = [])
     {
+        $this->setCommonDefaults($config);
         $config += [
             'accessToken' => null,
             'authHttpHandler' => null,
-            'credentialsFetcher' => null,
             'httpHandler' => null,
             'httpOptions' => [],
-            'keyFile' => null,
-            'retries' => null,
-            'scopes' => null,
             'shouldSignRequest' => true
         ];
 
-        if ($config['credentialsFetcher'] && !$config['credentialsFetcher'] instanceof FetchAuthTokenInterface) {
-            throw new \InvalidArgumentException('credentialsFetcher must implement FetchAuthTokenInterface.');
-        }
-
         $this->accessToken = $config['accessToken'];
-        $this->credentialsFetcher = $config['credentialsFetcher'];
         $this->httpHandler = $config['httpHandler'] ?: HttpHandlerFactory::build();
         $this->authHttpHandler = $config['authHttpHandler'] ?: $this->httpHandler;
         $this->httpOptions = $config['httpOptions'];
-        $this->retries = $config['retries'];
-        $this->scopes = $config['scopes'];
-        $this->keyFile = $config['keyFile'];
         $this->shouldSignRequest = $config['shouldSignRequest'];
     }
 
@@ -177,26 +146,6 @@ class RequestWrapper
         } catch (\Exception $ex) {
             throw $this->convertToGoogleException($ex);
         }
-    }
-
-    /**
-     * Gets the credentials fetcher. Precedence begins with user supplied
-     * credentials fetcher instance, followed by a reference to a key file
-     * stream, and finally the application default credentials.
-     *
-     * @return FetchAuthTokenInterface
-     */
-    public function getCredentialsFetcher()
-    {
-        if ($this->credentialsFetcher) {
-            return $this->credentialsFetcher;
-        }
-
-        if ($this->keyFile) {
-            return CredentialsLoader::makeCredentials($this->scopes, $this->keyFile);
-        }
-
-        return ApplicationDefaultCredentials::getCredentials($this->scopes, $this->authHttpHandler);
     }
 
     /**

--- a/src/RequestWrapper.php
+++ b/src/RequestWrapper.php
@@ -83,22 +83,16 @@ class RequestWrapper
     private $shouldSignRequest;
 
     /**
-     * @param array $options [optional] {
-     *     Configuration options.
+     * @param array $config [optional] {
+     *     Configuration options. Please see
+     *     {@see Google\Cloud\RequestWrapperTrait::setCommonDefaults()} for the other
+     *     available options.
      *
      *     @type string $accessToken Access token used to sign requests.
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
-     *     @type FetchAuthTokenInterface $credentialsFetcher A credentials
-     *           fetcher instance.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
-     *     @type string $keyFile The contents of the service account
-     *           credentials .json file retrieved from the Google Developers
-     *           Console.
      *     @type array $httpOptions HTTP client specific configuration options.
-     *     @type int $retries Number of retries for a failed request.
-     *           **Defaults to** `3`.
-     *     @type array $scopes Scopes to be used for the request.
      *     @type bool $shouldSignRequest Whether to enable request signing.
      * }
      */

--- a/src/RequestWrapperTrait.php
+++ b/src/RequestWrapperTrait.php
@@ -50,7 +50,18 @@ trait RequestWrapperTrait
     /**
      * Sets common defaults between request wrappers.
      *
-     * @param callable $array
+     * @param array $config {
+     *     Configuration options.
+     *
+     *     @type FetchAuthTokenInterface $credentialsFetcher A credentials
+     *           fetcher instance.
+     *     @type string $keyFile The contents of the service account
+     *           credentials .json file retrieved from the Google Developers
+     *           Console.
+     *     @type int $retries Number of retries for a failed request.
+     *           **Defaults to** `3`.
+     *     @type array $scopes Scopes to be used for the request.
+     * }
      * @throws \InvalidArgumentException
      */
     public function setCommonDefaults(array $config)

--- a/src/RequestWrapperTrait.php
+++ b/src/RequestWrapperTrait.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud;
+
+use Google\Auth\ApplicationDefaultCredentials;
+use Google\Auth\CredentialsLoader;
+use Google\Auth\FetchAuthTokenInterface;
+
+/**
+ * Encapsulates shared functionality of request wrappers.
+ */
+trait RequestWrapperTrait
+{
+    /**
+     * @var FetchAuthTokenInterface Fetches credentials.
+     */
+    private $credentialsFetcher;
+
+    /**
+     * @var array The contents of the service account credentials .json file
+     * retrieved from the Google Developers Console.
+     */
+    private $keyFile;
+
+    /**
+     * @var int Number of retries for a failed request. **Defaults to** `3`.
+     */
+    private $retries;
+
+    /**
+     * @var array Scopes to be used for the request.
+     */
+    private $scopes = [];
+
+    /**
+     * Sets common defaults between request wrappers.
+     *
+     * @param callable $array
+     * @throws \InvalidArgumentException
+     */
+    public function setCommonDefaults(array $config)
+    {
+        $config += [
+            'credentialsFetcher' => null,
+            'keyFile' => null,
+            'retries' => null,
+            'scopes' => null
+        ];
+
+        if ($config['credentialsFetcher'] && !$config['credentialsFetcher'] instanceof FetchAuthTokenInterface) {
+            throw new \InvalidArgumentException('credentialsFetcher must implement FetchAuthTokenInterface.');
+        }
+
+        $this->credentialsFetcher = $config['credentialsFetcher'];
+        $this->retries = $config['retries'];
+        $this->scopes = $config['scopes'];
+        $this->keyFile = $config['keyFile'];
+    }
+
+    /**
+     * Gets the credentials fetcher. Precedence begins with user supplied
+     * credentials fetcher instance, followed by a reference to a key file
+     * stream, and finally the application default credentials.
+     *
+     * @return FetchAuthTokenInterface
+     */
+    public function getCredentialsFetcher()
+    {
+        if ($this->credentialsFetcher) {
+            return $this->credentialsFetcher;
+        }
+
+        if ($this->keyFile) {
+            return CredentialsLoader::makeCredentials($this->scopes, $this->keyFile);
+        }
+
+        return ApplicationDefaultCredentials::getCredentials($this->scopes, $this->authHttpHandler);
+    }
+}

--- a/src/RestTrait.php
+++ b/src/RestTrait.php
@@ -81,23 +81,4 @@ trait RestTrait
             true
         );
     }
-
-    /**
-     * When emulators are enabled, use them as the service host
-     *
-     * @param string $baseUri
-     * @param string $emulatorHost [optional]
-     * @return string
-     */
-    public function getEmulatorBaseUri($baseUri, $emulatorHost = null)
-    {
-        if ($emulatorHost) {
-            $emulatorUriComponents = parse_url($emulatorHost);
-            $emulatorUriComponents = array_merge(['scheme' => 'http', 'port' => ''], $emulatorUriComponents);
-            $baseUri = "{$emulatorUriComponents['scheme']}://{$emulatorUriComponents['host']}";
-            $baseUri .= $emulatorUriComponents['port'] ? ":{$emulatorUriComponents['port']}/" : '/';
-        }
-
-        return $baseUri;
-    }
 }

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -75,6 +75,7 @@ class ServiceBuilder
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
+     *           Only valid for requests sent over REST.
      *     @type string $keyFile The contents of the service account
      *           credentials .json file retrieved from the Google Developer's
      *           Console.
@@ -180,8 +181,13 @@ class ServiceBuilder
      * $pubsub = $cloud->pubsub();
      * ```
      *
-     * @param array $config [optional] Configuration options. See
-     *        {@see Google\Cloud\ServiceBuilder::__construct()} for the available options.
+     * @param array $config [optional] {
+     *     Configuration options. See
+     *     {@see Google\Cloud\ServiceBuilder::__construct()} for the other available options.
+     *
+     *     @type string $transport The transport type used for requests. May be
+     *           either `grpc` or `rest`. **Defaults to** `grpc` if gRPC support
+     *           is detected on the system.
      * @return PubSubClient
      */
     public function pubsub(array $config = [])
@@ -283,6 +289,7 @@ class ServiceBuilder
      *     @type string $target The target language to assign to the client.
      *           Defaults to `en` (English).
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
+     *           Only valid for requests sent over REST.
      *     @type int $retries Number of retries for a failed request.
      *           **Defaults to** `3`.
      * }

--- a/src/Speech/SpeechClient.php
+++ b/src/Speech/SpeechClient.php
@@ -77,6 +77,7 @@ class SpeechClient
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
+     *           Only valid for requests sent over REST.
      *     @type string $keyFile The contents of the service account
      *           credentials .json file retrieved from the Google Developers
      *           Console.

--- a/src/Storage/StorageClient.php
+++ b/src/Storage/StorageClient.php
@@ -66,6 +66,7 @@ class StorageClient
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
+     *           Only valid for requests sent over REST.
      *     @type string $keyFile The contents of the service account
      *           credentials .json file retrieved from the Google Developers
      *           Console.

--- a/src/Translate/TranslateClient.php
+++ b/src/Translate/TranslateClient.php
@@ -84,6 +84,7 @@ class TranslateClient
      *           Must be a valid ISO 639-1 language code. **Defaults to** `"en"`
      *           (English).
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
+     *           Only valid for requests sent over REST.
      *     @type int $retries Number of retries for a failed request.
      *           **Defaults to** `3`.
      * }

--- a/tests/EmulatorTraitTest.php
+++ b/tests/EmulatorTraitTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests;
+
+use Google\Cloud\EmulatorTrait;
+use Prophecy\Argument;
+
+/**
+ * @group root
+ */
+class EmulatorTraitTest extends \PHPUnit_Framework_TestCase
+{
+    private $implementation;
+
+    public function setUp()
+    {
+        $this->implementation = $this->getObjectForTrait(EmulatorTrait::class);
+    }
+
+    public function testGetEmulatorBaseUriNoEmulator()
+    {
+        $res = $this->implementation->getEmulatorBaseUri('http://google.com', null);
+
+        $this->assertEquals('http://google.com', $res);
+    }
+
+    public function testGetEmulatorBaseUriEmulator()
+    {
+        $res = $this->implementation->getEmulatorBaseUri('http://google.com', 'http://localhost:8080');
+
+        $this->assertEquals('http://localhost:8080/', $res);
+    }
+}

--- a/tests/GrpcRequestWrapperTest.php
+++ b/tests/GrpcRequestWrapperTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests;
+
+use DrSlump\Protobuf\Message;
+use Google\Cloud\Exception;
+use Google\Cloud\GrpcRequestWrapper;
+use Google\GAX\ApiException;
+use Google\GAX\Page;
+use Google\GAX\PagedListResponse;
+use Prophecy\Argument;
+
+/**
+ * @group root
+ */
+class GrpcRequestWrapperTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (!extension_loaded('grpc')) {
+            $this->markTestSkipped('Must have the grpc extension installed to run this test.');
+        }
+    }
+
+    /**
+     * @dataProvider responseProvider
+     */
+    public function testSuccessfullySendsRequest($response, $expectedMessage)
+    {
+        $requestWrapper = new GrpcRequestWrapper();
+
+        $actualResponse = $requestWrapper->send(
+            function ($test) use ($response) {
+                return $response;
+            },
+            ['test', []]
+        );
+
+        $this->assertEquals($expectedMessage, $actualResponse);
+    }
+
+    public function responseProvider()
+    {
+        $expectedMessage = ['successful' => 'request'];
+        $message = $this->prophesize(Message::class);
+        $message->serialize(Argument::any())->willReturn($expectedMessage);
+        $pagedMessage = $this->prophesize(PagedListResponse::class);
+        $page = $this->prophesize(Page::class);
+        $page->getResponseObject()->willReturn($message->reveal());
+        $pagedMessage->getPage()->willReturn($page->reveal());
+
+        return [
+            [$message->reveal(), $expectedMessage],
+            [$pagedMessage->reveal(), $expectedMessage],
+            [null, []]
+        ];
+    }
+
+    /**
+     * @expectedException Google\Cloud\Exception\GoogleException
+     */
+    public function testThrowsExceptionWhenRequestFails()
+    {
+        $requestWrapper = new GrpcRequestWrapper();
+
+        $requestWrapper->send(function () {
+            throw new ApiException('message', 5);
+        }, [[]]);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testThrowsExceptionWithInvalidCredentialsFetcher()
+    {
+        $credentialsFetcher = new \stdClass();
+
+        $requestWrapper = new GrpcRequestWrapper([
+            'credentialsFetcher' => $credentialsFetcher
+        ]);
+    }
+
+    /**
+     * @dataProvider credentialsProvider
+     */
+    public function testCredentialsFetcher($wrapperConfig)
+    {
+        $requestWrapper = new GrpcRequestWrapper($wrapperConfig);
+
+        $this->assertInstanceOf(
+            'Google\Auth\FetchAuthTokenInterface',
+            $requestWrapper->getCredentialsFetcher()
+        );
+    }
+
+    /**
+     * @dataProvider keyFileCredentialsProvider
+     */
+    public function testCredentialsFromKeyFileStreamCanBeReadMultipleTimes($wrapperConfig)
+    {
+        $requestWrapper = new GrpcRequestWrapper($wrapperConfig);
+
+        $requestWrapper->getCredentialsFetcher();
+        $credentials = $requestWrapper->getCredentialsFetcher();
+
+        $this->assertInstanceOf('Google\Auth\FetchAuthTokenInterface', $credentials);
+    }
+
+    public function credentialsProvider()
+    {
+        $keyFilePath = __DIR__ . '/fixtures/json-key-fixture.json';
+        putenv("GOOGLE_APPLICATION_CREDENTIALS=$keyFilePath"); // for application default credentials
+
+        $credentialsFetcher = $this->prophesize('Google\Auth\FetchAuthTokenInterface');
+
+        return [
+            [['keyFile' => json_decode(file_get_contents($keyFilePath), true)]], // keyFile
+            [['keyFilePath' => $keyFilePath]], //keyFilePath
+            [['credentialsFetcher' => $credentialsFetcher->reveal()]], // user supplied fetcher
+            [[]] // application default
+        ];
+    }
+
+    public function keyFileCredentialsProvider()
+    {
+        $keyFilePath = __DIR__ . '/fixtures/json-key-fixture.json';
+
+        return [
+            [['keyFile' => json_decode(file_get_contents($keyFilePath), true)]], // keyFile
+            [['keyFilePath' => $keyFilePath]], //keyFilePath
+        ];
+    }
+
+    /**
+     * @dataProvider exceptionProvider
+     */
+    public function testCastsToProperException($code, $expectedException)
+    {
+        $requestWrapper = new GrpcRequestWrapper();
+
+        try {
+            $requestWrapper->send(function () use ($code) {
+                throw new ApiException('message', $code);
+            }, [[]], ['retries' => 0]);
+        } catch (\Exception $ex) {
+            $this->assertInstanceOf($expectedException, $ex);
+        }
+    }
+
+    public function exceptionProvider()
+    {
+        return [
+            [3, Exception\BadRequestException::class],
+            [5, Exception\NotFoundException::class],
+            [6, Exception\ConflictException::class],
+            [13, Exception\ServerException::class],
+            [15, Exception\ServiceException::class]
+        ];
+    }
+}

--- a/tests/GrpcRequestWrapperTest.php
+++ b/tests/GrpcRequestWrapperTest.php
@@ -68,7 +68,7 @@ class GrpcRequestWrapperTest extends \PHPUnit_Framework_TestCase
         return [
             [$message->reveal(), $expectedMessage],
             [$pagedMessage->reveal(), $expectedMessage],
-            [null, []]
+            [null, null]
         ];
     }
 

--- a/tests/GrpcTraitTest.php
+++ b/tests/GrpcTraitTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests;
+
+use Google\Cloud\GrpcRequestWrapper;
+use Google\Cloud\GrpcTrait;
+use Prophecy\Argument;
+
+/**
+ * @group root
+ */
+class GrpcTraitTest extends \PHPUnit_Framework_TestCase
+{
+    private $implementation;
+    private $requestWrapper;
+
+    public function setUp()
+    {
+        if (!extension_loaded('grpc')) {
+            $this->markTestSkipped('Must have the grpc extension installed to run this test.');
+        }
+
+        $this->implementation = $this->getObjectForTrait(GrpcTrait::class);
+        $this->requestWrapper = $this->prophesize(GrpcRequestWrapper::class);
+    }
+
+    public function testSendsRequest()
+    {
+        $grpcOptions = [
+            'timeoutMs' => 100
+        ];
+        $message = ['successful' => 'message'];
+        $this->requestWrapper->send(
+            Argument::type('callable'),
+            Argument::type('array'),
+            ['grpcOptions' => $grpcOptions]
+        )->willReturn($message);
+
+        $this->implementation->setRequestWrapper($this->requestWrapper->reveal());
+        $actualResponse = $this->implementation->send(function () {
+            return true;
+        }, [['grpcOptions' => $grpcOptions]]);
+
+        $this->assertEquals($message, $actualResponse);
+    }
+
+    public function testPluck()
+    {
+        $value = '123';
+        $key = 'key';
+        $array = [$key => $value];
+        $actualValue = $this->implementation->pluck($key, $array);
+
+        $this->assertEquals($value, $actualValue);
+        $this->assertEquals([], $array);
+    }
+}

--- a/tests/GrpcTraitTest.php
+++ b/tests/GrpcTraitTest.php
@@ -69,4 +69,13 @@ class GrpcTraitTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($value, $actualValue);
         $this->assertEquals([], $array);
     }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testPluckThrowsExceptionWithInvalidKey()
+    {
+        $array = [];
+        $actualValue = $this->implementation->pluck('not_here', $array);
+    }
 }

--- a/tests/PhpArrayTest.php
+++ b/tests/PhpArrayTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests;
+
+use DrSlump\Protobuf\Message;
+use Google\Cloud\PhpArray;
+use Prophecy\Argument;
+
+/**
+ * @group root
+ */
+class PhpArrayTest extends \PHPUnit_Framework_TestCase
+{
+    private $phpArray;
+
+    public function setUp()
+    {
+        $this->phpArray = new PhpArray();
+    }
+
+    public function testProperlyTransformsKeys()
+    {
+        $value = 'testing123';
+        $message = new TestMessage();
+        $message->setTestField($value);
+        $serializedMessage = $message->serialize(new PhpArray());
+
+        $this->assertEquals(['testField' => $value], $serializedMessage);
+    }
+}
+
+class TestMessage extends Message
+{
+    public $test_field = null;
+
+    protected static $__extensions = array();
+
+    public static function descriptor()
+    {
+      $descriptor = new \DrSlump\Protobuf\Descriptor(__CLASS__, 'Google.Cloud.Tests.TestMessage');
+
+      $f = new \DrSlump\Protobuf\Field();
+      $f->number    = 1;
+      $f->name      = "test_field";
+      $f->type      = \DrSlump\Protobuf::TYPE_STRING;
+      $f->rule      = \DrSlump\Protobuf::RULE_OPTIONAL;
+      $descriptor->addField($f);
+
+
+      foreach (self::$__extensions as $cb) {
+        $descriptor->addField($cb(), true);
+      }
+
+      return $descriptor;
+    }
+
+    public function hasTestField(){
+      return $this->_has(1);
+    }
+
+    public function clearTestField(){
+      return $this->_clear(1);
+    }
+
+    public function getTestField(){
+      return $this->_get(1);
+    }
+
+    public function setTestField( $value){
+      return $this->_set(1, $value);
+    }
+}

--- a/tests/PubSub/Connection/GrpcTest.php
+++ b/tests/PubSub/Connection/GrpcTest.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\PubSub\Connection;
+
+use Google\Cloud\PubSub\Connection\Grpc;
+use Google\Cloud\GrpcRequestWrapper;
+use Prophecy\Argument;
+use google\pubsub\v1\PubsubMessage;
+use google\pubsub\v1\PubsubMessage\AttributesEntry as MessageAttributesEntry;
+use google\pubsub\v1\PushConfig\AttributesEntry as PushConfigAttributesEntry;
+use google\pubsub\v1\PushConfig;
+
+/**
+ * @group pubsub
+ */
+class GrpcTest extends \PHPUnit_Framework_TestCase
+{
+    private $requestWrapper;
+    private $successMessage;
+    private $publisherApi;
+    private $subscriberApi;
+
+    public function setUp()
+    {
+        if (!extension_loaded('grpc')) {
+            $this->markTestSkipped('Must have the grpc extension installed to run this test.');
+        }
+
+        $this->requestWrapper = $this->prophesize(GrpcRequestWrapper::class);
+        $this->successMessage = 'success';
+    }
+
+    /**
+     * @dataProvider methodProvider
+     */
+    public function testCallBasicMethods($method, $args, $expectedArgs)
+    {
+        $this->requestWrapper->send(
+            Argument::type('callable'),
+            $expectedArgs,
+            Argument::type('array')
+        )->willReturn($this->successMessage);
+
+        $grpc = new Grpc();
+        $grpc->setRequestWrapper($this->requestWrapper->reveal());
+
+        $this->assertEquals($this->successMessage, $grpc->$method($args));
+    }
+
+    public function methodProvider()
+    {
+        $value = 'value';
+        $pageSizeSetting = ['pageSize' => 3];
+        $messageData = '123';
+        $attributeKey = 'testing';
+        $attributeValue = '123';
+        $pbMessage = new PubsubMessage();
+        $pbMessage->setData('123');
+        $pbMessageAttribute = new MessageAttributesEntry();
+        $pbMessageAttribute->setKey($attributeKey);
+        $pbMessageAttribute->setValue($attributeValue);
+        $pbMessage->addAttributes($pbMessageAttribute);
+        $policy = ['fake' => 'policy'];
+        $permissions = ['fake' => 'permissions'];
+        $pbPushConfig = new PushConfig();
+        $pushEndpoint = 'http://www.example.com';
+        $pbPushConfig->setPushEndpoint($pushEndpoint);
+        $pbPushAttribute = new PushConfigAttributesEntry();
+        $pbPushAttribute->setKey($attributeKey);
+        $pbPushAttribute->setValue($attributeValue);
+        $pbPushConfig->addAttributes($pbPushAttribute);
+        $ackIds = ['1', '2', '3'];
+        $maxMessages = 100;
+        $ackDeadlineSeconds = 1;
+
+        return [
+            [
+                'createTopic',
+                ['name' => $value],
+                [$value, []]
+            ],
+            [
+                'getTopic',
+                ['topic' => $value],
+                [$value, []]
+            ],
+            [
+                'deleteTopic',
+                ['topic' => $value],
+                [$value, []]
+            ],
+            [
+                'listTopics',
+                ['project' => $value],
+                [$value, []]
+            ],
+            [
+                'publishMessage',
+                [
+                    'topic' => $value,
+                    'messages' => [
+                        [
+                            'data' => $messageData,
+                            'attributes' => [$attributeKey => $attributeValue]
+                        ]
+                    ]
+                ],
+                [$value, [$pbMessage], []]
+            ],
+            [
+                'listSubscriptionsByTopic',
+                ['topic' => $value] + $pageSizeSetting,
+                [$value, $pageSizeSetting]
+            ],
+            [
+                'getTopicIamPolicy',
+                ['resource' => $value],
+                [$value, []]
+            ],
+            [
+                'setTopicIamPolicy',
+                ['resource' => $value, 'policy' => $policy],
+                [$value, $policy, []]
+            ],
+            [
+                'testTopicIamPermissions',
+                ['resource' => $value, 'permissions' => $permissions],
+                [$value, $permissions, []]
+            ],
+            [
+                'createSubscription',
+                [
+                    'name' => $value,
+                    'topic' => strtoupper($value),
+                    'pushConfig' => [
+                        'pushEndpoint' => $pushEndpoint,
+                        'attributes' => [$attributeKey => $attributeValue]
+                    ]
+                ],
+                [$value, strtoupper($value), ['pushConfig' => $pbPushConfig]]
+            ],
+            [
+                'getSubscription',
+                ['subscription' => $value],
+                [$value, []]
+            ],
+            [
+                'listSubscriptions',
+                ['project' => $value] + $pageSizeSetting,
+                [$value, $pageSizeSetting]
+            ],
+            [
+                'deleteSubscription',
+                ['subscription' => $value],
+                [$value, []]
+            ],
+            [
+                'modifyPushConfig',
+                [
+                    'subscription' => $value,
+                    'pushConfig' => [
+                        'pushEndpoint' => $pushEndpoint,
+                        'attributes' => [$attributeKey => $attributeValue]
+                    ]
+                ],
+                [$value, $pbPushConfig, []]
+            ],
+            [
+                'pull',
+                ['subscription' => $value, 'maxMessages' => $maxMessages] + $pageSizeSetting,
+                [$value, $maxMessages, $pageSizeSetting]
+            ],
+            [
+                'modifyAckDeadline',
+                ['subscription' => $value, 'ackIds' => $ackIds, 'ackDeadlineSeconds' => $ackDeadlineSeconds],
+                [$value, $ackIds, $ackDeadlineSeconds, []]
+            ],
+            [
+                'acknowledge',
+                ['subscription' => $value, 'ackIds' => $ackIds],
+                [$value, $ackIds, []]
+            ],
+            [
+                'getSubscriptionIamPolicy',
+                ['resource' => $value],
+                [$value, []]
+            ],
+            [
+                'setSubscriptionIamPolicy',
+                ['resource' => $value, 'policy' => $policy],
+                [$value, $policy, []]
+            ],
+            [
+                'testSubscriptionIamPermissions',
+                ['resource' => $value, 'permissions' => $permissions],
+                [$value, $permissions, []]
+            ]
+        ];
+    }
+}

--- a/tests/PubSub/PubSubClientTest.php
+++ b/tests/PubSub/PubSubClientTest.php
@@ -19,6 +19,8 @@ namespace Google\Cloud\Tests\PubSub;
 
 use Generator;
 use Google\Cloud\PubSub\Connection\ConnectionInterface;
+use Google\Cloud\PubSub\Connection\Grpc;
+use Google\Cloud\PubSub\Connection\Rest;
 use Google\Cloud\PubSub\PubSubClient;
 use Google\Cloud\PubSub\Subscription;
 use Google\Cloud\PubSub\Topic;
@@ -37,7 +39,20 @@ class PubSubClientTest extends \PHPUnit_Framework_TestCase
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
 
-        $this->client = new PubSubClientStub(['projectId' => 'project']);
+        $this->client = new PubSubClientStub([
+            'projectId' => 'project',
+            'transport' => 'rest'
+        ]);
+    }
+
+    public function testUsesGrpcConnectionByDefault()
+    {
+        if (!extension_loaded('grpc')) {
+            $this->markTestSkipped('Must have the grpc extension installed to run this test.');
+        }
+        $client = new PubSubClientStub(['projectId' => 'project']);
+
+        $this->assertInstanceOf(Grpc::class, $client->getConnection());
     }
 
     public function testCreateTopic()
@@ -273,5 +288,10 @@ class PubSubClientStub extends PubSubClient
     public function setConnection($connection)
     {
         $this->connection = $connection;
+    }
+
+    public function getConnection()
+    {
+        return $this->connection;
     }
 }

--- a/tests/RestTraitTest.php
+++ b/tests/RestTraitTest.php
@@ -69,18 +69,4 @@ class RestTraitTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(json_decode($responseBody, true), $actualResponse);
     }
-
-    public function testGetEmulatorBaseUriNoEmulator()
-    {
-        $res = $this->implementation->getEmulatorBaseUri('http://google.com', null);
-
-        $this->assertEquals('http://google.com', $res);
-    }
-
-    public function testGetEmulatorBaseUriEmulator()
-    {
-        $res = $this->implementation->getEmulatorBaseUri('http://google.com', 'http://localhost:8080');
-
-        $this->assertEquals('http://localhost:8080/', $res);
-    }
 }


### PR DESCRIPTION
With this PR we now officially have gRPC support for pub/sub!

Perform the following installation:
```sh
$ pecl install grpc
$ composer require google/gax
$ composer require google/proto-client-php
```

... and the pub/sub client should automatically detect you are capable of using gRPC and enable that as the transport mechanism.

You can also toggle between REST/gRPC by providing the `transport` option when building your pub/sub client.

```php
<?php
require 'vendor/autoload.php';

use Google\Cloud\PubSub\PubSubClient;

$pubSub = new PubSubClient([
    'projectId' => 'my_project',
    'transport' => 'REST'
]);
```