### PR TITLE
Update Translate API Client

### DIFF
--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -268,10 +268,10 @@ class ServiceBuilder
      * more information at
      * [Google Translate docs](https://cloud.google.com/translate/docs/).
      *
-     * Please note that unlike most other Cloud Platform services Google
-     * Translate requires a public API access key and cannot currently be
-     * accessed with a service account or application default credentials.
-     * Follow the
+     * Please note that while Google Translate supports authentication via service
+     * account and application default credentials like other Cloud Platform APIs,
+     * it also supports authentication via a public API access key. If you wish to
+     * authenticate using an API key, follow the
      * [before you begin](https://cloud.google.com/translate/v2/translating-text-with-rest#before-you-begin)
      * instructions to learn how to generate a key.
      *

--- a/src/Translate/Connection/Rest.php
+++ b/src/Translate/Connection/Rest.php
@@ -31,7 +31,7 @@ class Rest implements ConnectionInterface
     use RestTrait;
     use UriTrait;
 
-    const BASE_URI = 'https://www.googleapis.com/language/translate/';
+    const BASE_URI = 'https://translation.googleapis.com/language/translate/';
 
     /**
      * @param array $config

--- a/src/Translate/Connection/ServiceDefinition/translate-v2.json
+++ b/src/Translate/Connection/ServiceDefinition/translate-v2.json
@@ -16,9 +16,9 @@
   },
   "documentationLink": "https://developers.google.com/translate/v2/using_rest",
   "protocol": "rest",
-  "baseUrl": "https://www.googleapis.com/language/translate/",
+  "baseUrl": "https://translation.googleapis.com/language/translate/",
   "basePath": "/language/translate/",
-  "rootUrl": "https://www.googleapis.com/",
+  "rootUrl": "https://translation.googleapis.com/",
   "servicePath": "language/translate/",
   "batchPath": "batch",
   "parameters": {
@@ -219,6 +219,12 @@
               "type": "string",
               "description": "The customization id for translate",
               "repeated": true,
+              "location": "query"
+            },
+            "model": {
+              "type": "string",
+              "description": "The model to use",
+              "repeated": false,
               "location": "query"
             },
             "format": {

--- a/src/Translate/TranslateClient.php
+++ b/src/Translate/TranslateClient.php
@@ -220,9 +220,7 @@ class TranslateClient
             'q' => $strings,
             'key' => $this->key,
             'target' => $this->targetLanguage,
-            'model' => (isset($options['model']))
-                ? $options['model']
-                : ''
+            'model' => $options['model']
         ]);
 
         $translations = [];

--- a/src/Translate/TranslateClient.php
+++ b/src/Translate/TranslateClient.php
@@ -137,7 +137,7 @@ class TranslateClient
      *     @type string $model The model to use for the translation request. May
      *           be `nmt` or `base`. **Defaults to** an empty string.
      * }
-     * @return array A translation result including a `source` key containing
+     * @return array|null A translation result including a `source` key containing
      *         the detected or provided langauge of the provided input, an
      *         `input` key containing the original string, and a `text` key
      *         containing the translated result.
@@ -148,8 +148,6 @@ class TranslateClient
         if (count($res) > 0) {
             return $res[0];
         }
-
-        return null;
     }
 
     /**

--- a/tests/unit/Translate/TranslateClientTest.php
+++ b/tests/unit/Translate/TranslateClientTest.php
@@ -78,6 +78,35 @@ class TranslateClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $translation);
     }
 
+    public function testTranslateWithNmtModel()
+    {
+        $expected = $this->getTranslateExpectedData('translate', 'translated', 'en', 'nmt');
+
+        $options = [
+            'source' => $expected['source'],
+            'target' => 'de',
+            'format' => 'text',
+            'model' => 'nmt'
+        ];
+        $this->connection
+            ->listTranslations($options + [
+                'q' => [$expected['input']],
+                'key' => $this->key
+            ])
+            ->willReturn([
+                'data' => [
+                    'translations' => [
+                        $this->getTranslateApiData($expected['text'], null, 'nmt')
+                    ]
+                ]
+            ])
+            ->shouldBeCalledTimes(1);
+        $this->client->setConnection($this->connection->reveal());
+        $translation = $this->client->translate($expected['input'], $options);
+
+        $this->assertEquals($expected, $translation);
+    }
+
     public function testTranslateBatch()
     {
         $expected1 = $this->getTranslateExpectedData('translate', 'translated', 'en');
@@ -205,22 +234,22 @@ class TranslateClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedLanguage, $languages[0]);
     }
 
-    private function getTranslateApiData($translatedText, $source = null)
+    private function getTranslateApiData($translatedText, $source = null, $model = 'base')
     {
         return array_filter([
             'translatedText' => $translatedText,
             'detectedSourceLanguage' => $source,
-            'model' => 'base'
+            'model' => $model
         ]);
     }
 
-    private function getTranslateExpectedData($textToTranslate, $translatedText, $source)
+    private function getTranslateExpectedData($textToTranslate, $translatedText, $source, $model = 'base')
     {
         return [
             'text' => $translatedText,
             'source' => $source,
             'input' => $textToTranslate,
-            'model' => 'base'
+            'model' => $model
         ];
     }
 


### PR DESCRIPTION
Please hold this until 11/15.

* Support service account and application default credentials in Translate
* Add support for the new `model` field.

Note that this change does not switch the operation from GET to POST.