### PR TITLE
uses resourceNames instead of projectId for Logging API entities.list

### DIFF
--- a/src/Logging/Connection/Grpc.php
+++ b/src/Logging/Connection/Grpc.php
@@ -134,7 +134,7 @@ class Grpc implements ConnectionInterface
     public function listEntries(array $args = [])
     {
         return $this->send([$this->loggingApi, 'listLogEntries'], [
-            $this->pluck('projectIds', $args),
+            $this->pluck('resourceNames', $args),
             $args
         ]);
     }

--- a/src/Logging/LoggingClient.php
+++ b/src/Logging/LoggingClient.php
@@ -352,6 +352,10 @@ class LoggingClient
      *     @type string[] $projectIds A list of projectIds to fetch
      *           entries from in addition to entries found in the project bound
      *           to this client.
+     *     @type string[] $resourceNames One or more cloud resources from which
+     *           to retrieve log entries. Projects listed in projectIds are
+     *           added to this list.
+     *           Example: "projects/my-project-1A", "projects/1234567890".
      *     @type string $filter An [advanced logs filter](https://cloud.google.com/logging/docs/view/advanced_filters).
      *     @type string $orderBy How the results should be sorted. Presently,
      *           the only permitted values are `timestamp asc` and

--- a/src/Logging/LoggingClient.php
+++ b/src/Logging/LoggingClient.php
@@ -365,10 +365,17 @@ class LoggingClient
     {
         $options['pageToken'] = null;
 
+        $resourceNames = ['projects/' . $this->projectId];
         if (isset($options['projectIds'])) {
-            $options['projectIds'] = array_merge([$this->projectId], $options['projectIds']);
+            foreach ($options['projectIds'] as $projectId) {
+                  $resourceNames[] = 'projects/' . $projectId;
+            }
+            unset($options['projectIds']);
+        }
+        if (isset($options['resourceNames'])) {
+            $options['resourceNames'] = array_merge($resourceNames, $options['projectIds']);
         } else {
-            $options['projectIds'] = [$this->projectId];
+            $options['resourceNames'] = $resourceNames;
         }
 
         do {

--- a/src/Logging/V2/ConfigServiceV2Api.php
+++ b/src/Logging/V2/ConfigServiceV2Api.php
@@ -227,7 +227,8 @@ class ConfigServiceV2Api
             'retryingOverride' => null,
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
             'appName' => 'gax',
-            'appVersion' => self::_GAX_VERSION
+            'appVersion' => self::_GAX_VERSION,
+            'credentialsLoader' => null,
         ];
         $options = array_merge($defaultOptions, $options);
 
@@ -253,8 +254,6 @@ class ConfigServiceV2Api
             $this->descriptors[$method]['pageStreamingDescriptor'] = $pageStreamingDescriptor;
         }
 
-        // TODO load the client config in a more package-friendly way
-        // https://github.com/googleapis/toolkit/issues/332
         $clientConfigJsonString = file_get_contents(__DIR__.'/resources/config_service_v2_client_config.json');
         $clientConfig = json_decode($clientConfigJsonString, true);
         $this->defaultCallSettings =
@@ -304,7 +303,7 @@ class ConfigServiceV2Api
      * }
      * ```
      *
-     * @param string $parent       Required. The resource name containing the sinks.
+     * @param string $parent       Required. The cloud resource containing the sinks.
      *                             Example: `"projects/my-logging-project"`.
      * @param array  $optionalArgs {
      *                             Optional.
@@ -373,7 +372,7 @@ class ConfigServiceV2Api
      * }
      * ```
      *
