### PR TITLE
Implement retries and expose caching for access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,28 @@ If you need support for other Google APIs, please check out the [Google APIs Cli
 $ composer require google/cloud
 ```
 
+## Caching Access Tokens
+
+It is possible to cache access tokens by passing a [PSR-6](http://www.php-fig.org/psr/psr-6/) caching implementation in to the desired client.
+
+The following example takes advantage of [Stash](https://github.com/tedious/Stash).
+
+```php
+<?php
+require 'vendor/autoload.php';
+
+use Google\Cloud\Storage\StorageClient;
+use Stash\Driver\FileSystem;
+use Stash\Pool;
+
+$driver = new FileSystem([]);
+$pool = new Pool($driver);
+
+$storage = new StorageClient([
+    'authCache' => $pool
+]);
+```
+
 ## Google BigQuery
 
 - [API Documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/latest/bigquery/bigqueryclient)

--- a/README.md
+++ b/README.md
@@ -345,23 +345,22 @@ foreach ($annotation->faces() as $key => $face) {
 
 ## Caching Access Tokens
 
-It is possible to cache access tokens by passing a [PSR-6](http://www.php-fig.org/psr/psr-6/) caching implementation in to the desired client.
+By default the library will use a simple in-memory caching implementation, however it is possible to override this behavior by passing a [PSR-6](http://www.php-fig.org/psr/psr-6/) caching implementation in to the desired client.
 
-The following example takes advantage of [Stash](https://github.com/tedious/Stash).
+The following example takes advantage of [Symfony's Cache Component](https://github.com/symfony/cache).
 
 ```php
 <?php
 require 'vendor/autoload.php';
 
 use Google\Cloud\Storage\StorageClient;
-use Stash\Driver\FileSystem;
-use Stash\Pool;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
-$driver = new FileSystem([]);
-$pool = new Pool($driver);
+// Choose the implementation that fits your needs.
+$cache = new ArrayAdapter();
 
 $storage = new StorageClient([
-    'authCache' => $pool
+    'authCache' => $cache
 ]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -354,13 +354,10 @@ The following example takes advantage of [Symfony's Cache Component](https://git
 require 'vendor/autoload.php';
 
 use Google\Cloud\Storage\StorageClient;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
-$cacheDir = '/tmp/google-cloud-cache';
 // Please take the proper precautions when storing your access tokens in a cache no matter the implementation. 
-// In the case of a file system cache, set proper permissions to restrict access to tokens.
-@mkdir($cacheDir, 0600);
-$cache = new FilesystemAdapter('token', null, $cacheDir);
+$cache = new ArrayAdapter();
 
 $storage = new StorageClient([
     'authCache' => $cache

--- a/README.md
+++ b/README.md
@@ -354,10 +354,12 @@ The following example takes advantage of [Symfony's Cache Component](https://git
 require 'vendor/autoload.php';
 
 use Google\Cloud\Storage\StorageClient;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
-// Choose the implementation that fits your needs.
-$cache = new ArrayAdapter();
+$cacheDir = '/tmp/google-cloud-cache';
+// Make sure to set the proper permissions to restrict access to tokens.
+@mkdir($cacheDir, 0600);
+$cache = new FilesystemAdapter('token', null, $cacheDir);
 
 $storage = new StorageClient([
     'authCache' => $cache

--- a/README.md
+++ b/README.md
@@ -26,28 +26,6 @@ If you need support for other Google APIs, please check out the [Google APIs Cli
 $ composer require google/cloud
 ```
 
-## Caching Access Tokens
-
-It is possible to cache access tokens by passing a [PSR-6](http://www.php-fig.org/psr/psr-6/) caching implementation in to the desired client.
-
-The following example takes advantage of [Stash](https://github.com/tedious/Stash).
-
-```php
-<?php
-require 'vendor/autoload.php';
-
-use Google\Cloud\Storage\StorageClient;
-use Stash\Driver\FileSystem;
-use Stash\Pool;
-
-$driver = new FileSystem([]);
-$pool = new Pool($driver);
-
-$storage = new StorageClient([
-    'authCache' => $pool
-]);
-```
-
 ## Google BigQuery
 
 - [API Documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/latest/bigquery/bigqueryclient)
@@ -365,9 +343,31 @@ foreach ($annotation->faces() as $key => $face) {
 }
 ```
 
+## Caching Access Tokens
+
+It is possible to cache access tokens by passing a [PSR-6](http://www.php-fig.org/psr/psr-6/) caching implementation in to the desired client.
+
+The following example takes advantage of [Stash](https://github.com/tedious/Stash).
+
+```php
+<?php
+require 'vendor/autoload.php';
+
+use Google\Cloud\Storage\StorageClient;
+use Stash\Driver\FileSystem;
+use Stash\Pool;
+
+$driver = new FileSystem([]);
+$pool = new Pool($driver);
+
+$storage = new StorageClient([
+    'authCache' => $pool
+]);
+```
+
 ## Versioning
 
-This library follows [Semantic Versioning](http://semver.org/)
+This library follows [Semantic Versioning](http://semver.org/).
 
 Please note it is currently under active development. Any release versioned 0.x.y is subject to backwards incompatible changes at any time.
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,8 @@ use Google\Cloud\Storage\StorageClient;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
 $cacheDir = '/tmp/google-cloud-cache';
-// Make sure to set the proper permissions to restrict access to tokens.
+// Please take the proper precautions when storing your access tokens in a cache no matter the implementation. 
+// In the case of a file system cache, set proper permissions to restrict access to tokens.
 @mkdir($cacheDir, 0600);
 $cache = new FilesystemAdapter('token', null, $cacheDir);
 

--- a/src/BigQuery/BigQueryClient.php
+++ b/src/BigQuery/BigQueryClient.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\BigQuery;
 use Google\Cloud\BigQuery\Connection\ConnectionInterface;
 use Google\Cloud\BigQuery\Connection\Rest;
 use Google\Cloud\ClientTrait;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Google Cloud BigQuery client. Allows you to create, manage, share and query
@@ -63,6 +64,9 @@ class BigQueryClient
      *
      *     @type string $projectId The project ID from the Google Developer's
      *           Console.
+     *     @type CacheItemPoolInterface $authCache A cache for storing access
+     *           tokens. **Defaults to** a simple in memory implementation.
+     *     @type array $authCacheOptions Cache configuration options.
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.

--- a/src/Datastore/DatastoreClient.php
+++ b/src/Datastore/DatastoreClient.php
@@ -25,6 +25,7 @@ use Google\Cloud\Datastore\Query\Query;
 use Google\Cloud\Datastore\Query\QueryBuilder;
 use Google\Cloud\Datastore\Query\QueryInterface;
 use InvalidArgumentException;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Google Cloud Datastore client. Cloud Datastore is a highly-scalable NoSQL
@@ -111,6 +112,9 @@ class DatastoreClient
      *
      *     @type string $projectId The project ID from the Google Developer's
      *           Console.
+     *     @type CacheItemPoolInterface $authCache A cache for storing access
+     *           tokens. **Defaults to** a simple in memory implementation.
+     *     @type array $authCacheOptions Cache configuration options.
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.

--- a/src/GrpcTrait.php
+++ b/src/GrpcTrait.php
@@ -73,11 +73,7 @@ trait GrpcTrait
     private function getGaxConfig()
     {
         return [
-            'credentialsLoader' => new FetchAuthTokenCache(
-                $this->requestWrapper->getCredentialsFetcher(),
-                null,
-                new MemoryCacheItemPool()
-            ),
+            'credentialsLoader' => $this->requestWrapper->getCredentialsFetcher(),
             'enableCaching' => false,
             'appName' => 'gcloud-php',
             'version' => ServiceBuilder::VERSION

--- a/src/Logging/LoggingClient.php
+++ b/src/Logging/LoggingClient.php
@@ -21,6 +21,7 @@ use Google\Cloud\ClientTrait;
 use Google\Cloud\Logging\Connection\ConnectionInterface;
 use Google\Cloud\Logging\Connection\Grpc;
 use Google\Cloud\Logging\Connection\Rest;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Google Stackdriver Logging client. Allows you to store, search, analyze,
@@ -89,6 +90,9 @@ class LoggingClient
      *
      *     @type string $projectId The project ID from the Google Developer's
      *           Console.
+     *     @type CacheItemPoolInterface $authCache A cache for storing access
+     *           tokens. **Defaults to** a simple in memory implementation.
+     *     @type array $authCacheOptions Cache configuration options.
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.

--- a/src/NaturalLanguage/NaturalLanguageClient.php
+++ b/src/NaturalLanguage/NaturalLanguageClient.php
@@ -21,6 +21,7 @@ use Google\Cloud\ClientTrait;
 use Google\Cloud\NaturalLanguage\Connection\ConnectionInterface;
 use Google\Cloud\NaturalLanguage\Connection\Rest;
 use Google\Cloud\Storage\StorageObject;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Google Cloud Natural Language client. Provides natural language understanding
@@ -73,6 +74,9 @@ class NaturalLanguageClient
      *
      *     @type string $projectId The project ID from the Google Developer's
      *           Console.
+     *     @type CacheItemPoolInterface $authCache A cache for storing access
+     *           tokens. **Defaults to** a simple in memory implementation.
+     *     @type array $authCacheOptions Cache configuration options.
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.

--- a/src/PubSub/PubSubClient.php
+++ b/src/PubSub/PubSubClient.php
@@ -21,6 +21,7 @@ use Google\Cloud\ClientTrait;
 use Google\Cloud\PubSub\Connection\Grpc;
 use Google\Cloud\PubSub\Connection\Rest;
 use InvalidArgumentException;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Google Cloud Pub/Sub client. Allows you to send and receive
@@ -105,6 +106,9 @@ class PubSubClient
      *
      *     @type string $projectId The project ID from the Google Developer's
      *           Console.
+     *     @type CacheItemPoolInterface $authCache A cache for storing access
+     *           tokens. **Defaults to** a simple in memory implementation.
+     *     @type array $authCacheOptions Cache configuration options.
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -27,6 +27,7 @@ use Google\Cloud\Speech\SpeechClient;
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Translate\TranslateClient;
 use Google\Cloud\Vision\VisionClient;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Google Cloud Platform is a set of modular cloud-based services that allow you
@@ -72,6 +73,9 @@ class ServiceBuilder
      *
      *     @type string $projectId The project ID from the Google Developer's
      *           Console.
+     *     @type CacheItemPoolInterface $authCache A cache for storing access
+     *           tokens. **Defaults to** a simple in memory implementation.
+     *     @type array $authCacheOptions Cache configuration options.
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.

--- a/src/Speech/SpeechClient.php
+++ b/src/Speech/SpeechClient.php
@@ -21,6 +21,7 @@ use Google\Cloud\ClientTrait;
 use Google\Cloud\Speech\Connection\ConnectionInterface;
 use Google\Cloud\Speech\Connection\Rest;
 use Google\Cloud\Storage\StorageObject;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Google Cloud Speech client. The Cloud Speech API enables easy integration of
@@ -74,6 +75,9 @@ class SpeechClient
      *
      *     @type string $projectId The project ID from the Google Developer's
      *           Console.
+     *     @type CacheItemPoolInterface $authCache A cache for storing access
+     *           tokens. **Defaults to** a simple in memory implementation.
+     *     @type array $authCacheOptions Cache configuration options.
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.

--- a/src/Storage/StorageClient.php
+++ b/src/Storage/StorageClient.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Storage;
 use Google\Cloud\ClientTrait;
 use Google\Cloud\Storage\Connection\ConnectionInterface;
 use Google\Cloud\Storage\Connection\Rest;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Google Cloud Storage client. Allows you to store and retrieve data on
@@ -63,6 +64,9 @@ class StorageClient
      *
      *     @type string $projectId The project ID from the Google Developer's
      *           Console.
+     *     @type CacheItemPoolInterface $authCache A cache used storing access
+     *           tokens. **Defaults to** a simple in memory implementation.
+     *     @type array $authCacheOptions Cache configuration options.
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.

--- a/src/Vision/VisionClient.php
+++ b/src/Vision/VisionClient.php
@@ -21,6 +21,7 @@ use Google\Cloud\ClientTrait;
 use Google\Cloud\ValidateTrait;
 use Google\Cloud\Vision\Connection\Rest;
 use InvalidArgumentException;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Google Cloud Vision client. Allows you to understand the content of an image,
@@ -64,6 +65,9 @@ class VisionClient
      *
      *     @type string $projectId The project ID from the Google Developer's
      *           Console.
+     *     @type CacheItemPoolInterface $authCache A cache for storing access
+     *           tokens. **Defaults to** a simple in memory implementation.
+     *     @type array $authCacheOptions Cache configuration options.
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.

--- a/tests/GrpcTraitTest.php
+++ b/tests/GrpcTraitTest.php
@@ -69,11 +69,7 @@ class GrpcTraitTest extends \PHPUnit_Framework_TestCase
         $this->requestWrapper->getCredentialsFetcher()->willReturn($fetcher);
         $this->implementation->setRequestWrapper($this->requestWrapper->reveal());
         $expected = [
-            'credentialsLoader' => new FetchAuthTokenCache(
-                $fetcher,
-                null,
-                new MemoryCacheItemPool()
-            ),
+            'credentialsLoader' => $fetcher,
             'enableCaching' => false,
             'appName' => 'gcloud-php',
             'version' => ServiceBuilder::VERSION


### PR DESCRIPTION
Closes: https://github.com/GoogleCloudPlatform/google-cloud-php/issues/172

Example using [Stash](https://github.com/tedious/Stash):

``` php
<?php
require 'vendor/autoload.php';

use Google\Cloud\Storage\StorageClient;
use Stash\Driver\FileSystem;
use Stash\Pool;

$driver = new FileSystem([]);
$pool = new Pool($driver);

$storage = new StorageClient([
    'authCache' => $pool
]);
```
