### PR TITLE
Prepare v0.13.0

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -6,6 +6,7 @@
     "defaultService": "servicebuilder",
     "markdown": "php",
     "versions": [
+        "v0.13.0",
         "v0.12.0",
         "v0.11.1",
         "v0.11.0",

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -48,7 +48,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class ServiceBuilder
 {
-    const VERSION = '0.12.0';
+    const VERSION = '0.13.0';
 
     /**
      * @var array Configuration options to be used between clients.


### PR DESCRIPTION
# Google Cloud PHP v0.13.0

## What's New?

* Added new `analyzeSyntax` method to
  `Google\Cloud\NaturalLanguage\NaturalLanguageClient`. (#241)
* Google Translate now supports Service Account Credentials and Application
  Default Credentials. This means that you no longer need to manage a separate
  API key to authenticate Google Translate. API keys are still supported. (#240)

## What's Fixed?

* Fixed a bug in Google Cloud Logging when using the gRPC transport. (#243)