-     * @param string $sinkName     The resource name of the sink to return.
+     * @param string $sinkName     Required. The resource name of the sink to return.
      *                             Example: `"projects/my-project-id/sinks/my-sink-id"`.
      * @param array  $optionalArgs {
      *                             Optional.
@@ -428,12 +427,11 @@ class ConfigServiceV2Api
      * }
      * ```
      *
-     * @param string $parent The resource in which to create the sink.
-     *                       Example: `"projects/my-project-id"`.
-     *
-     * The new sink must be provided in the request.
-     * @param LogSink $sink         The new sink, which must not have an identifier that already
-     *                              exists.
+     * @param string  $parent       Required. The resource in which to create the sink.
+     *                              Example: `"projects/my-project-id"`.
+     *                              The new sink must be provided in the request.
+     * @param LogSink $sink         Required. The new sink, whose `name` parameter is a sink identifier that
+     *                              is not already in use.
      * @param array   $optionalArgs {
      *                              Optional.
      *
@@ -472,7 +470,7 @@ class ConfigServiceV2Api
     }
 
     /**
-     * Creates or updates a sink.
+     * Updates or creates a sink.
      *
      * Sample code:
      * ```
@@ -488,14 +486,11 @@ class ConfigServiceV2Api
      * }
      * ```
      *
-     * @param string $sinkName The resource name of the sink to update.
-     *                         Example: `"projects/my-project-id/sinks/my-sink-id"`.
-     *
-     * The updated sink must be provided in the request and have the
-     * same name that is specified in `sinkName`.  If the sink does not
-     * exist, it is created.
-     * @param LogSink $sink         The updated sink, whose name must be the same as the sink
-     *                              identifier in `sinkName`.  If `sinkName` does not exist, then
+     * @param string  $sinkName     Required. The resource name of the sink to update, including the parent
+     *                              resource and the sink identifier.  If the sink does not exist, this method
+     *                              creates the sink.  Example: `"projects/my-project-id/sinks/my-sink-id"`.
+     * @param LogSink $sink         Required. The updated sink, whose name is the same identifier that appears
+     *                              as part of `sinkName`.  If `sinkName` does not exist, then
      *                              this method creates a new sink.
      * @param array   $optionalArgs {
      *                              Optional.
@@ -550,8 +545,10 @@ class ConfigServiceV2Api
      * }
      * ```
      *
-     * @param string $sinkName     The resource name of the sink to delete.
-     *                             Example: `"projects/my-project-id/sinks/my-sink-id"`.
+     * @param string $sinkName     Required. The resource name of the sink to delete, including the parent
+     *                             resource and the sink identifier.  Example:
+     *                             `"projects/my-project-id/sinks/my-sink-id"`.  It is an error if the sink
+     *                             does not exist.
      * @param array  $optionalArgs {
      *                             Optional.
      *

--- a/src/Logging/V2/LoggingServiceV2Api.php
+++ b/src/Logging/V2/LoggingServiceV2Api.php
@@ -233,7 +233,8 @@ class LoggingServiceV2Api
             'retryingOverride' => null,
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
             'appName' => 'gax',
-            'appVersion' => self::_GAX_VERSION
+            'appVersion' => self::_GAX_VERSION,
+            'credentialsLoader' => null,
         ];
         $options = array_merge($defaultOptions, $options);
 
@@ -258,8 +259,6 @@ class LoggingServiceV2Api
             $this->descriptors[$method]['pageStreamingDescriptor'] = $pageStreamingDescriptor;
         }
 
-        // TODO load the client config in a more package-friendly way
-        // https://github.com/googleapis/toolkit/issues/332
         $clientConfigJsonString = file_get_contents(__DIR__.'/resources/logging_service_v2_client_config.json');
         $clientConfig = json_decode($clientConfigJsonString, true);
         $this->defaultCallSettings =
