### PR TITLE
fix Datastore entity deserialisation when arrayValue empty

### DIFF
--- a/src/Datastore/EntityMapper.php
+++ b/src/Datastore/EntityMapper.php
@@ -216,8 +216,10 @@ class EntityMapper
             case 'arrayValue':
                 $result = [];
 
-                foreach ($value['values'] as $val) {
-                    $result[] = $this->getPropertyValue($val);
+                if (array_key_exists('values', $value)) {
+                    foreach ($value['values'] as $val) {
+                        $result[] = $this->getPropertyValue($val);
+                    }
                 }
 
                 break;

--- a/tests/Datastore/EntityMapperTest.php
+++ b/tests/Datastore/EntityMapperTest.php
@@ -437,6 +437,15 @@ class EntityMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['foo', 'bar'], $res);
     }
 
+    public function testEmptyArrayValue()
+    {
+        $type = 'arrayValue';
+        $val = [];
+
+        $res = $this->mapper->convertValue($type, $val);
+        $this->assertTrue(is_array($res));
+        $this->assertEquals([], $res);
+    }
 
     public function testValueObjectBool()
     {


### PR DESCRIPTION
When type of property in datastore is array and is empty, Datastore responds with `"field": {}`.
Test incoming.