### PR TITLE
Logging: only lookup severity numeric value when dealing with a string

### DIFF
--- a/src/Logging/Connection/Grpc.php
+++ b/src/Logging/Connection/Grpc.php
@@ -321,7 +321,7 @@ class Grpc implements ConnectionInterface
             $entry['resource']['labels'] = $this->formatLabelsForApi($entry['resource']['labels']);
         }
 
-        if (isset($entry['severity'])) {
+        if (isset($entry['severity']) && is_string($entry['severity'])) {
             $entry['severity'] = array_flip(Logger::getLogLevelMap())[$entry['severity']];
         }
 


### PR DESCRIPTION
Addresses an issue with gRPC connections where logging a severity with a numeric value would throw an error.