@@ -361,28 +360,37 @@ class LoggingServiceV2Api
      * }
      * ```
      *
-     * @param LogEntry[] $entries Required. The log entries to write. The log entries must have values for
-     *                            all required fields.
+     * @param LogEntry[] $entries Required. The log entries to write. Values supplied for the fields
+     *                            `log_name`, `resource`, and `labels` in this `entries.write` request are
+     *                            added to those log entries that do not provide their own values for the
+     *                            fields.
      *
-     * To improve throughput and to avoid exceeding the quota limit for calls
-     * to `entries.write`, use this field to write multiple log entries at once
-     * rather than  // calling this method for each log entry.
+     * To improve throughput and to avoid exceeding the
+     * [quota limit](/logging/quota-policy) for calls to `entries.write`,
+     * you should write multiple log entries at once rather than
+     * calling this method for each individual log entry.
      * @param array $optionalArgs {
      *                            Optional.
      *
      *     @type string $logName
-     *          Optional. A default log resource name for those log entries in `entries`
-     *          that do not specify their own `logName`.  Example:
+     *          Optional. A default log resource name that is assigned to all log entries
+     *          in `entries` that do not specify a value for `log_name`.  Example:
      *          `"projects/my-project/logs/syslog"`.  See
      *          [LogEntry][google.logging.v2.LogEntry].
      *     @type MonitoredResource $resource
-     *          Optional. A default monitored resource for those log entries in `entries`
-     *          that do not specify their own `resource`.
+     *          Optional. A default monitored resource object that is assigned to all log
+     *          entries in `entries` that do not specify a value for `resource`. Example:
+     *
+     *              { "type": "gce_instance",
+     *                "labels": {
+     *                  "zone": "us-central1-a", "instance_id": "00000000000000000000" }}
+     *
+     *          See [LogEntry][google.logging.v2.LogEntry].
      *     @type array $labels
-     *          Optional. User-defined `key:value` items that are added to
-     *          the `labels` field of each log entry in `entries`, except when a log
-     *          entry specifies its own `key:value` item with the same key.
-     *          Example: `{ "size": "large", "color":"red" }`
+     *          Optional. Default labels that are added to the `labels` field of all log
+     *          entries in `entries`. If a log entry already has a label with the same key
+     *          as a label in this parameter, then the log entry's label is not changed.
+     *          See [LogEntry][google.logging.v2.LogEntry].
      *     @type bool $partialSuccess
      *          Optional. Whether valid entries should be written even if some other
      *          entries fail due to INVALID_ARGUMENT or PERMISSION_DENIED errors. If any
@@ -447,8 +455,8 @@ class LoggingServiceV2Api
      * ```
      * try {
      *     $loggingServiceV2Api = new LoggingServiceV2Api();
-     *     $projectIds = [];
-     *     foreach ($loggingServiceV2Api->listLogEntries($projectIds) as $element) {
+     *     $resourceNames = [];
+     *     foreach ($loggingServiceV2Api->listLogEntries($resourceNames) as $element) {
      *         // doThingsWith(element);
      *     }
      * } finally {
@@ -458,16 +466,22 @@ class LoggingServiceV2Api
      * }
      * ```
      *
-     * @param string[] $projectIds   Required. One or more project IDs or project numbers from which to retrieve
-     *                               log entries.  Examples of a project ID: `"my-project-1A"`, `"1234567890"`.
-     * @param array    $optionalArgs {
-     *                               Optional.
+     * @param string[] $resourceNames Optional. One or more cloud resources from which to retrieve log entries.
+     *                                Example: `"projects/my-project-1A"`, `"projects/1234567890"`.  Projects
+     *                                listed in `projectIds` are added to this list.
+     * @param array    $optionalArgs  {
+     *                                Optional.
      *
+     *     @type string[] $projectIds
+     *          Deprecated. One or more project identifiers or project numbers from which
+     *          to retrieve log entries.  Examples: `"my-project-1A"`, `"1234567890"`. If
+     *          present, these project identifiers are converted to resource format and
+     *          added to the list of resources in `resourceNames`. Callers should use
+     *          `resourceNames` rather than this parameter.
      *     @type string $filter
-     *          Optional. An [advanced logs filter](/logging/docs/view/advanced_filters).
-     *          The filter is compared against all log entries in the projects specified by
-     *          `projectIds`.  Only entries that match the filter are retrieved.  An empty
-     *          filter matches all log entries.
+     *          Optional. A filter that chooses which log entries to return.  See [Advanced
+     *          Logs Filters](/logging/docs/view/advanced_filters).  Only log entries that
+     *          match the filter are returned.  An empty filter matches all log entries.
      *     @type string $orderBy
      *          Optional. How the results should be sorted.  Presently, the only permitted
      *          values are `"timestamp asc"` (default) and `"timestamp desc"`. The first
@@ -496,11 +510,16 @@ class LoggingServiceV2Api
      *
      * @throws Google\GAX\ApiException if the remote call fails
      */
-    public function listLogEntries($projectIds, $optionalArgs = [])
+    public function listLogEntries($resourceNames, $optionalArgs = [])
     {
         $request = new ListLogEntriesRequest();
-        foreach ($projectIds as $elem) {
-            $request->addProjectIds($elem);
+        foreach ($resourceNames as $elem) {
+            $request->addResourceNames($elem);
+        }
+        if (isset($optionalArgs['projectIds'])) {
+            foreach ($optionalArgs['projectIds'] as $elem) {
+                $request->addProjectIds($elem);
+            }
         }
         if (isset($optionalArgs['filter'])) {
             $request->setFilter($optionalArgs['filter']);

--- a/src/Logging/V2/MetricsServiceV2Api.php
+++ b/src/Logging/V2/MetricsServiceV2Api.php
@@ -226,7 +226,8 @@ class MetricsServiceV2Api
             'retryingOverride' => null,
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
             'appName' => 'gax',
-            'appVersion' => self::_GAX_VERSION
+            'appVersion' => self::_GAX_VERSION,
+            'credentialsLoader' => null,
         ];
         $options = array_merge($defaultOptions, $options);
 
@@ -252,8 +253,6 @@ class MetricsServiceV2Api
             $this->descriptors[$method]['pageStreamingDescriptor'] = $pageStreamingDescriptor;
         }
 
-        // TODO load the client config in a more package-friendly way
-        // https://github.com/googleapis/toolkit/issues/332
         $clientConfigJsonString = file_get_contents(__DIR__.'/resources/metrics_service_v2_client_config.json');
         $clientConfig = json_decode($clientConfigJsonString, true);
         $this->defaultCallSettings =

--- a/tests/unit/Logging/Connection/GrpcTest.php
+++ b/tests/unit/Logging/Connection/GrpcTest.php
@@ -103,7 +103,7 @@ class GrpcTest extends \PHPUnit_Framework_TestCase
         $pbEntry = (new LogEntry())->deserialize($entryData, new PhpArray());
         $pbSink = (new LogSink())->deserialize(['outputVersionFormat' => 1] + $sinkData, new PhpArray());
         $pbMetric = (new LogMetric())->deserialize($metricData, new PhpArray());
-        $projectIds = ['id'];
+        $resourceNames = ['projects/id'];
         $pageSizeSetting = ['pageSize' => 2];
 
         return [
@@ -132,8 +132,8 @@ class GrpcTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 'listEntries',
-                ['projectIds' => $projectIds],
-                [$projectIds, []]
+                ['resourceNames' => $resourceNames],
+                [$resourceNames, []]
             ],
             [
                 'createSink',

--- a/tests/unit/Logging/LoggingClientTest.php
+++ b/tests/unit/Logging/LoggingClientTest.php
@@ -209,7 +209,10 @@ class LoggingClientTest extends \PHPUnit_Framework_TestCase
         $secondProjectId = 'secondProjectId';
         $this->connection->listEntries([
             'pageToken' => null,
-            'projectIds' => [$this->projectId, $secondProjectId]
+            'resourceNames' => [
+                'projects/' . $this->projectId,
+                'projects/' . $secondProjectId
+            ]
         ])
             ->willReturn([])
             ->shouldBeCalledTimes(1);


### PR DESCRIPTION
see #211