### PR TITLE
Update Operation to be stateless

### DIFF
--- a/src/Datastore/DatastoreClient.php
+++ b/src/Datastore/DatastoreClient.php
@@ -505,8 +505,12 @@ class DatastoreClient
     public function insertBatch(array $entities, array $options = [])
     {
         $entities = $this->operation->allocateIdsToEntities($entities);
-        $this->operation->mutate('insert', $entities, Entity::class);
-        return $this->operation->commit($options);
+        $mutations = [];
+        foreach ($entities as $entity) {
+            $mutations[] = $this->operation->mutation('insert', $entity, Entity::class);
+        }
+
+        return $this->operation->commit($mutations, $options);
     }
 
     /**
@@ -589,8 +593,12 @@ class DatastoreClient
         ];
 
         $this->operation->checkOverwrite($entities, $options['allowOverwrite']);
-        $this->operation->mutate('update', $entities, Entity::class);
-        return $this->operation->commit($options);
+        $mutations = [];
+        foreach ($entities as $entity) {
+            $mutations[] = $this->operation->mutation('update', $entity, Entity::class);
+        }
+
+        return $this->operation->commit($mutations, $options);
     }
 
     /**
@@ -661,8 +669,12 @@ class DatastoreClient
      */
     public function upsertBatch(array $entities, array $options = [])
     {
-        $this->operation->mutate('upsert', $entities, Entity::class);
-        return $this->operation->commit($options);
+        $mutations = [];
+        foreach ($entities as $entity) {
+            $mutations[] = $this->operation->mutation('upsert', $entity, Entity::class);
+        }
+
+        return $this->operation->commit($mutations, $options);
     }
 
     /**
@@ -729,8 +741,12 @@ class DatastoreClient
             'baseVersion' => null
         ];
 
-        $this->operation->mutate('delete', $keys, Key::class, $options['baseVersion']);
-        return $this->operation->commit($options);
+        $mutations = [];
+        foreach ($keys as $key) {
+            $mutations[] = $this->operation->mutation('delete', $key, Key::class, $options['baseVersion']);
+        }
+
+        return $this->operation->commit($mutations, $options);
     }
 
     /**

--- a/src/Datastore/Key.php
+++ b/src/Datastore/Key.php
@@ -348,6 +348,60 @@ class Key implements JsonSerializable
     }
 
     /**
+     * Get the last pathElement identifier.
+     *
+     * If the key is incomplete, returns `null`.
+     *
+     * Example:
+     * ```
+     * $lastPathElementIndentifier = $key->pathEndIdentifier();
+     * ```
+     *
+     * @return string|null
+     */
+    public function pathEndIdentifier()
+    {
+        $end = $this->pathEnd();
+
+        if (isset($end['id'])) {
+            return $end['id'];
+        }
+
+        if (isset($end['name'])) {
+            return $end['name'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the last pathElement identifier type.
+     *
+     * If the key is incomplete, returns `null`.
+     *
+     * Example:
+     * ```
+     * $lastPathElementIdentifierType = $key->pathEndIdentifierType();
+     * ```
+     *
+     * @return string|null
+     */
+    public function pathEndIdentifierType()
+    {
+        $end = $this->pathEnd();
+
+        if (isset($end['id'])) {
+            return self::TYPE_ID;
+        }
+
+        if (isset($end['name'])) {
+            return self::TYPE_NAME;
+        }
+
+        return null;
+    }
+
+    /**
      * Get the key object formatted for the datastore service.
      *
      * @access private

--- a/src/Datastore/Key.php
+++ b/src/Datastore/Key.php
@@ -357,7 +357,7 @@ class Key implements JsonSerializable
      * $lastPathElementIndentifier = $key->pathEndIdentifier();
      * ```
      *
-     * @return string|null
+     * @return string|int|null
      */
     public function pathEndIdentifier()
     {

--- a/src/Datastore/Transaction.php
+++ b/src/Datastore/Transaction.php
@@ -142,7 +142,9 @@ class Transaction
     public function insertBatch(array $entities)
     {
         $entities = $this->operation->allocateIdsToEntities($entities);
-        $this->operation->mutate('insert', $entities, Entity::class);
+        foreach ($entities as $entity) {
+            $this->mutations[] = $this->operation->mutation('insert', $entity, Entity::class);
+        }
 
         return $this;
     }
@@ -222,7 +224,9 @@ class Transaction
         ];
 
         $this->operation->checkOverwrite($entities, $options['allowOverwrite']);
-        $this->operation->mutate('update', $entities, Entity::class);
+        foreach ($entities as $entity) {
+            $this->mutations[] = $this->operation->mutation('update', $entity, Entity::class);
+        }
 
         return $this;
     }
@@ -283,7 +287,9 @@ class Transaction
      */
     public function upsertBatch(array $entities)
     {
-        $this->operation->mutate('upsert', $entities, Entity::class);
+        foreach ($entities as $entity) {
+            $this->mutations[] = $this->operation->mutation('upsert', $entity, Entity::class);
+        }
 
         return $this;
     }
@@ -332,7 +338,9 @@ class Transaction
      */
     public function deleteBatch(array $keys)
     {
-        $this->operation->mutate('delete', $keys, Key::class);
+        foreach ($keys as $key) {
+            $this->mutations[] = $this->operation->mutation('delete', $key, Key::class);
+        }
 
         return $this;
     }
@@ -458,7 +466,7 @@ class Transaction
     {
         $options['transaction'] = $this->transactionId;
 
-        return $this->operation->commit($options);
+        return $this->operation->commit($this->mutations, $options);
     }
 
     /**

--- a/tests/unit/Datastore/DatastoreClientTest.php
+++ b/tests/unit/Datastore/DatastoreClientTest.php
@@ -214,10 +214,10 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
         $this->operation->allocateIdsToEntities(Argument::type('array'))
             ->willReturn([$e->reveal()]);
 
-        $this->operation->mutate(Argument::exact('insert'), Argument::type('array'), Argument::exact(Entity::class), Argument::exact(null))
+        $this->operation->mutation(Argument::exact('insert'), Argument::type(Entity::class), Argument::exact(Entity::class), Argument::exact(null))
             ->shouldBeCalled();
 
-        $this->operation->commit(Argument::type('array'))
+        $this->operation->commit(Argument::type('array'), Argument::type('array'))
             ->shouldBeCalled()
             ->willReturn(['mutationResults' => [['version' => '1234']]]);
 
@@ -238,10 +238,10 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
         $this->operation->allocateIdsToEntities(Argument::type('array'))
             ->willReturn([$e->reveal()]);
 
-        $this->operation->mutate(Argument::exact('insert'), Argument::type('array'), Argument::exact(Entity::class), Argument::exact(null))
+        $this->operation->mutation(Argument::exact('insert'), Argument::type(Entity::class), Argument::exact(Entity::class), Argument::exact(null))
             ->shouldBeCalled();
 
-        $this->operation->commit(Argument::type('array'))
+        $this->operation->commit(Argument::type('array'), Argument::type('array'))
             ->shouldBeCalled()
             ->willReturn(['mutationResults' => [['version' => '1234', 'conflictDetected' => true]]]);
 
@@ -254,11 +254,11 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
     {
         $e = $this->prophesize(Entity::class);
 
-        $this->operation->commit(Argument::type('array'))
+        $this->operation->commit(Argument::type('array'), Argument::type('array'))
             ->shouldBeCalled()
             ->willReturn(['mutationResults' => [['version' => '1234']]]);
 
-        $this->operation->mutate(Argument::exact('insert'), Argument::type('array'), Argument::exact(Entity::class), Argument::exact(null))
+        $this->operation->mutation(Argument::exact('insert'), Argument::type(Entity::class), Argument::exact(Entity::class), Argument::exact(null))
             ->shouldBeCalled();
 
         $this->operation->allocateIdsToEntities(Argument::type('array'))
@@ -273,11 +273,11 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
 
     public function testUpdate()
     {
-        $this->operation->commit(Argument::type('array'))
+        $this->operation->commit(Argument::type('array'), Argument::type('array'))
             ->shouldBeCalled()
             ->willReturn(['mutationResults' => [['version' => '1234']]]);
 
-        $this->operation->mutate(Argument::exact('update'), Argument::type('array'), Argument::exact(Entity::class), Argument::exact(null))
+        $this->operation->mutation(Argument::exact('update'), Argument::type(Entity::class), Argument::exact(Entity::class), Argument::exact(null))
             ->shouldBeCalled();
 
         $this->operation->checkOverwrite(Argument::type('array'), Argument::type('bool'))
@@ -294,11 +294,11 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
 
     public function testUpdateBatch()
     {
-        $this->operation->commit(Argument::type('array'))
+        $this->operation->commit(Argument::type('array'), Argument::type('array'))
             ->shouldBeCalled()
             ->willReturn(['mutationResults' => [['version' => '1234']]]);
 
-        $this->operation->mutate(Argument::exact('update'), Argument::type('array'), Argument::exact(Entity::class), Argument::exact(null))
+        $this->operation->mutation(Argument::exact('update'), Argument::type(Entity::class), Argument::exact(Entity::class), Argument::exact(null))
             ->shouldBeCalled();
 
         $this->operation->checkOverwrite(Argument::type('array'), Argument::type('bool'))
@@ -315,11 +315,11 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
 
     public function testUpsert()
     {
-        $this->operation->commit(Argument::type('array'))
+        $this->operation->commit(Argument::type('array'), Argument::type('array'))
             ->shouldBeCalled()
             ->willReturn(['mutationResults' => [['version' => '1234']]]);
 
-        $this->operation->mutate(Argument::exact('upsert'), Argument::type('array'), Argument::exact(Entity::class), Argument::exact(null))
+        $this->operation->mutation(Argument::exact('upsert'), Argument::type(Entity::class), Argument::exact(Entity::class), Argument::exact(null))
             ->shouldBeCalled();
 
         $this->datastore->setOperation($this->operation->reveal());
@@ -333,11 +333,11 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
 
     public function testUpsertBatch()
     {
-        $this->operation->commit(Argument::type('array'))
+        $this->operation->commit(Argument::type('array'), Argument::type('array'))
             ->shouldBeCalled()
             ->willReturn(['mutationResults' => [['version' => '1234']]]);
 
-        $this->operation->mutate(Argument::exact('upsert'), Argument::type('array'), Argument::exact(Entity::class), Argument::exact(null))
+        $this->operation->mutation(Argument::exact('upsert'), Argument::type(Entity::class), Argument::exact(Entity::class), Argument::exact(null))
             ->shouldBeCalled();
 
         $this->datastore->setOperation($this->operation->reveal());
@@ -351,11 +351,11 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
 
     public function testDelete()
     {
-        $this->operation->commit(Argument::type('array'))
+        $this->operation->commit(Argument::type('array'), Argument::type('array'))
             ->shouldBeCalled()
             ->willReturn(['mutationResults' => [['version' => '1234']]]);
 
-        $this->operation->mutate(Argument::exact('delete'), Argument::type('array'), Argument::exact(Key::class), Argument::exact(null))
+        $this->operation->mutation(Argument::exact('delete'), Argument::type(Key::class), Argument::exact(Key::class), Argument::exact(null))
             ->shouldBeCalled();
 
         $this->datastore->setOperation($this->operation->reveal());
@@ -369,11 +369,11 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteBatch()
     {
-        $this->operation->commit(Argument::type('array'))
+        $this->operation->commit(Argument::type('array'), Argument::type('array'))
             ->shouldBeCalled()
             ->willReturn(['mutationResults' => [['version' => '1234']]]);
 
-        $this->operation->mutate(Argument::exact('delete'), Argument::type('array'), Argument::exact(Key::class), Argument::exact(null))
+        $this->operation->mutation(Argument::exact('delete'), Argument::type(Key::class), Argument::exact(Key::class), Argument::exact(null))
             ->shouldBeCalled();
 
         $this->datastore->setOperation($this->operation->reveal());

--- a/tests/unit/Datastore/DatastoreSessionHandlerTest.php
+++ b/tests/unit/Datastore/DatastoreSessionHandlerTest.php
@@ -117,9 +117,11 @@ class DatastoreSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $ret);
     }
 
+    /**
+     * @expectedException PHPUnit_Framework_Error_Warning
+     */
     public function testReadWithException()
     {
-        \PHPUnit_Framework_Error_Warning::$enabled = FALSE;
         $this->datastore->transaction()
             ->shouldBeCalledTimes(1)
             ->willReturn($this->transaction->reveal());
@@ -207,9 +209,11 @@ class DatastoreSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, $ret);
     }
 
+    /**
+     * @expectedException PHPUnit_Framework_Error_Warning
+     */
     public function testWriteWithException()
     {
-        \PHPUnit_Framework_Error_Warning::$enabled = FALSE;
         $data = 'sessiondata';
         $key = new Key('projectid');
         $key->pathElement(self::KIND, 'sessionid');
@@ -278,9 +282,11 @@ class DatastoreSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, $ret);
     }
 
