### PR TITLE
RFC: Project ID Detection

### DIFF
--- a/src/AppEngine/AppIdentity.php
+++ b/src/AppEngine/AppIdentity.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Google\Cloud\AppEngine;
+
+/*
+ * The AppIdentityS class is automatically defined on App Engine,
+ * so including this dependency is not necessary, and will result in a
+ * PHP fatal error in the App Engine environment.
+ */
+use google\appengine\api\app_identity\AppIdentityService;
+
+/**
+ * A wrapper for the AppEngine AppIdentity service
+ * This class will only work when running on AppEngine, or
+ * if the App Engine SDK is available.
+ *
+ * ```
+ * use Google\Cloud\AppEngine\AppIdentity;
+ *
+ * $appIdentity = new AppIdentity();
+ * $projectId = $identity->getApplicationId();
+ * ```
+ */
+class AppIdentity
+{
+    /**
+     * Get the current application ID from the App Identity Service
+     *
+     * Example:
+     * ```
+     * $projectId = $appIdentity->getApplicationId();
+     * ```
+     *
+     * @return string
+     */
+    public function getApplicationId()
+    {
+        if (!class_exists('google\appengine\api\app_identity\AppIdentityService')) {
+            throw new \Exception('This class must be run in App Engine');
+        }
+
+        return AppIdentityService::getApplicationId();
+    }
+}

--- a/src/DetectProjectTrait.php
+++ b/src/DetectProjectTrait.php
@@ -1,0 +1,182 @@
+<?php
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud;
+
+use Google\Auth\Credentials\AppIdentityCredentials;
+use Google\Auth\Credentials\GCECredentials;
+use Google\Auth\CredentialsLoader;
+use Google\Cloud\AppEngine\AppIdentity;
+use Google\Cloud\Compute\Metadata;
+
+/**
+ * DetectProjectTrait contains the behaviour used to locate and find the
+ * default project
+ */
+trait DetectProjectTrait
+{
+    /**
+     * Return a project ID from the GCLOUD_PROJECT environment variable
+     * This is available in App Engine Flexible.
+     *
+     * @return string|null $projectId
+     */
+    protected function projectFromEnvVar()
+    {
+        return getenv($this->getEnvVar());
+    }
+
+    /**
+     * Return a project ID from App Engine.
+     *
+     * @return string|null $projectId
+     */
+    private function projectFromAppEngine()
+    {
+        if ($this->onAppEngine()) {
+            $appIdentity = $this->getAppIdentity();
+            $projectId = $appIdentity->getApplicationId();
+            if ($projectId) {
+                return $projectId;
+            }
+        }
+    }
+
+    /**
+     * Return a project ID from GCE.
+     *
+     * @return string|null $projectId
+     */
+    private function projectFromGce($httpHandler = null)
+    {
+        if ($this->onGce($httpHandler)) {
+            $metadata = $this->getMetaData();
+            $projectId = $metadata->getProjectId();
+            if ($projectId) {
+                return $projectId;
+            }
+        }
+    }
+
+    /**
+     * The gcloud config path is OS dependent:
+     * - windows: %APPDATA%/gcloud/configurations/config_default
+     * - others: $HOME/.config/gcloud/configurations/config_default
+     *
+     * If the file does not exists, this returns null.
+     *
+     * @return string|null $projectId
+     */
+    private function projectFromGcloudConfig()
+    {
+        $path = $this->pathToGcloudConfig();
+        if (!file_exists($path)) {
+            return;
+        }
+        $configDefault = parse_ini_file($path, true);
+        if (isset($configDefault['core']['project'])) {
+            return $configDefault['core']['project'];
+        }
+    }
+
+    /**
+     * Determine the path to the gcloud configuration path
+     *
+     * @codeCoverageIgnore
+     * @return bool
+     */
+    protected function pathToGcloudConfig()
+    {
+        if ($this->onWindows()) {
+            $path = [getenv('APPDATA')];
+        } else {
+            $path = [
+                getenv('HOME'),
+                CredentialsLoader::NON_WINDOWS_WELL_KNOWN_PATH_BASE
+            ];
+        }
+        $path[] = 'gcloud/configurations/config_default';
+        return implode(DIRECTORY_SEPARATOR, $path);
+    }
+
+    /**
+     * Abstract the CredentialsLoader call so we can mock it in the unit tests!
+     *
+     * @codeCoverageIgnore
+     * @return bool
+     */
+    protected function onWindows()
+    {
+        return CredentialsLoader::isOnWindows();
+    }
+
+    /**
+     * Abstract the AppIdentity call so we can mock it in the unit tests!
+     *
+     * @codeCoverageIgnore
+     * @return bool
+     */
+    protected function onAppEngine()
+    {
+        return AppIdentityCredentials::onAppEngine() &&
+            !GCECredentials::onAppEngineFlexible();
+    }
+
+    /**
+     * Abstract the AppIdentity instantiation for unit testing
+     *
+     * @codeCoverageIgnore
+     * @return Metadata
+     */
+    protected function getAppIdentity()
+    {
+        return new AppIdentity;
+    }
+
+    /**
+     * Abstract the GCECredentials call so we can mock it in the unit tests!
+     *
+     * @codeCoverageIgnore
+     * @return bool
+     */
+    protected function onGce($httpHandler)
+    {
+        return GCECredentials::onGce($httpHandler);
+    }
+
+    /**
+     * Abstract the Metadata instantiation for unit testing
+     *
+     * @codeCoverageIgnore
+     * @return Metadata
+     */
+    protected function getMetaData()
+    {
+        return new Metadata;
+    }
+
+    /**
+     * Abstract the Environment Variable name for unit testing
+     *
+     * @codeCoverageIgnore
+     * @return string
+     */
+    protected function getEnvVar()
+    {
+        return 'GCLOUD_PROJECT';
+    }
+}

