### PR TITLE
Allow per-query overrride of the datastore namespaceId

### DIFF
--- a/src/Datastore/Operation.php
+++ b/src/Datastore/Operation.php
@@ -386,14 +386,15 @@ class Operation
     public function runQuery(QueryInterface $query, array $options = [])
     {
         $options += [
-            'className' => null
+            'className' => null,
+            'namespaceId' => $this->namespaceId
         ];
 
         $moreResults = true;
         do {
             $request = $options + $this->readOptions($options) + [
                 'projectId' => $this->projectId,
-                'partitionId' => $this->partitionId($this->projectId, $this->namespaceId),
+                'partitionId' => $this->partitionId($this->projectId, $options['namespaceId']),
                 $query->queryKey() => $query->queryObject()
             ];
 


### PR DESCRIPTION
Other spots where namespaces are used allow for overriding the value set in the client constructor, but runQuery does not.

This small change fixes that with no BC issues. The documented way to set a namespaceId is on the client. This is undocumented, but it does have legit use cases (see #213)