+    /**
+     * @expectedException PHPUnit_Framework_Error_Warning
+     */
     public function testDestroyWithException()
     {
-        \PHPUnit_Framework_Error_Warning::$enabled = FALSE;
         $key = new Key('projectid');
         $key->pathElement(self::KIND, 'sessionid');
         $this->transaction->delete($key)
@@ -396,9 +402,11 @@ class DatastoreSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, $ret);
     }
 
+    /**
+     * @expectedException PHPUnit_Framework_Error_Warning
+     */
     public function testGcWithException()
     {
-        \PHPUnit_Framework_Error_Warning::$enabled = FALSE;
         $key1 = new Key('projectid');
         $key1->pathElement(self::KIND, 'sessionid1');
         $key2 = new Key('projectid');

--- a/tests/unit/Datastore/KeyTest.php
+++ b/tests/unit/Datastore/KeyTest.php
@@ -268,6 +268,78 @@ class KeyTest extends \PHPUnit_Framework_TestCase
         ]);
     }
 
+    public function testPathEndIdentifier()
+    {
+        $key = new Key('foo', [
+            'path' => [
+                ['kind' => 'foo', 'id' => 2],
+                ['kind' => 'bar', 'id' => 10]
+            ]
+        ]);
+
+        $this->assertEquals(10, $key->pathEndIdentifier());
+    }
+
+    public function testPathEndIdentifierName()
+    {
+        $key = new Key('foo', [
+            'path' => [
+                ['kind' => 'foo', 'id' => 2],
+                ['kind' => 'bar', 'name' => 10]
+            ]
+        ]);
+
+        $this->assertEquals(10, $key->pathEndIdentifier());
+    }
+
+    public function testPathEndIdentifierNull()
+    {
+        $key = new Key('foo', [
+            'path' => [
+                ['kind' => 'foo', 'id' => 2],
+                ['kind' => 'bar']
+            ]
+        ]);
+
+        $this->assertNull($key->pathEndIdentifier());
+    }
+
+    public function testPathEndIdentifierType()
+    {
+        $key = new Key('foo', [
+            'path' => [
+                ['kind' => 'foo', 'id' => 2],
+                ['kind' => 'bar', 'id' => 10]
+            ]
+        ]);
+
+        $this->assertEquals(Key::TYPE_ID, $key->pathEndIdentifierType());
+    }
+
+    public function testPathEndIdentifierTypeName()
+    {
+        $key = new Key('foo', [
+            'path' => [
+                ['kind' => 'foo', 'id' => 2],
+                ['kind' => 'bar', 'name' => 10]
+            ]
+        ]);
+
+        $this->assertEquals(Key::TYPE_NAME, $key->pathEndIdentifierType());
+    }
+
+    public function testPathEndIdentifierTypeNull()
+    {
+        $key = new Key('foo', [
+            'path' => [
+                ['kind' => 'foo', 'id' => 2],
+                ['kind' => 'bar']
+            ]
+        ]);
+
+        $this->assertNull($key->pathEndIdentifierType());
+    }
+
     public function testToString()
     {
         $key = new Key('foo', [

--- a/tests/unit/Datastore/TransactionTest.php
+++ b/tests/unit/Datastore/TransactionTest.php
@@ -44,7 +44,7 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
     {
         $e = $this->prophesize(Entity::class);
 
-        $this->operation->mutate(Argument::exact('insert'), Argument::type('array'), Argument::exact(Entity::class, null))
+        $this->operation->mutation(Argument::exact('insert'), Argument::type(Entity::class), Argument::exact(Entity::class, null))
             ->shouldBeCalled()->willReturn(null);
 
         $this->operation->commit()->shouldNotBeCalled();
@@ -61,7 +61,7 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
     {
         $e = $this->prophesize(Entity::class);
 
-        $this->operation->mutate(Argument::exact('insert'), Argument::type('array'), Argument::exact(Entity::class, null))
+        $this->operation->mutation(Argument::exact('insert'), Argument::type(Entity::class), Argument::exact(Entity::class, null))
             ->shouldBeCalled()->willReturn(null);
 
         $this->operation->commit()->shouldNotBeCalled();
@@ -78,7 +78,7 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
     {
         $e = $this->prophesize(Entity::class);
 
-        $this->operation->mutate(Argument::exact('update'), Argument::type('array'), Argument::exact(Entity::class, null))
+        $this->operation->mutation(Argument::exact('update'), Argument::type(Entity::class), Argument::exact(Entity::class, null))
             ->shouldBeCalled()->willReturn(null);
 
         $this->operation->commit()->shouldNotBeCalled();
@@ -94,7 +94,7 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
     {
         $e = $this->prophesize(Entity::class);
 
-        $this->operation->mutate(Argument::exact('update'), Argument::type('array'), Argument::exact(Entity::class, null))
+        $this->operation->mutation(Argument::exact('update'), Argument::type(Entity::class), Argument::exact(Entity::class, null))
             ->shouldBeCalled()->willReturn(null);
 
         $this->operation->commit()->shouldNotBeCalled();
@@ -110,7 +110,7 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
     {
         $e = $this->prophesize(Entity::class);
 
-        $this->operation->mutate(Argument::exact('upsert'), Argument::type('array'), Argument::exact(Entity::class, null))
+        $this->operation->mutation(Argument::exact('upsert'), Argument::type(Entity::class), Argument::exact(Entity::class, null))
             ->shouldBeCalled()->willReturn(null);
 
         $this->operation->commit()->shouldNotBeCalled();
@@ -124,7 +124,7 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
     {
         $e = $this->prophesize(Entity::class);
 
-        $this->operation->mutate(Argument::exact('upsert'), Argument::type('array'), Argument::exact(Entity::class, null))
+        $this->operation->mutation(Argument::exact('upsert'), Argument::type(Entity::class), Argument::exact(Entity::class, null))
             ->shouldBeCalled()->willReturn(null);
 
         $this->operation->commit()->shouldNotBeCalled();
@@ -138,11 +138,10 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
     {
         $k = $this->prophesize(Key::class);
 
-        $this->operation->mutate(Argument::exact('delete'), Argument::type('array'), Argument::exact(Key::class, null))
+        $this->operation->mutation(Argument::exact('delete'), Argument::type(Key::class), Argument::exact(Key::class, null))
             ->shouldBeCalled()->willReturn(null);
 
         $this->operation->commit()->shouldNotBeCalled();
-
 
         $this->transaction->setOperation($this->operation->reveal());
 
@@ -153,7 +152,7 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
     {
         $k = $this->prophesize(Key::class);
 
-        $this->operation->mutate(Argument::exact('delete'), Argument::type('array'), Argument::exact(Key::class, null))
+        $this->operation->mutation(Argument::exact('delete'), Argument::type(Key::class), Argument::exact(Key::class, null))
             ->shouldBeCalled()->willReturn(null);
 
         $this->operation->commit()->shouldNotBeCalled();
@@ -215,7 +214,7 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
 
     public function testCommit()
     {
-        $this->operation->commit(Argument::that(function ($arg) {
+        $this->operation->commit(Argument::type('array'), Argument::that(function ($arg) {
             if ($arg['transaction'] !== $this->transactionId) return false;
         }));
 


### PR DESCRIPTION
Until now, `Operation`, which is a class used to provide a common gateway for transactional and non-transactional Datastore operations, has been responsible for maintaining a list of enqueued mutations.

`Operation` is created on instantiation of `DatastoreClient` and persists throughout the use of Datastore. This makes it a poor choice for storing state. Additionally, if a mutation was enqueued inside a `Transaction` but not committed, and an operation was run from `DatastoreClient`, the transactional mutation would be committed outside the transaction.

This change moves enqueued mutations into `Transaction`, preventing mutations from being improperly committed.

Additionally, two new helper methods have been added to `Key`. `Key::pathEndIdentifier()` will return the name or ID of the last path element, or `null` if the key is incomplete. `Key::pathEndIdentifierType()` will return `name` or `id`, depending on the identifier type, or `null` if the key is incomplete.

Technically this change includes breaking changes in the public API, however all the API changes are in `Operation`, which is intended only for use internally by the library.