--- a/tests/unit/DetectProjectTrait.php
+++ b/tests/unit/DetectProjectTrait.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests;
+
+use Google\Cloud\AppEngine\AppIdentity;
+use Google\Cloud\Compute\Metadata;
+use Google\Cloud\DetectProjectTrait;
+
+/**
+ * @group root
+ */
+class DetectProjectTraitTest extends \PHPUnit_Framework_TestCase
+{
+    public function testPathToGcloudConfig()
+    {
+        $configPath = getenv('HOME') . '/.config/gcloud/configurations/config_default';
+
+        $trait = new DetectProjectTraitStub();
+
+        $res = $trait->runPathToGcloudConfig();
+
+        $this->assertEquals($res, $configPath);
+    }
+
+    public function testPathToGcloudConfigOnWindows()
+    {
+        $configPath = 'test/gcloud/configurations/config_default';
+
+        $trait = new DetectProjectTraitStubOnWindows();
+
+        putenv('APPDATA=' . 'test');
+
+        $res = $trait->runPathToGcloudConfig();
+
+        putenv('APPDATA');
+
+        $this->assertEquals($res, $configPath);
+    }
+
+
+    public function testDetectProjectIdOnGce()
+    {
+        $projectId = 'gce-project-rawks';
+
+        $m = $this->prophesize(Metadata::class);
+        $m->getProjectId()->willReturn($projectId)->shouldBeCalled();
+
+        $trait = new DetectProjectTraitStubOnGce($m);
+
+        $res = $trait->runProjectFromGce([]);
+
+        $this->assertEquals($res, $projectId);
+    }
+
+    public function testDetectProjectIdOnAppEngine()
+    {
+        $projectId = 'appengine-project-rawks';
+
+        $m = $this->prophesize(AppIdentity::class);
+        $m->getApplicationId()->willReturn($projectId)->shouldBeCalled();
+
+        $trait = new DetectProjectTraitStubOnAppEngine($m);
+
+        $res = $trait->runProjectFromAppEngine();
+
+        $this->assertEquals($res, $projectId);
+    }
+
+    public function testDetectProjectIdWithEnvVar()
+    {
+        $projectId = 'appengineflex-project-rawks';
+
+        // set a test environment variable
+        putenv('GOOGLE_DETECT_PROJECT_TEST_PROJECT_ID=' . $projectId);
+
+        $trait = new DetectProjectTraitStubWithEnvVar();
+
+        $res = $trait->runProjectFromEnvVar();
+
+        // remove the environment variable
+        putenv('GOOGLE_DETECT_PROJECT_TEST_PROJECT_ID');
+
+        $this->assertEquals($res, $projectId);
+    }
+
+    public function testDetectProjectIdWithGcloudConfig()
+    {
+        $projectId = 'gcloud-project-rawks';
+
+        $configPath = __DIR__ . '/fixtures/config_default_fixture';
+
+        $trait = new DetectProjectTraitStubWithGcloudConfig($configPath);
+
+        $res = $trait->runProjectFromGcloudConfig();
+
+        $this->assertEquals($res, $projectId);
+    }
+}
+
+class DetectProjectTraitStub
+{
+    use DetectProjectTrait;
+
+    public function runPathToGcloudConfig()
+    {
+        return $this->pathToGcloudConfig();
+    }
+
+    public function runProjectFromEnvVar()
+    {
+        return $this->projectFromEnvVar();
+    }
+
+    public function runProjectFromGce()
+    {
+        return $this->projectFromGce();
+    }
+
+    public function runProjectFromAppEngine()
+    {
+        return $this->projectFromAppEngine();
+    }
+
+    public function runProjectFromGcloudConfig()
+    {
+        return $this->projectFromGcloudConfig();
+    }
+}
+
+class DetectProjectTraitStubOnWindows extends DetectProjectTraitStub
+{
+    use DetectProjectTrait;
+
+    public function onWindows()
+    {
+        return true;
+    }
+}
+
+class DetectProjectTraitStubWithEnvVar extends DetectProjectTraitStub
+{
+    use DetectProjectTrait;
+
+    protected function getEnvVar()
+    {
+        return 'GOOGLE_DETECT_PROJECT_TEST_PROJECT_ID';
+    }
+}
+
+class DetectProjectTraitStubOnAppEngine extends DetectProjectTraitStub
+{
+    use DetectProjectTrait;
+
+    private $appIdentity;
+
+    public function __construct($appIdentity)
+    {
+        $this->appIdentity = $appIdentity;
+    }
+
+    protected function onAppEngine()
+    {
+        return true;
+    }
+
+    protected function getAppIdentity()
+    {
+        return $this->appIdentity->reveal();
+    }
+}
+
+class DetectProjectTraitStubOnGce extends DetectProjectTraitStub
+{
+    use DetectProjectTrait;
+
+    private $metadata;
+
+    public function __construct($metadata)
+    {
+        $this->metadata = $metadata;
+    }
+
+    protected function onGce($httpHandler)
+    {
+        return true;
+    }
+
+    protected function getMetadata()
+    {
+        return $this->metadata->reveal();
+    }
+}
+
+class DetectProjectTraitStubWithGcloudConfig extends DetectProjectTraitStub
+{
+    use DetectProjectTrait;
+
+    private $configPath;
+
+    public function __construct($configPath)
+    {
+        $this->configPath = $configPath;
+    }
+
+    protected function pathToGcloudConfig()
+    {
+        return $this->configPath;
+    }
+}
+
+class DetectProjectTraitStubGrpcDependencyChecks extends DetectProjectTraitStub
+{
+    use DetectProjectTrait;
+
+    private $dependencyStatus;
+
+    public function __construct(array $dependencyStatus)
+    {
+        $this->dependencyStatus = $dependencyStatus;
+    }
+
+    protected function getGrpcDependencyStatus()
+    {
+        return $this->dependencyStatus;
+    }
+}

--- a/tests/unit/fixtures/config_default_fixture
+++ b/tests/unit/fixtures/config_default_fixture
@@ -1,0 +1,2 @@
+[core]
+project = gcloud-project-rawks


### PR DESCRIPTION
Adds Project ID Detection in this order:
 - Project ID from Application Default Credentials
 - Project ID from GCLOUD_CONFIG environment variable
 - Project ID from App Engine AppIdentity service
 - Project ID from Compute Engine metadata server
 - Project ID from gcloud default config file

As "Project ID" is only used for API calls to Google Cloud Platform, it makes more sense to put this in `google/cloud` as opposed to `google/auth`