### PR TITLE
Logging: default resource type to global (BC Break)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,7 @@ $logging = new LoggingClient([
 $logger = $logging->logger('my_log');
 
 // Write a log entry.
-$entry = $logger->entry('my message', [
-	'type' => 'gcs_bucket',
-	'labels' => [
-		'bucket_name' => 'my_bucket'
-	]
-]);
-
-$logger->write($entry);
+$logger->write('my message');
 
 // List log entries from a specific log.
 $entries = $logging->entries([

--- a/src/Logging/Logger.php
+++ b/src/Logging/Logger.php
@@ -100,6 +100,7 @@ class Logger
     private $labels;
 
     /**
+     * @codingStandardsIgnoreStart
      * @param ConnectionInterface $connection Represents a connection to
      *        Stackdriver Logging.
      * @param string $name The name of the log to write entries to.
@@ -109,6 +110,7 @@ class Logger
      *        to associate log entries with. **Defaults to** type global.
      * @param array $labels [optional] A set of user-defined (key, value) data
      *        that provides additional information about the log entries.
+     * @codingStandardsIgnoreEnd
      */
     public function __construct(
         ConnectionInterface $connection,

--- a/src/Logging/Logger.php
+++ b/src/Logging/Logger.php
@@ -17,7 +17,9 @@
 
 namespace Google\Cloud\Logging;
 
+use Google\Cloud\ArrayTrait;
 use Google\Cloud\Logging\Connection\ConnectionInterface;
+use Google\Cloud\ValidateTrait;
 
 /**
  * A logger used to write entries to Google Stackdriver Logging.
@@ -34,6 +36,9 @@ use Google\Cloud\Logging\Connection\ConnectionInterface;
  */
 class Logger
 {
+    use ArrayTrait;
+    use ValidateTrait;
+
     const EMERGENCY = 800;
     const ALERT = 700;
     const CRITICAL = 600;
@@ -61,6 +66,17 @@ class Logger
      * @var ConnectionInterface Represents a connection to Stackdriver Logging.
      */
     private $connection;
+
+    /**
+     * @var array Entry options.
+     */
+    private $entryOptions = [
+        'resource',
+        'httpRequest',
+        'labels',
+        'operation',
+        'severity'
+    ];
 
     /**
      * @var string The logger's formatted name to be used in API requests.
@@ -181,39 +197,25 @@ class Logger
      * Example:
      * ```
      * // Create an entry with a key/value set of data
-     * $entry = $logger->entry(
-     *     ['user' => 'calvin'],
-     *     [
-     *         'type' => 'gcs_bucket',
-     *         'labels' => [
-     *             'bucket_name' => 'my-bucket'
-     *         ]
-     *     ]
-     * );
+     * $entry = $logger->entry(['user' => 'calvin']);
      * ```
      *
      * ```
      * // Create an entry with a string
-     * $entry = $logger->entry('my message', [
-     *     'type' => 'gcs_bucket',
-     *     'labels' => [
-     *         'bucket_name' => 'my-bucket'
-     *     ]
-     * ]);
+     * $entry = $logger->entry('my message');
      * ```
      *
      * ```
-     * // Create an entry with a severity of `EMERGENCY`
-     * $entry = $logger->entry(
-     *     'my message',
-     *     [
+     * // Create an entry with a severity of `EMERGENCY` and specifying a resource.
+     * $entry = $logger->entry('my message', [
+     *     'severity' => Logger::EMERGENCY,
+     *     'resource' => [
      *         'type' => 'gcs_bucket',
      *         'labels' => [
      *             'bucket_name' => 'my-bucket'
      *         ]
-     *     ],
-     *     ['severity' => Logger::EMERGENCY]
-     * );
+     *     ]
+     * ]);
      * ```
      * @codingStandardsIgnoreStart
      * @see https://cloud.google.com/logging/docs/api/reference/rest/Shared.Types/LogEntry LogEntry resource documentation.
@@ -221,12 +223,12 @@ class Logger
      * @param array|string $data The data to log. When providing a string the
      *        data will be stored as a `textPayload` type. When providing an
      *        array the data will be stored as a `jsonPayload` type.
-     * @param array $resource The
-     *        [monitored resource](https://cloud.google.com/logging/docs/api/reference/rest/Shared.Types/MonitoredResource)
-     *        to associate this log entry with.
      * @param array $options [optional] {
      *     Configuration options.
      *
+     *     @type array $resource The
+     *           [monitored resource](https://cloud.google.com/logging/docs/api/reference/rest/Shared.Types/MonitoredResource)
+     *           to associate this log entry with. **Defaults to** type global.
      *     @type array $httpRequest Information about the HTTP request
      *           associated with this log entry, if applicable. Please see
      *           [the API docs](https://cloud.google.com/logging/docs/api/reference/rest/Shared.Types/LogEntry#httprequest)
@@ -241,9 +243,10 @@ class Logger
      *           `"DEFAULT"`.
      * }
      * @return Entry
+     * @throws \InvalidArgumentException
      * @codingStandardsIgnoreEnd
      */
-    public function entry($data, array $resource, array $options = [])
+    public function entry($data, array $options = [])
     {
         if (!is_array($data) && !is_string($data)) {
             throw new \InvalidArgumentException('$data must be either a string or an array.');
@@ -257,7 +260,9 @@ class Logger
 
         return new Entry($options + [
             'logName' => $this->formattedName,
-            'resource' => $resource
+            'resource' => [
+                'type' => 'global'
+            ]
         ]);
     }
 
@@ -266,6 +271,20 @@ class Logger
      *
      * Example:
      * ```
+     * // Writing a simple log entry.
+     * $logger->write('a log entry');
+     * ```
+     *
+     * ```
+     * // Writing a simple entry with a key/value set of data and a severity of `EMERGENCY`.
+     * $logger->write(['user' => 'calvin'], [
+     *     'severity' => Logger::EMERGENCY
+     * ]);
+     * ```
+     *
+     * ```
+     * // Using the entry factory method to write a log entry.
+     * $entry = $logger->entry('a log entry');
      * $logger->write($entry);
      * ```
      *
@@ -273,11 +292,26 @@ class Logger
      * @see https://cloud.google.com/logging/docs/api/reference/rest/v2/entries/write Entries write API documentation.
      * @codingStandardsIgnoreEnd
      *
-     * @param Entry $entry The entry to write to the log.
-     * @param array $options [optional] Configuration Options.
+     * @param array|string|Entry $entry The entry to write to the log.
+     * @param array $options [optional] Please see
+     *        {@see Google\Cloud\Logging\Logger::entry()} to see the options
+     *        that can be applied to a log entry. Please note that if the
+     *        provided entry is of type `Entry` these options will overwrite
+     *        those that may already be set on the instance.
+     * @throws \InvalidArgumentException
      */
-    public function write(Entry $entry, array $options = [])
+    public function write($entry, array $options = [])
     {
+        $entryOptions = $this->pluckArray($this->entryOptions, $options);
+
+        if ($entry instanceof Entry) {
+            if ($entryOptions) {
+                $entry = new Entry($entryOptions + $entry->info());
+            }
+        } else {
+            $entry = $this->entry($entry, $entryOptions);
+        }
+
         $this->writeBatch([$entry], $options);
     }
 
@@ -286,17 +320,9 @@ class Logger
      *
      * Example:
      * ```
-     * $resource = [
-     *     'type' => 'gcs_bucket',
-     *         'labels' => [
-     *             'bucket_name' => 'my-bucket'
-     *         ]
-     *     ]
-     * ];
-     *
      * $entries = [];
-     * $entries[] = $logger->entry('my message', $resource);
-     * $entries[] = $logger->entry('my second message', $resource);
+     * $entries[] = $logger->entry('my message');
+     * $entries[] = $logger->entry('my second message');
      *
      * $logger->writeBatch($entries);
      * ```
@@ -310,6 +336,8 @@ class Logger
      */
     public function writeBatch(array $entries, array $options = [])
     {
+        $this->validateBatch($entries, Entry::class);
+
         foreach ($entries as &$entry) {
             $entry = $entry->info();
         }

--- a/src/Logging/LoggingClient.php
+++ b/src/Logging/LoggingClient.php
@@ -392,26 +392,27 @@ class LoggingClient
      *
      * Example:
      * ```
-     * $psrLogger = $logging->psrLogger('my-log', [
-     *     'type' => 'gcs_bucket',
-     *     'labels' => [
-     *         'bucket_name' => 'my-bucket'
-     *     ]
-     * ]);
+     * $psrLogger = $logging->psrLogger('my-log');
      * $psrLogger->alert('an alert!');
      * ```
      *
      * @codingStandardsIgnoreStart
      * @param string $name The name of the log to write entries to.
-     * @param array $resource The
-     *        [monitored resource](https://cloud.google.com/logging/docs/api/reference/rest/Shared.Types/MonitoredResource)
-     *        to associate log entries with.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type array $resource The
+     *           [monitored resource](https://cloud.google.com/logging/docs/api/reference/rest/Shared.Types/MonitoredResource)
+     *           to associate log entries with. **Defaults to** type global.
+     *     @type array $labels A set of user-defined (key, value) data that
+     *           provides additional information about the log entry.
+     * }
      * @return PsrLogger
      * @codingStandardsIgnoreEnd
      */
-    public function psrLogger($name, array $resource)
+    public function psrLogger($name, array $options = [])
     {
-        return new PsrLogger($this->logger($name), $resource);
+        return new PsrLogger($this->logger($name, $options));
     }
 
     /**
@@ -420,20 +421,31 @@ class LoggingClient
      * Example:
      * ```
      * $logger = $logging->logger('my-log');
-     * $entry = $logger->entry('my-data', [
-     *     'type' => 'gcs_bucket',
-     *     'labels' => [
-     *         'bucket_name' => 'my-bucket'
-     *     ]
-     * ]);
-     * $logger->write($entry);
+     * $logger->write('my-data');
      * ```
      *
+     * @codingStandardsIgnoreStart
      * @param string $name The name of the log to write entries to.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type array $resource The
+     *           [monitored resource](https://cloud.google.com/logging/docs/api/reference/rest/Shared.Types/MonitoredResource)
+     *           to associate log entries with. **Defaults to** type global.
+     *     @type array $labels A set of user-defined (key, value) data that
+     *           provides additional information about the log entry.
+     * }
+     * @codingStandardsIgnoreEnd
      * @return Logger
      */
-    public function logger($name)
+    public function logger($name, array $options = [])
     {
-        return new Logger($this->connection, $name, $this->projectId);
+        return new Logger(
+            $this->connection,
+            $name,
+            $this->projectId,
+            isset($options['resource']) ? $options['resource'] : null,
+            isset($options['labels']) ? $options['labels'] : null
+        );
     }
 }

--- a/src/Logging/PsrLogger.php
+++ b/src/Logging/PsrLogger.php
@@ -47,22 +47,11 @@ class PsrLogger implements LoggerInterface
     private $logger;
 
     /**
-     * @var array A monitored resource.
-     */
-    private $resource;
-
-    /**
-     * @codingStandardsIgnoreStart
      * @param Logger $logger The logger used to write entries.
-     * @param array $resource [optional] The
-     *        [monitored resource](https://cloud.google.com/logging/docs/api/reference/rest/Shared.Types/MonitoredResource)
-     *        to associate log entries with. **Defaults to** type global.
-     * @codingStandardsIgnoreEnd
      */
-    public function __construct(Logger $logger, array $resource = ['type' => 'global'])
+    public function __construct(Logger $logger)
     {
         $this->logger = $logger;
-        $this->resource = $resource;
     }
 
     /**
@@ -215,6 +204,9 @@ class PsrLogger implements LoggerInterface
      * @param string|int $level The severity of the log entry.
      * @param string $message The message to log.
      * @param array $context {
+     *     @type array $resource The
+     *           [monitored resource](https://cloud.google.com/logging/docs/api/reference/rest/Shared.Types/MonitoredResource)
+     *           to associate this log entry with. **Defaults to** type global.
      *     @type array $httpRequest Information about the HTTP request
      *           associated with this log entry, if applicable. Please see
      *           [the API docs](https://cloud.google.com/logging/docs/api/reference/rest/Shared.Types/LogEntry#httprequest)
@@ -242,8 +234,7 @@ class PsrLogger implements LoggerInterface
         $entry = $this->logger->entry(
             $message,
             $context + [
-                'severity' => $level,
-                'resource' => $this->resource
+                'severity' => $level
             ]
         );
 

--- a/src/Logging/PsrLogger.php
+++ b/src/Logging/PsrLogger.php
@@ -54,12 +54,12 @@ class PsrLogger implements LoggerInterface
     /**
      * @codingStandardsIgnoreStart
      * @param Logger $logger The logger used to write entries.
-     * @param array $resource The
+     * @param array $resource [optional] The
      *        [monitored resource](https://cloud.google.com/logging/docs/api/reference/rest/Shared.Types/MonitoredResource)
-     *        to associate log entries with.
+     *        to associate log entries with. **Defaults to** type global.
      * @codingStandardsIgnoreEnd
      */
-    public function __construct(Logger $logger, array $resource)
+    public function __construct(Logger $logger, array $resource = ['type' => 'global'])
     {
         $this->logger = $logger;
         $this->resource = $resource;
@@ -241,8 +241,10 @@ class PsrLogger implements LoggerInterface
 
         $entry = $this->logger->entry(
             $message,
-            $this->resource,
-            $context + ['severity' => $level]
+            $context + [
+                'severity' => $level,
+                'resource' => $this->resource
+            ]
         );
 
         $this->logger->write($entry);

--- a/tests/system/Logging/WriteAndListEntryTest.php
+++ b/tests/system/Logging/WriteAndListEntryTest.php
@@ -223,9 +223,7 @@ class WriteAndListEntryTest extends LoggingTestCase
     private function assertPsrLoggerWrites($client, $level)
     {
         $logName = uniqid(self::TESTING_PREFIX);
-        $psrLogger = $client->psrLogger($logName, [
-            'type' => 'global'
-        ]);
+        $psrLogger = $client->psrLogger($logName);
         $logger = $client->logger($logName);
         self::$deletionQueue[] = $logger;
         $data = $level;

--- a/tests/system/Logging/WriteAndListEntryTest.php
+++ b/tests/system/Logging/WriteAndListEntryTest.php
@@ -29,9 +29,7 @@ class WriteAndListEntryTest extends LoggingTestCase
         $logger = $client->logger(uniqid(self::TESTING_PREFIX));
         self::$deletionQueue[] = $logger;
         $data = 'test';
-        $entry = $logger->entry($data, [
-            'type' => 'global'
-        ]);
+        $entry = $logger->entry($data);
 
         $logger->write($entry);
 
@@ -64,9 +62,7 @@ class WriteAndListEntryTest extends LoggingTestCase
             ]
         ];
 
-        $entry = $logger->entry($data, [
-            'type' => 'global'
-        ]);
+        $entry = $logger->entry($data);
 
         $logger->write($entry);
 
@@ -93,12 +89,8 @@ class WriteAndListEntryTest extends LoggingTestCase
         self::$deletionQueue[] = $logger;
         $data = 'test';
         $entriesToWrite = [
-            $logger->entry($data, [
-                'type' => 'global'
-            ]),
-            $logger->entry($data, [
-                'type' => 'global'
-            ])
+            $logger->entry($data),
+            $logger->entry($data)
         ];
 
         $logger->writeBatch($entriesToWrite);
@@ -136,7 +128,7 @@ class WriteAndListEntryTest extends LoggingTestCase
         ];
         $severity = 'INFO';
 
-        $entry = $logger->entry($data, ['type' => 'global'], [
+        $entry = $logger->entry($data, [
             'httpRequest' => $httpRequest,
             'labels' => $labels,
             'severity' => 200

--- a/tests/unit/Logging/LoggerTest.php
+++ b/tests/unit/Logging/LoggerTest.php
@@ -178,9 +178,34 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
             ->willReturn([])
             ->shouldBeCalledTimes(1);
         $logger = $this->getLogger($this->connection);
-        $entry = $logger->entry($this->textPayload, $this->resource);
 
-        $this->assertNull($logger->write($entry));
+        $this->assertNull($logger->write($this->textPayload, ['resource' => $this->resource]));
+    }
+
+    public function testOverwritesEntryOptionsAndWrites()
+    {
+        $severity = 'INFO';
+        $this->connection->writeEntries([
+            'entries' => [
+                [
+                    'textPayload' => $this->textPayload,
+                    'logName' => $this->formattedName,
+                    'resource' => $this->resource,
+                    'severity' => $severity
+                ]
+            ]
+        ])
+            ->willReturn([])
+            ->shouldBeCalledTimes(1);
+        $logger = $this->getLogger($this->connection);
+        $entry = $logger->entry($this->textPayload, [
+            'resource' => $this->resource,
+            'severity' => 'DEBUG' // this should be overwritten
+        ]);
+
+        $this->assertNull($logger->write($entry, [
+            'severity' => $severity
+        ]));
     }
 
     public function testWritesEntries()
@@ -202,8 +227,8 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
             ->willReturn([])
             ->shouldBeCalledTimes(1);
         $logger = $this->getLogger($this->connection);
-        $entry1 = $logger->entry($this->textPayload, $this->resource);
-        $entry2 = $logger->entry($this->jsonPayload, $this->resource);
+        $entry1 = $logger->entry($this->textPayload, ['resource' => $this->resource]);
+        $entry2 = $logger->entry($this->jsonPayload, ['resource' => $this->resource]);
 
         $this->assertNull($logger->writeBatch([$entry1, $entry2]));
     }

--- a/tests/unit/Logging/LoggingClientTest.php
+++ b/tests/unit/Logging/LoggingClientTest.php
@@ -263,7 +263,7 @@ class LoggingClientTest extends \PHPUnit_Framework_TestCase
     public function testGetsPsrLogger()
     {
         $this->client->setConnection($this->connection->reveal());
-        $this->assertInstanceOf(PsrLogger::class, $this->client->psrLogger('myLogger', ['type' => 'global']));
+        $this->assertInstanceOf(PsrLogger::class, $this->client->psrLogger('myLogger'));
     }
 
     public function testGetsLogger()


### PR DESCRIPTION
closes: https://github.com/GoogleCloudPlatform/google-cloud-php/issues/180

@bshaffer Curious about your thoughts on the approach of having `write` accept multiple types as opposed to `logText` and `logStruct` methods. Please let me know what you think :)