### PR TITLE
Regenerate logging, bump proto-client-php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "james-heinrich/getid3": "^1.9",
         "erusev/parsedown": "^1.6",
         "vierbergenlars/php-semver": "^3.0",
-        "google/proto-client-php": "^0.5",
+        "google/proto-client-php": "^0.6",
         "google/gax": "^0.3"
     },
     "suggest": {

--- a/src/Logging/Connection/Grpc.php
+++ b/src/Logging/Connection/Grpc.php
@@ -19,9 +19,9 @@ namespace Google\Cloud\Logging\Connection;
 
 use DrSlump\Protobuf\Codec\CodecInterface;
 use Google\Cloud\Logging\Logger;
-use Google\Cloud\Logging\V2\ConfigServiceV2Api;
-use Google\Cloud\Logging\V2\LoggingServiceV2Api;
-use Google\Cloud\Logging\V2\MetricsServiceV2Api;
+use Google\Cloud\Logging\V2\ConfigServiceV2Client;
+use Google\Cloud\Logging\V2\LoggingServiceV2Client;
+use Google\Cloud\Logging\V2\MetricsServiceV2Client;
 use Google\Cloud\PhpArray;
 use Google\Cloud\GrpcRequestWrapper;
 use Google\Cloud\GrpcTrait;
@@ -45,19 +45,19 @@ class Grpc implements ConnectionInterface
     ];
 
     /**
-     * @var ConfigServiceV2API
+     * @var ConfigServiceV2Client
      */
-    private $configApi;
+    private $configClient;
 
     /**
-     * @var LoggingServiceV2Api
+     * @var LoggingServiceV2Client
      */
-    private $loggingApi;
+    private $loggingClient;
 
     /**
-     * @var MetricsServiceV2Api
+     * @var MetricsServiceV2Client
      */
-    private $metricsApi;
+    private $metricsClient;
 
     /**
      * @var CodecInterface
@@ -90,7 +90,7 @@ class Grpc implements ConnectionInterface
     {
         $this->codec = new PhpArray([
             'timestamp' => function ($v) {
-                return $this->formatTimestampFromApi($v);
+                return $this->formatTimestampFromClient($v);
             },
             'severity' => function ($v) {
                 return Logger::getLogLevelMap()[$v];
@@ -103,9 +103,9 @@ class Grpc implements ConnectionInterface
         $this->setRequestWrapper(new GrpcRequestWrapper($config));
         $gaxConfig = $this->getGaxConfig();
 
-        $this->configApi = new ConfigServiceV2Api($gaxConfig);
-        $this->loggingApi = new LoggingServiceV2Api($gaxConfig);
-        $this->metricsApi = new MetricsServiceV2Api($gaxConfig);
+        $this->configClient = new ConfigServiceV2Client($gaxConfig);
+        $this->loggingClient = new LoggingServiceV2Client($gaxConfig);
+        $this->metricsClient = new MetricsServiceV2Client($gaxConfig);
     }
 
     /**
@@ -121,7 +121,7 @@ class Grpc implements ConnectionInterface
             $pbEntries[] = $this->buildEntry($entry);
         }
 
-        return $this->send([$this->loggingApi, 'writeLogEntries'], [
+        return $this->send([$this->loggingClient, 'writeLogEntries'], [
             $pbEntries,
             $args
         ]);
@@ -133,7 +133,7 @@ class Grpc implements ConnectionInterface
      */
     public function listEntries(array $args = [])
     {
-        return $this->send([$this->loggingApi, 'listLogEntries'], [
+        return $this->send([$this->loggingClient, 'listLogEntries'], [
             $this->pluck('resourceNames', $args),
             $args
         ]);
@@ -154,7 +154,7 @@ class Grpc implements ConnectionInterface
             $this->codec
         );
 
-        return $this->send([$this->configApi, 'createSink'], [
+        return $this->send([$this->configClient, 'createSink'], [
             $this->pluck('parent', $args),
             $pbSink,
             $args
@@ -167,7 +167,7 @@ class Grpc implements ConnectionInterface
      */
     public function getSink(array $args = [])
     {
-        return $this->send([$this->configApi, 'getSink'], [
+        return $this->send([$this->configClient, 'getSink'], [
             $this->pluck('sinkName', $args),
             $args
         ]);
@@ -179,7 +179,7 @@ class Grpc implements ConnectionInterface
      */
     public function listSinks(array $args = [])
     {
-        return $this->send([$this->configApi, 'listSinks'], [
+        return $this->send([$this->configClient, 'listSinks'], [
             $this->pluck('parent', $args),
             $args
         ]);
@@ -200,7 +200,7 @@ class Grpc implements ConnectionInterface
             $this->codec
         );
 
-        return $this->send([$this->configApi, 'updateSink'], [
+        return $this->send([$this->configClient, 'updateSink'], [
             $this->pluck('sinkName', $args),
             $pbSink,
             $args
@@ -213,7 +213,7 @@ class Grpc implements ConnectionInterface
      */
     public function deleteSink(array $args = [])
     {
-        return $this->send([$this->configApi, 'deleteSink'], [
+        return $this->send([$this->configClient, 'deleteSink'], [
             $this->pluck('sinkName', $args),
             $args
         ]);
@@ -230,7 +230,7 @@ class Grpc implements ConnectionInterface
             $this->codec
         );
 
-        return $this->send([$this->metricsApi, 'createLogMetric'], [
+        return $this->send([$this->metricsClient, 'createLogMetric'], [
             $this->pluck('parent', $args),
             $pbMetric,
             $args
@@ -243,7 +243,7 @@ class Grpc implements ConnectionInterface
      */
     public function getMetric(array $args = [])
     {
-        return $this->send([$this->metricsApi, 'getLogMetric'], [
+        return $this->send([$this->metricsClient, 'getLogMetric'], [
             $this->pluck('metricName', $args),
             $args
         ]);
@@ -255,7 +255,7 @@ class Grpc implements ConnectionInterface
      */
     public function listMetrics(array $args = [])
     {
-        return $this->send([$this->metricsApi, 'listLogMetrics'], [
+        return $this->send([$this->metricsClient, 'listLogMetrics'], [
             $this->pluck('parent', $args),
             $args
         ]);
@@ -272,7 +272,7 @@ class Grpc implements ConnectionInterface
             $this->codec
         );
 
-        return $this->send([$this->metricsApi, 'updateLogMetric'], [
+        return $this->send([$this->metricsClient, 'updateLogMetric'], [
             $this->pluck('metricName', $args),
             $pbMetric,
             $args
@@ -285,7 +285,7 @@ class Grpc implements ConnectionInterface
      */
     public function deleteMetric(array $args = [])
     {
-        return $this->send([$this->metricsApi, 'deleteLogMetric'], [
+        return $this->send([$this->metricsClient, 'deleteLogMetric'], [
             $this->pluck('metricName', $args),
             $args
         ]);
@@ -297,7 +297,7 @@ class Grpc implements ConnectionInterface
      */
     public function deleteLog(array $args = [])
     {
-        return $this->send([$this->loggingApi, 'deleteLog'], [
+        return $this->send([$this->loggingClient, 'deleteLog'], [
             $this->pluck('logName', $args),
             $args
         ]);

--- a/src/Logging/Connection/Grpc.php
+++ b/src/Logging/Connection/Grpc.php
@@ -90,7 +90,7 @@ class Grpc implements ConnectionInterface
     {
         $this->codec = new PhpArray([
             'timestamp' => function ($v) {
-                return $this->formatTimestampFromClient($v);
+                return $this->formatTimestampFromApi($v);
             },
             'severity' => function ($v) {
                 return Logger::getLogLevelMap()[$v];

--- a/src/Logging/V2/ConfigServiceV2Client.php
+++ b/src/Logging/V2/ConfigServiceV2Client.php
@@ -29,6 +29,7 @@ use Google\GAX\GrpcConstants;
 use Google\GAX\GrpcCredentialsHelper;
 use Google\GAX\PageStreamingDescriptor;
 use Google\GAX\PathTemplate;
+use google\logging\v2\ConfigServiceV2Client as ConfigServiceV2GrpcClient;
 use google\logging\v2\CreateSinkRequest;
 use google\logging\v2\DeleteSinkRequest;
 use google\logging\v2\GetSinkRequest;
@@ -273,7 +274,7 @@ class ConfigServiceV2Client
         $this->grpcCredentialsHelper = new GrpcCredentialsHelper($this->scopes, $grpcCredentialsHelperOptions);
 
         $createConfigServiceV2StubFunction = function ($hostname, $opts) {
-            return new \google\logging\v2\ConfigServiceV2Client($hostname, $opts);
+            return new ConfigServiceV2GrpcClient($hostname, $opts);
         };
         $this->configServiceV2Stub = $this->grpcCredentialsHelper->createStub(
             $createConfigServiceV2StubFunction,

--- a/src/Logging/V2/ConfigServiceV2Client.php
+++ b/src/Logging/V2/ConfigServiceV2Client.php
@@ -16,7 +16,7 @@
 /*
  * GENERATED CODE WARNING
  * This file was generated from the file
- * https://github.com/google/googleapis/blob/master/google/logging/v2/logging_metrics.proto
+ * https://github.com/google/googleapis/blob/master/google/logging/v2/logging_config.proto
  * and updates to that file get reflected here through a refresh process.
  */
 
@@ -29,30 +29,30 @@ use Google\GAX\GrpcConstants;
 use Google\GAX\GrpcCredentialsHelper;
 use Google\GAX\PageStreamingDescriptor;
 use Google\GAX\PathTemplate;
-use google\logging\v2\CreateLogMetricRequest;
-use google\logging\v2\DeleteLogMetricRequest;
-use google\logging\v2\GetLogMetricRequest;
-use google\logging\v2\ListLogMetricsRequest;
-use google\logging\v2\LogMetric;
-use google\logging\v2\MetricsServiceV2Client;
-use google\logging\v2\UpdateLogMetricRequest;
+use google\logging\v2\CreateSinkRequest;
+use google\logging\v2\DeleteSinkRequest;
+use google\logging\v2\GetSinkRequest;
+use google\logging\v2\ListSinksRequest;
+use google\logging\v2\LogSink;
+use google\logging\v2\UpdateSinkRequest;
 
 /**
- * Service Description: Service for configuring logs-based metrics.
+ * Service Description: Service for configuring sinks used to export log entries outside of
+ * Stackdriver Logging.
  *
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods. Sample code to get started:
  *
  * ```
  * try {
- *     $metricsServiceV2Api = new MetricsServiceV2Api();
- *     $formattedParent = MetricsServiceV2Api::formatParentName("[PROJECT]");
- *     foreach ($metricsServiceV2Api->listLogMetrics($formattedParent) as $element) {
+ *     $configServiceV2Client = new ConfigServiceV2Client();
+ *     $formattedParent = ConfigServiceV2Client::formatParentName("[PROJECT]");
+ *     foreach ($configServiceV2Client->listSinks($formattedParent) as $element) {
  *         // doThingsWith(element);
  *     }
  * } finally {
- *     if (isset($metricsServiceV2Api)) {
- *         $metricsServiceV2Api->close();
+ *     if (isset($configServiceV2Client)) {
+ *         $configServiceV2Client->close();
  *     }
  * }
  * ```
@@ -62,7 +62,7 @@ use google\logging\v2\UpdateLogMetricRequest;
  * a parse method to extract the individual identifiers contained within names that are
  * returned.
  */
-class MetricsServiceV2Api
+class ConfigServiceV2Client
 {
     /**
      * The default address of the service.
@@ -84,10 +84,10 @@ class MetricsServiceV2Api
     const _CODEGEN_VERSION = '0.0.0';
 
     private static $parentNameTemplate;
-    private static $metricNameTemplate;
+    private static $sinkNameTemplate;
 
     private $grpcCredentialsHelper;
-    private $metricsServiceV2Stub;
+    private $configServiceV2Stub;
     private $scopes;
     private $defaultCallSettings;
     private $descriptors;
@@ -105,13 +105,13 @@ class MetricsServiceV2Api
 
     /**
      * Formats a string containing the fully-qualified path to represent
-     * a metric resource.
+     * a sink resource.
      */
-    public static function formatMetricName($project, $metric)
+    public static function formatSinkName($project, $sink)
     {
-        return self::getMetricNameTemplate()->render([
+        return self::getSinkNameTemplate()->render([
             'project' => $project,
-            'metric' => $metric,
+            'sink' => $sink,
         ]);
     }
 
@@ -126,20 +126,20 @@ class MetricsServiceV2Api
 
     /**
      * Parses the project from the given fully-qualified path which
-     * represents a metric resource.
+     * represents a sink resource.
      */
-    public static function parseProjectFromMetricName($metricName)
+    public static function parseProjectFromSinkName($sinkName)
     {
-        return self::getMetricNameTemplate()->match($metricName)['project'];
+        return self::getSinkNameTemplate()->match($sinkName)['project'];
     }
 
     /**
-     * Parses the metric from the given fully-qualified path which
-     * represents a metric resource.
+     * Parses the sink from the given fully-qualified path which
+     * represents a sink resource.
      */
-    public static function parseMetricFromMetricName($metricName)
+    public static function parseSinkFromSinkName($sinkName)
     {
-        return self::getMetricNameTemplate()->match($metricName)['metric'];
+        return self::getSinkNameTemplate()->match($sinkName)['sink'];
     }
 
     private static function getParentNameTemplate()
@@ -151,27 +151,27 @@ class MetricsServiceV2Api
         return self::$parentNameTemplate;
     }
 
-    private static function getMetricNameTemplate()
+    private static function getSinkNameTemplate()
     {
-        if (self::$metricNameTemplate == null) {
-            self::$metricNameTemplate = new PathTemplate('projects/{project}/metrics/{metric}');
+        if (self::$sinkNameTemplate == null) {
+            self::$sinkNameTemplate = new PathTemplate('projects/{project}/sinks/{sink}');
         }
 
-        return self::$metricNameTemplate;
+        return self::$sinkNameTemplate;
     }
 
     private static function getPageStreamingDescriptors()
     {
-        $listLogMetricsPageStreamingDescriptor =
+        $listSinksPageStreamingDescriptor =
                 new PageStreamingDescriptor([
                     'requestPageTokenField' => 'page_token',
                     'requestPageSizeField' => 'page_size',
                     'responsePageTokenField' => 'next_page_token',
-                    'resourceField' => 'metrics',
+                    'resourceField' => 'sinks',
                 ]);
 
         $pageStreamingDescriptors = [
-            'listLogMetrics' => $listLogMetricsPageStreamingDescriptor,
+            'listSinks' => $listSinksPageStreamingDescriptor,
         ];
 
         return $pageStreamingDescriptors;
@@ -227,7 +227,6 @@ class MetricsServiceV2Api
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
             'appName' => 'gax',
             'appVersion' => self::_GAX_VERSION,
-            'credentialsLoader' => null,
         ];
         $options = array_merge($defaultOptions, $options);
 
@@ -242,22 +241,22 @@ class MetricsServiceV2Api
 
         $defaultDescriptors = ['headerDescriptor' => $headerDescriptor];
         $this->descriptors = [
-            'listLogMetrics' => $defaultDescriptors,
-            'getLogMetric' => $defaultDescriptors,
-            'createLogMetric' => $defaultDescriptors,
-            'updateLogMetric' => $defaultDescriptors,
-            'deleteLogMetric' => $defaultDescriptors,
+            'listSinks' => $defaultDescriptors,
+            'getSink' => $defaultDescriptors,
+            'createSink' => $defaultDescriptors,
+            'updateSink' => $defaultDescriptors,
+            'deleteSink' => $defaultDescriptors,
         ];
         $pageStreamingDescriptors = self::getPageStreamingDescriptors();
         foreach ($pageStreamingDescriptors as $method => $pageStreamingDescriptor) {
             $this->descriptors[$method]['pageStreamingDescriptor'] = $pageStreamingDescriptor;
         }
 
-        $clientConfigJsonString = file_get_contents(__DIR__.'/resources/metrics_service_v2_client_config.json');
+        $clientConfigJsonString = file_get_contents(__DIR__.'/resources/config_service_v2_client_config.json');
         $clientConfig = json_decode($clientConfigJsonString, true);
         $this->defaultCallSettings =
                 CallSettings::load(
-                    'google.logging.v2.MetricsServiceV2',
+                    'google.logging.v2.ConfigServiceV2',
                     $clientConfig,
                     $options['retryingOverride'],
                     GrpcConstants::getStatusCodeNames(),
@@ -267,17 +266,17 @@ class MetricsServiceV2Api
         $this->scopes = $options['scopes'];
 
         $createStubOptions = [];
-        if (!empty($options['sslCreds'])) {
+        if (array_key_exists('sslCreds', $options)) {
             $createStubOptions['sslCreds'] = $options['sslCreds'];
         }
         $grpcCredentialsHelperOptions = array_diff_key($options, $defaultOptions);
         $this->grpcCredentialsHelper = new GrpcCredentialsHelper($this->scopes, $grpcCredentialsHelperOptions);
 
-        $createMetricsServiceV2StubFunction = function ($hostname, $opts) {
-            return new MetricsServiceV2Client($hostname, $opts);
+        $createConfigServiceV2StubFunction = function ($hostname, $opts) {
+            return new \google\logging\v2\ConfigServiceV2Client($hostname, $opts);
         };
-        $this->metricsServiceV2Stub = $this->grpcCredentialsHelper->createStub(
-            $createMetricsServiceV2StubFunction,
+        $this->configServiceV2Stub = $this->grpcCredentialsHelper->createStub(
+            $createConfigServiceV2StubFunction,
             $options['serviceAddress'],
             $options['port'],
             $createStubOptions
@@ -285,27 +284,29 @@ class MetricsServiceV2Api
     }
 
     /**
-     * Lists logs-based metrics.
+     * Lists sinks.
      *
      * Sample code:
      * ```
      * try {
-     *     $metricsServiceV2Api = new MetricsServiceV2Api();
-     *     $formattedParent = MetricsServiceV2Api::formatParentName("[PROJECT]");
-     *     foreach ($metricsServiceV2Api->listLogMetrics($formattedParent) as $element) {
+     *     $configServiceV2Client = new ConfigServiceV2Client();
+     *     $formattedParent = ConfigServiceV2Client::formatParentName("[PROJECT]");
+     *     foreach ($configServiceV2Client->listSinks($formattedParent) as $element) {
      *         // doThingsWith(element);
      *     }
      * } finally {
-     *     if (isset($metricsServiceV2Api)) {
-     *         $metricsServiceV2Api->close();
+     *     if (isset($configServiceV2Client)) {
+     *         $configServiceV2Client->close();
      *     }
      * }
      * ```
      *
-     * @param string $parent       Required. The resource name containing the metrics.
-     *                             Example: `"projects/my-project-id"`.
-     * @param array  $optionalArgs {
-     *                             Optional.
+     * @param string $parent Required. The resource name where this sink was created:
+     *
+     *     "projects/[PROJECT_ID]"
+     *     "organizations/[ORGANIZATION_ID]"
+     * @param array $optionalArgs {
+     *                            Optional.
      *
      *     @type string $pageToken
      *          A page token is used to specify a page of values to be returned.
@@ -316,7 +317,7 @@ class MetricsServiceV2Api
      *          The maximum number of resources contained in the underlying API
      *          response. The API may return fewer values in a page, even if
      *          there are additional values to be retrieved.
-     *     @type Google\GAX\RetrySettings $retrySettings
+     *     @type \Google\GAX\RetrySettings $retrySettings
      *          Retry settings to use for this call. If present, then
      *          $timeoutMillis is ignored.
      *     @type int $timeoutMillis
@@ -324,13 +325,13 @@ class MetricsServiceV2Api
      *          is not set.
      * }
      *
-     * @return Google\GAX\PagedListResponse
+     * @return \Google\GAX\PagedListResponse
      *
-     * @throws Google\GAX\ApiException if the remote call fails
+     * @throws \Google\GAX\ApiException if the remote call fails
      */
-    public function listLogMetrics($parent, $optionalArgs = [])
+    public function listSinks($parent, $optionalArgs = [])
     {
-        $request = new ListLogMetricsRequest();
+        $request = new ListSinksRequest();
         $request->setParent($parent);
         if (isset($optionalArgs['pageToken'])) {
             $request->setPageToken($optionalArgs['pageToken']);
@@ -339,14 +340,14 @@ class MetricsServiceV2Api
             $request->setPageSize($optionalArgs['pageSize']);
         }
 
-        $mergedSettings = $this->defaultCallSettings['listLogMetrics']->merge(
+        $mergedSettings = $this->defaultCallSettings['listSinks']->merge(
             new CallSettings($optionalArgs)
         );
         $callable = ApiCallable::createApiCall(
-            $this->metricsServiceV2Stub,
-            'ListLogMetrics',
+            $this->configServiceV2Stub,
+            'ListSinks',
             $mergedSettings,
-            $this->descriptors['listLogMetrics']
+            $this->descriptors['listSinks']
         );
 
         return $callable(
@@ -356,27 +357,29 @@ class MetricsServiceV2Api
     }
 
     /**
-     * Gets a logs-based metric.
+     * Gets a sink.
      *
      * Sample code:
      * ```
      * try {
-     *     $metricsServiceV2Api = new MetricsServiceV2Api();
-     *     $formattedMetricName = MetricsServiceV2Api::formatMetricName("[PROJECT]", "[METRIC]");
-     *     $response = $metricsServiceV2Api->getLogMetric($formattedMetricName);
+     *     $configServiceV2Client = new ConfigServiceV2Client();
+     *     $formattedSinkName = ConfigServiceV2Client::formatSinkName("[PROJECT]", "[SINK]");
+     *     $response = $configServiceV2Client->getSink($formattedSinkName);
      * } finally {
-     *     if (isset($metricsServiceV2Api)) {
-     *         $metricsServiceV2Api->close();
+     *     if (isset($configServiceV2Client)) {
+     *         $configServiceV2Client->close();
      *     }
      * }
      * ```
      *
-     * @param string $metricName   The resource name of the desired metric.
-     *                             Example: `"projects/my-project-id/metrics/my-metric-id"`.
-     * @param array  $optionalArgs {
-     *                             Optional.
+     * @param string $sinkName Required. The resource name of the sink to return:
      *
-     *     @type Google\GAX\RetrySettings $retrySettings
+     *     "projects/[PROJECT_ID]/sinks/[SINK_ID]"
+     *     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
+     * @param array $optionalArgs {
+     *                            Optional.
+     *
+     *     @type \Google\GAX\RetrySettings $retrySettings
      *          Retry settings to use for this call. If present, then
      *          $timeoutMillis is ignored.
      *     @type int $timeoutMillis
@@ -384,23 +387,23 @@ class MetricsServiceV2Api
      *          is not set.
      * }
      *
-     * @return google\logging\v2\LogMetric
+     * @return \google\logging\v2\LogSink
      *
-     * @throws Google\GAX\ApiException if the remote call fails
+     * @throws \Google\GAX\ApiException if the remote call fails
      */
-    public function getLogMetric($metricName, $optionalArgs = [])
+    public function getSink($sinkName, $optionalArgs = [])
     {
-        $request = new GetLogMetricRequest();
-        $request->setMetricName($metricName);
+        $request = new GetSinkRequest();
+        $request->setSinkName($sinkName);
 
-        $mergedSettings = $this->defaultCallSettings['getLogMetric']->merge(
+        $mergedSettings = $this->defaultCallSettings['getSink']->merge(
             new CallSettings($optionalArgs)
         );
         $callable = ApiCallable::createApiCall(
-            $this->metricsServiceV2Stub,
-            'GetLogMetric',
+            $this->configServiceV2Stub,
+            'GetSink',
             $mergedSettings,
-            $this->descriptors['getLogMetric']
+            $this->descriptors['getSink']
         );
 
         return $callable(
@@ -410,32 +413,38 @@ class MetricsServiceV2Api
     }
 
     /**
-     * Creates a logs-based metric.
+     * Creates a sink.
      *
      * Sample code:
      * ```
      * try {
-     *     $metricsServiceV2Api = new MetricsServiceV2Api();
-     *     $formattedParent = MetricsServiceV2Api::formatParentName("[PROJECT]");
-     *     $metric = new LogMetric();
-     *     $response = $metricsServiceV2Api->createLogMetric($formattedParent, $metric);
+     *     $configServiceV2Client = new ConfigServiceV2Client();
+     *     $formattedParent = ConfigServiceV2Client::formatParentName("[PROJECT]");
+     *     $sink = new LogSink();
+     *     $response = $configServiceV2Client->createSink($formattedParent, $sink);
      * } finally {
-     *     if (isset($metricsServiceV2Api)) {
-     *         $metricsServiceV2Api->close();
+     *     if (isset($configServiceV2Client)) {
+     *         $configServiceV2Client->close();
      *     }
      * }
      * ```
      *
-     * @param string $parent The resource name of the project in which to create the metric.
-     *                       Example: `"projects/my-project-id"`.
+     * @param string $parent Required. The resource in which to create the sink:
      *
-     * The new metric must be provided in the request.
-     * @param LogMetric $metric       The new logs-based metric, which must not have an identifier that
-     *                                already exists.
-     * @param array     $optionalArgs {
-     *                                Optional.
+     *     "projects/[PROJECT_ID]"
+     *     "organizations/[ORGANIZATION_ID]"
+     * @param LogSink $sink         Required. The new sink, whose `name` parameter is a sink identifier that
+     *                              is not already in use.
+     * @param array   $optionalArgs {
+     *                              Optional.
      *
-     *     @type Google\GAX\RetrySettings $retrySettings
+     *     @type bool $uniqueWriterIdentity
+     *          Optional. Whether the sink will have a dedicated service account returned
+     *          in the sink's writer_identity. Set this field to be true to export
+     *          logs from one project to a different project. This field is ignored for
+     *          non-project sinks (e.g. organization sinks) because those sinks are
+     *          required to have dedicated service accounts.
+     *     @type \Google\GAX\RetrySettings $retrySettings
      *          Retry settings to use for this call. If present, then
      *          $timeoutMillis is ignored.
      *     @type int $timeoutMillis
@@ -443,24 +452,27 @@ class MetricsServiceV2Api
      *          is not set.
      * }
      *
-     * @return google\logging\v2\LogMetric
+     * @return \google\logging\v2\LogSink
      *
-     * @throws Google\GAX\ApiException if the remote call fails
+     * @throws \Google\GAX\ApiException if the remote call fails
      */
-    public function createLogMetric($parent, $metric, $optionalArgs = [])
+    public function createSink($parent, $sink, $optionalArgs = [])
     {
-        $request = new CreateLogMetricRequest();
+        $request = new CreateSinkRequest();
         $request->setParent($parent);
-        $request->setMetric($metric);
+        $request->setSink($sink);
+        if (isset($optionalArgs['uniqueWriterIdentity'])) {
+            $request->setUniqueWriterIdentity($optionalArgs['uniqueWriterIdentity']);
+        }
 
-        $mergedSettings = $this->defaultCallSettings['createLogMetric']->merge(
+        $mergedSettings = $this->defaultCallSettings['createSink']->merge(
             new CallSettings($optionalArgs)
         );
         $callable = ApiCallable::createApiCall(
-            $this->metricsServiceV2Stub,
-            'CreateLogMetric',
+            $this->configServiceV2Stub,
+            'CreateSink',
             $mergedSettings,
-            $this->descriptors['createLogMetric']
+            $this->descriptors['createSink']
         );
 
         return $callable(
@@ -470,35 +482,42 @@ class MetricsServiceV2Api
     }
 
     /**
-     * Creates or updates a logs-based metric.
+     * Updates or creates a sink.
      *
      * Sample code:
      * ```
      * try {
-     *     $metricsServiceV2Api = new MetricsServiceV2Api();
-     *     $formattedMetricName = MetricsServiceV2Api::formatMetricName("[PROJECT]", "[METRIC]");
-     *     $metric = new LogMetric();
-     *     $response = $metricsServiceV2Api->updateLogMetric($formattedMetricName, $metric);
+     *     $configServiceV2Client = new ConfigServiceV2Client();
+     *     $formattedSinkName = ConfigServiceV2Client::formatSinkName("[PROJECT]", "[SINK]");
+     *     $sink = new LogSink();
+     *     $response = $configServiceV2Client->updateSink($formattedSinkName, $sink);
      * } finally {
-     *     if (isset($metricsServiceV2Api)) {
-     *         $metricsServiceV2Api->close();
+     *     if (isset($configServiceV2Client)) {
+     *         $configServiceV2Client->close();
      *     }
      * }
      * ```
      *
-     * @param string $metricName The resource name of the metric to update.
-     *                           Example: `"projects/my-project-id/metrics/my-metric-id"`.
+     * @param string $sinkName Required. The resource name of the sink to update, including the parent
+     *                         resource and the sink identifier:
      *
-     * The updated metric must be provided in the request and have the
-     * same identifier that is specified in `metricName`.
-     * If the metric does not exist, it is created.
-     * @param LogMetric $metric       The updated metric, whose name must be the same as the
-     *                                metric identifier in `metricName`. If `metricName` does not
-     *                                exist, then a new metric is created.
-     * @param array     $optionalArgs {
-     *                                Optional.
+     *     "projects/[PROJECT_ID]/sinks/[SINK_ID]"
+     *     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
      *
-     *     @type Google\GAX\RetrySettings $retrySettings
+     * Example: `"projects/my-project-id/sinks/my-sink-id"`.
+     * @param LogSink $sink         Required. The updated sink, whose name is the same identifier that appears
+     *                              as part of `sinkName`.  If `sinkName` does not exist, then
+     *                              this method creates a new sink.
+     * @param array   $optionalArgs {
+     *                              Optional.
+     *
+     *     @type bool $uniqueWriterIdentity
+     *          Optional. Whether the sink will have a dedicated service account returned
+     *          in the sink's writer_identity. Set this field to be true to export
+     *          logs from one project to a different project. This field is ignored for
+     *          non-project sinks (e.g. organization sinks) because those sinks are
+     *          required to have dedicated service accounts.
+     *     @type \Google\GAX\RetrySettings $retrySettings
      *          Retry settings to use for this call. If present, then
      *          $timeoutMillis is ignored.
      *     @type int $timeoutMillis
@@ -506,24 +525,27 @@ class MetricsServiceV2Api
      *          is not set.
      * }
      *
-     * @return google\logging\v2\LogMetric
+     * @return \google\logging\v2\LogSink
      *
-     * @throws Google\GAX\ApiException if the remote call fails
+     * @throws \Google\GAX\ApiException if the remote call fails
      */
-    public function updateLogMetric($metricName, $metric, $optionalArgs = [])
+    public function updateSink($sinkName, $sink, $optionalArgs = [])
     {
-        $request = new UpdateLogMetricRequest();
-        $request->setMetricName($metricName);
-        $request->setMetric($metric);
+        $request = new UpdateSinkRequest();
+        $request->setSinkName($sinkName);
+        $request->setSink($sink);
+        if (isset($optionalArgs['uniqueWriterIdentity'])) {
+            $request->setUniqueWriterIdentity($optionalArgs['uniqueWriterIdentity']);
+        }
 
-        $mergedSettings = $this->defaultCallSettings['updateLogMetric']->merge(
+        $mergedSettings = $this->defaultCallSettings['updateSink']->merge(
             new CallSettings($optionalArgs)
         );
         $callable = ApiCallable::createApiCall(
-            $this->metricsServiceV2Stub,
-            'UpdateLogMetric',
+            $this->configServiceV2Stub,
+            'UpdateSink',
             $mergedSettings,
-            $this->descriptors['updateLogMetric']
+            $this->descriptors['updateSink']
         );
 
         return $callable(
@@ -533,27 +555,32 @@ class MetricsServiceV2Api
     }
 
     /**
-     * Deletes a logs-based metric.
+     * Deletes a sink.
      *
      * Sample code:
      * ```
      * try {
-     *     $metricsServiceV2Api = new MetricsServiceV2Api();
-     *     $formattedMetricName = MetricsServiceV2Api::formatMetricName("[PROJECT]", "[METRIC]");
-     *     $metricsServiceV2Api->deleteLogMetric($formattedMetricName);
+     *     $configServiceV2Client = new ConfigServiceV2Client();
+     *     $formattedSinkName = ConfigServiceV2Client::formatSinkName("[PROJECT]", "[SINK]");
+     *     $configServiceV2Client->deleteSink($formattedSinkName);
      * } finally {
-     *     if (isset($metricsServiceV2Api)) {
-     *         $metricsServiceV2Api->close();
+     *     if (isset($configServiceV2Client)) {
+     *         $configServiceV2Client->close();
      *     }
      * }
      * ```
      *
-     * @param string $metricName   The resource name of the metric to delete.
-     *                             Example: `"projects/my-project-id/metrics/my-metric-id"`.
-     * @param array  $optionalArgs {
-     *                             Optional.
+     * @param string $sinkName Required. The resource name of the sink to delete, including the parent
+     *                         resource and the sink identifier:
      *
-     *     @type Google\GAX\RetrySettings $retrySettings
+     *     "projects/[PROJECT_ID]/sinks/[SINK_ID]"
+     *     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
+     *
+     * It is an error if the sink does not exist.
+     * @param array $optionalArgs {
+     *                            Optional.
+     *
+     *     @type \Google\GAX\RetrySettings $retrySettings
      *          Retry settings to use for this call. If present, then
      *          $timeoutMillis is ignored.
      *     @type int $timeoutMillis
@@ -561,21 +588,21 @@ class MetricsServiceV2Api
      *          is not set.
      * }
      *
-     * @throws Google\GAX\ApiException if the remote call fails
+     * @throws \Google\GAX\ApiException if the remote call fails
      */
-    public function deleteLogMetric($metricName, $optionalArgs = [])
+    public function deleteSink($sinkName, $optionalArgs = [])
     {
-        $request = new DeleteLogMetricRequest();
-        $request->setMetricName($metricName);
+        $request = new DeleteSinkRequest();
+        $request->setSinkName($sinkName);
 
-        $mergedSettings = $this->defaultCallSettings['deleteLogMetric']->merge(
+        $mergedSettings = $this->defaultCallSettings['deleteSink']->merge(
             new CallSettings($optionalArgs)
         );
         $callable = ApiCallable::createApiCall(
-            $this->metricsServiceV2Stub,
-            'DeleteLogMetric',
+            $this->configServiceV2Stub,
+            'DeleteSink',
             $mergedSettings,
-            $this->descriptors['deleteLogMetric']
+            $this->descriptors['deleteSink']
         );
 
         return $callable(
@@ -590,7 +617,7 @@ class MetricsServiceV2Api
      */
     public function close()
     {
-        $this->metricsServiceV2Stub->close();
+        $this->configServiceV2Stub->close();
     }
 
     private function createCredentialsCallback()

--- a/src/Logging/V2/LoggingServiceV2Client.php
+++ b/src/Logging/V2/LoggingServiceV2Client.php
@@ -34,6 +34,7 @@ use google\logging\v2\DeleteLogRequest;
 use google\logging\v2\ListLogEntriesRequest;
 use google\logging\v2\ListMonitoredResourceDescriptorsRequest;
 use google\logging\v2\LogEntry;
+use google\logging\v2\LoggingServiceV2Client as LoggingServiceV2GrpcClient;
 use google\logging\v2\WriteLogEntriesRequest;
 use google\logging\v2\WriteLogEntriesRequest\LabelsEntry;
 
@@ -278,7 +279,7 @@ class LoggingServiceV2Client
         $this->grpcCredentialsHelper = new GrpcCredentialsHelper($this->scopes, $grpcCredentialsHelperOptions);
 
         $createLoggingServiceV2StubFunction = function ($hostname, $opts) {
-            return new \google\logging\v2\LoggingServiceV2Client($hostname, $opts);
+            return new LoggingServiceV2GrpcClient($hostname, $opts);
         };
         $this->loggingServiceV2Stub = $this->grpcCredentialsHelper->createStub(
             $createLoggingServiceV2StubFunction,

--- a/src/Logging/V2/MetricsServiceV2Client.php
+++ b/src/Logging/V2/MetricsServiceV2Client.php
@@ -34,6 +34,7 @@ use google\logging\v2\DeleteLogMetricRequest;
 use google\logging\v2\GetLogMetricRequest;
 use google\logging\v2\ListLogMetricsRequest;
 use google\logging\v2\LogMetric;
+use google\logging\v2\MetricsServiceV2Client as MetricsServiceV2GrpcClient;
 use google\logging\v2\UpdateLogMetricRequest;
 
 /**
@@ -272,7 +273,7 @@ class MetricsServiceV2Client
         $this->grpcCredentialsHelper = new GrpcCredentialsHelper($this->scopes, $grpcCredentialsHelperOptions);
 
         $createMetricsServiceV2StubFunction = function ($hostname, $opts) {
-            return new \google\logging\v2\MetricsServiceV2Client($hostname, $opts);
+            return new MetricsServiceV2GrpcClient($hostname, $opts);
         };
         $this->metricsServiceV2Stub = $this->grpcCredentialsHelper->createStub(
             $createMetricsServiceV2StubFunction,

--- a/src/Logging/V2/MetricsServiceV2Client.php
+++ b/src/Logging/V2/MetricsServiceV2Client.php
@@ -16,7 +16,7 @@
 /*
  * GENERATED CODE WARNING
  * This file was generated from the file
- * https://github.com/google/googleapis/blob/master/google/logging/v2/logging_config.proto
+ * https://github.com/google/googleapis/blob/master/google/logging/v2/logging_metrics.proto
  * and updates to that file get reflected here through a refresh process.
  */
 
@@ -29,31 +29,29 @@ use Google\GAX\GrpcConstants;
 use Google\GAX\GrpcCredentialsHelper;
 use Google\GAX\PageStreamingDescriptor;
 use Google\GAX\PathTemplate;
-use google\logging\v2\ConfigServiceV2Client;
-use google\logging\v2\CreateSinkRequest;
-use google\logging\v2\DeleteSinkRequest;
-use google\logging\v2\GetSinkRequest;
-use google\logging\v2\ListSinksRequest;
-use google\logging\v2\LogSink;
-use google\logging\v2\UpdateSinkRequest;
+use google\logging\v2\CreateLogMetricRequest;
+use google\logging\v2\DeleteLogMetricRequest;
+use google\logging\v2\GetLogMetricRequest;
+use google\logging\v2\ListLogMetricsRequest;
+use google\logging\v2\LogMetric;
+use google\logging\v2\UpdateLogMetricRequest;
 
 /**
- * Service Description: Service for configuring sinks used to export log entries outside Stackdriver
- * Logging.
+ * Service Description: Service for configuring logs-based metrics.
  *
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods. Sample code to get started:
  *
  * ```
  * try {
- *     $configServiceV2Api = new ConfigServiceV2Api();
- *     $formattedParent = ConfigServiceV2Api::formatParentName("[PROJECT]");
- *     foreach ($configServiceV2Api->listSinks($formattedParent) as $element) {
+ *     $metricsServiceV2Client = new MetricsServiceV2Client();
+ *     $formattedParent = MetricsServiceV2Client::formatParentName("[PROJECT]");
+ *     foreach ($metricsServiceV2Client->listLogMetrics($formattedParent) as $element) {
  *         // doThingsWith(element);
  *     }
  * } finally {
- *     if (isset($configServiceV2Api)) {
- *         $configServiceV2Api->close();
+ *     if (isset($metricsServiceV2Client)) {
+ *         $metricsServiceV2Client->close();
  *     }
  * }
  * ```
@@ -63,7 +61,7 @@ use google\logging\v2\UpdateSinkRequest;
  * a parse method to extract the individual identifiers contained within names that are
  * returned.
  */
-class ConfigServiceV2Api
+class MetricsServiceV2Client
 {
     /**
      * The default address of the service.
@@ -85,10 +83,10 @@ class ConfigServiceV2Api
     const _CODEGEN_VERSION = '0.0.0';
 
     private static $parentNameTemplate;
-    private static $sinkNameTemplate;
+    private static $metricNameTemplate;
 
     private $grpcCredentialsHelper;
-    private $configServiceV2Stub;
+    private $metricsServiceV2Stub;
     private $scopes;
     private $defaultCallSettings;
     private $descriptors;
@@ -106,13 +104,13 @@ class ConfigServiceV2Api
 
     /**
      * Formats a string containing the fully-qualified path to represent
-     * a sink resource.
+     * a metric resource.
      */
-    public static function formatSinkName($project, $sink)
+    public static function formatMetricName($project, $metric)
     {
-        return self::getSinkNameTemplate()->render([
+        return self::getMetricNameTemplate()->render([
             'project' => $project,
-            'sink' => $sink,
+            'metric' => $metric,
         ]);
     }
 
@@ -127,20 +125,20 @@ class ConfigServiceV2Api
 
     /**
      * Parses the project from the given fully-qualified path which
-     * represents a sink resource.
+     * represents a metric resource.
      */
-    public static function parseProjectFromSinkName($sinkName)
+    public static function parseProjectFromMetricName($metricName)
     {
-        return self::getSinkNameTemplate()->match($sinkName)['project'];
+        return self::getMetricNameTemplate()->match($metricName)['project'];
     }
 
     /**
-     * Parses the sink from the given fully-qualified path which
-     * represents a sink resource.
+     * Parses the metric from the given fully-qualified path which
+     * represents a metric resource.
      */
-    public static function parseSinkFromSinkName($sinkName)
+    public static function parseMetricFromMetricName($metricName)
     {
-        return self::getSinkNameTemplate()->match($sinkName)['sink'];
+        return self::getMetricNameTemplate()->match($metricName)['metric'];
     }
 
     private static function getParentNameTemplate()
@@ -152,27 +150,27 @@ class ConfigServiceV2Api
         return self::$parentNameTemplate;
     }
 
-    private static function getSinkNameTemplate()
+    private static function getMetricNameTemplate()
     {
-        if (self::$sinkNameTemplate == null) {
-            self::$sinkNameTemplate = new PathTemplate('projects/{project}/sinks/{sink}');
+        if (self::$metricNameTemplate == null) {
+            self::$metricNameTemplate = new PathTemplate('projects/{project}/metrics/{metric}');
         }
 
-        return self::$sinkNameTemplate;
+        return self::$metricNameTemplate;
     }
 
     private static function getPageStreamingDescriptors()
     {
-        $listSinksPageStreamingDescriptor =
+        $listLogMetricsPageStreamingDescriptor =
                 new PageStreamingDescriptor([
                     'requestPageTokenField' => 'page_token',
                     'requestPageSizeField' => 'page_size',
                     'responsePageTokenField' => 'next_page_token',
-                    'resourceField' => 'sinks',
+                    'resourceField' => 'metrics',
                 ]);
 
         $pageStreamingDescriptors = [
-            'listSinks' => $listSinksPageStreamingDescriptor,
+            'listLogMetrics' => $listLogMetricsPageStreamingDescriptor,
         ];
 
         return $pageStreamingDescriptors;
@@ -228,7 +226,6 @@ class ConfigServiceV2Api
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
             'appName' => 'gax',
             'appVersion' => self::_GAX_VERSION,
-            'credentialsLoader' => null,
         ];
         $options = array_merge($defaultOptions, $options);
 
@@ -243,22 +240,22 @@ class ConfigServiceV2Api
 
         $defaultDescriptors = ['headerDescriptor' => $headerDescriptor];
         $this->descriptors = [
-            'listSinks' => $defaultDescriptors,
-            'getSink' => $defaultDescriptors,
-            'createSink' => $defaultDescriptors,
-            'updateSink' => $defaultDescriptors,
-            'deleteSink' => $defaultDescriptors,
+            'listLogMetrics' => $defaultDescriptors,
+            'getLogMetric' => $defaultDescriptors,
+            'createLogMetric' => $defaultDescriptors,
+            'updateLogMetric' => $defaultDescriptors,
+            'deleteLogMetric' => $defaultDescriptors,
         ];
         $pageStreamingDescriptors = self::getPageStreamingDescriptors();
         foreach ($pageStreamingDescriptors as $method => $pageStreamingDescriptor) {
             $this->descriptors[$method]['pageStreamingDescriptor'] = $pageStreamingDescriptor;
         }
 
-        $clientConfigJsonString = file_get_contents(__DIR__.'/resources/config_service_v2_client_config.json');
+        $clientConfigJsonString = file_get_contents(__DIR__.'/resources/metrics_service_v2_client_config.json');
         $clientConfig = json_decode($clientConfigJsonString, true);
         $this->defaultCallSettings =
                 CallSettings::load(
-                    'google.logging.v2.ConfigServiceV2',
+                    'google.logging.v2.MetricsServiceV2',
                     $clientConfig,
                     $options['retryingOverride'],
                     GrpcConstants::getStatusCodeNames(),
@@ -268,17 +265,17 @@ class ConfigServiceV2Api
         $this->scopes = $options['scopes'];
 
         $createStubOptions = [];
-        if (!empty($options['sslCreds'])) {
+        if (array_key_exists('sslCreds', $options)) {
             $createStubOptions['sslCreds'] = $options['sslCreds'];
         }
         $grpcCredentialsHelperOptions = array_diff_key($options, $defaultOptions);
         $this->grpcCredentialsHelper = new GrpcCredentialsHelper($this->scopes, $grpcCredentialsHelperOptions);
 
-        $createConfigServiceV2StubFunction = function ($hostname, $opts) {
-            return new ConfigServiceV2Client($hostname, $opts);
+        $createMetricsServiceV2StubFunction = function ($hostname, $opts) {
+            return new \google\logging\v2\MetricsServiceV2Client($hostname, $opts);
         };
-        $this->configServiceV2Stub = $this->grpcCredentialsHelper->createStub(
-            $createConfigServiceV2StubFunction,
+        $this->metricsServiceV2Stub = $this->grpcCredentialsHelper->createStub(
+            $createMetricsServiceV2StubFunction,
             $options['serviceAddress'],
             $options['port'],
             $createStubOptions
@@ -286,27 +283,28 @@ class ConfigServiceV2Api
     }
 
     /**
-     * Lists sinks.
+     * Lists logs-based metrics.
      *
      * Sample code:
      * ```
      * try {
-     *     $configServiceV2Api = new ConfigServiceV2Api();
-     *     $formattedParent = ConfigServiceV2Api::formatParentName("[PROJECT]");
-     *     foreach ($configServiceV2Api->listSinks($formattedParent) as $element) {
+     *     $metricsServiceV2Client = new MetricsServiceV2Client();
+     *     $formattedParent = MetricsServiceV2Client::formatParentName("[PROJECT]");
+     *     foreach ($metricsServiceV2Client->listLogMetrics($formattedParent) as $element) {
      *         // doThingsWith(element);
      *     }
      * } finally {
-     *     if (isset($configServiceV2Api)) {
-     *         $configServiceV2Api->close();
+     *     if (isset($metricsServiceV2Client)) {
+     *         $metricsServiceV2Client->close();
      *     }
      * }
      * ```
      *
-     * @param string $parent       Required. The cloud resource containing the sinks.
-     *                             Example: `"projects/my-logging-project"`.
-     * @param array  $optionalArgs {
-     *                             Optional.
+     * @param string $parent Required. The name of the project containing the metrics:
+     *
+     *     "projects/[PROJECT_ID]"
+     * @param array $optionalArgs {
+     *                            Optional.
      *
      *     @type string $pageToken
      *          A page token is used to specify a page of values to be returned.
@@ -317,7 +315,7 @@ class ConfigServiceV2Api
      *          The maximum number of resources contained in the underlying API
      *          response. The API may return fewer values in a page, even if
      *          there are additional values to be retrieved.
-     *     @type Google\GAX\RetrySettings $retrySettings
+     *     @type \Google\GAX\RetrySettings $retrySettings
      *          Retry settings to use for this call. If present, then
      *          $timeoutMillis is ignored.
      *     @type int $timeoutMillis
@@ -325,13 +323,13 @@ class ConfigServiceV2Api
      *          is not set.
      * }
      *
-     * @return Google\GAX\PagedListResponse
+     * @return \Google\GAX\PagedListResponse
      *
-     * @throws Google\GAX\ApiException if the remote call fails
+     * @throws \Google\GAX\ApiException if the remote call fails
      */
-    public function listSinks($parent, $optionalArgs = [])
+    public function listLogMetrics($parent, $optionalArgs = [])
     {
-        $request = new ListSinksRequest();
+        $request = new ListLogMetricsRequest();
         $request->setParent($parent);
         if (isset($optionalArgs['pageToken'])) {
             $request->setPageToken($optionalArgs['pageToken']);
@@ -340,14 +338,14 @@ class ConfigServiceV2Api
             $request->setPageSize($optionalArgs['pageSize']);
         }
 
-        $mergedSettings = $this->defaultCallSettings['listSinks']->merge(
+        $mergedSettings = $this->defaultCallSettings['listLogMetrics']->merge(
             new CallSettings($optionalArgs)
         );
         $callable = ApiCallable::createApiCall(
-            $this->configServiceV2Stub,
-            'ListSinks',
+            $this->metricsServiceV2Stub,
+            'ListLogMetrics',
             $mergedSettings,
-            $this->descriptors['listSinks']
+            $this->descriptors['listLogMetrics']
         );
 
         return $callable(
@@ -357,27 +355,28 @@ class ConfigServiceV2Api
     }
 
     /**
-     * Gets a sink.
+     * Gets a logs-based metric.
      *
      * Sample code:
      * ```
      * try {
-     *     $configServiceV2Api = new ConfigServiceV2Api();
-     *     $formattedSinkName = ConfigServiceV2Api::formatSinkName("[PROJECT]", "[SINK]");
-     *     $response = $configServiceV2Api->getSink($formattedSinkName);
+     *     $metricsServiceV2Client = new MetricsServiceV2Client();
+     *     $formattedMetricName = MetricsServiceV2Client::formatMetricName("[PROJECT]", "[METRIC]");
+     *     $response = $metricsServiceV2Client->getLogMetric($formattedMetricName);
      * } finally {
-     *     if (isset($configServiceV2Api)) {
-     *         $configServiceV2Api->close();
+     *     if (isset($metricsServiceV2Client)) {
+     *         $metricsServiceV2Client->close();
      *     }
      * }
      * ```
      *
-     * @param string $sinkName     Required. The resource name of the sink to return.
-     *                             Example: `"projects/my-project-id/sinks/my-sink-id"`.
-     * @param array  $optionalArgs {
-     *                             Optional.
+     * @param string $metricName The resource name of the desired metric:
      *
-     *     @type Google\GAX\RetrySettings $retrySettings
+     *     "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
+     * @param array $optionalArgs {
+     *                            Optional.
+     *
+     *     @type \Google\GAX\RetrySettings $retrySettings
      *          Retry settings to use for this call. If present, then
      *          $timeoutMillis is ignored.
      *     @type int $timeoutMillis
@@ -385,23 +384,23 @@ class ConfigServiceV2Api
      *          is not set.
      * }
      *
-     * @return google\logging\v2\LogSink
+     * @return \google\logging\v2\LogMetric
      *
-     * @throws Google\GAX\ApiException if the remote call fails
+     * @throws \Google\GAX\ApiException if the remote call fails
      */
-    public function getSink($sinkName, $optionalArgs = [])
+    public function getLogMetric($metricName, $optionalArgs = [])
     {
-        $request = new GetSinkRequest();
-        $request->setSinkName($sinkName);
+        $request = new GetLogMetricRequest();
+        $request->setMetricName($metricName);
 
-        $mergedSettings = $this->defaultCallSettings['getSink']->merge(
+        $mergedSettings = $this->defaultCallSettings['getLogMetric']->merge(
             new CallSettings($optionalArgs)
         );
         $callable = ApiCallable::createApiCall(
-            $this->configServiceV2Stub,
-            'GetSink',
+            $this->metricsServiceV2Stub,
+            'GetLogMetric',
             $mergedSettings,
-            $this->descriptors['getSink']
+            $this->descriptors['getLogMetric']
         );
 
         return $callable(
@@ -411,31 +410,33 @@ class ConfigServiceV2Api
     }
 
     /**
-     * Creates a sink.
+     * Creates a logs-based metric.
      *
      * Sample code:
      * ```
      * try {
-     *     $configServiceV2Api = new ConfigServiceV2Api();
-     *     $formattedParent = ConfigServiceV2Api::formatParentName("[PROJECT]");
-     *     $sink = new LogSink();
-     *     $response = $configServiceV2Api->createSink($formattedParent, $sink);
+     *     $metricsServiceV2Client = new MetricsServiceV2Client();
+     *     $formattedParent = MetricsServiceV2Client::formatParentName("[PROJECT]");
+     *     $metric = new LogMetric();
+     *     $response = $metricsServiceV2Client->createLogMetric($formattedParent, $metric);
      * } finally {
-     *     if (isset($configServiceV2Api)) {
-     *         $configServiceV2Api->close();
+     *     if (isset($metricsServiceV2Client)) {
+     *         $metricsServiceV2Client->close();
      *     }
      * }
      * ```
      *
-     * @param string  $parent       Required. The resource in which to create the sink.
-     *                              Example: `"projects/my-project-id"`.
-     *                              The new sink must be provided in the request.
-     * @param LogSink $sink         Required. The new sink, whose `name` parameter is a sink identifier that
-     *                              is not already in use.
-     * @param array   $optionalArgs {
-     *                              Optional.
+     * @param string $parent The resource name of the project in which to create the metric:
      *
-     *     @type Google\GAX\RetrySettings $retrySettings
+     *     "projects/[PROJECT_ID]"
+     *
+     * The new metric must be provided in the request.
+     * @param LogMetric $metric       The new logs-based metric, which must not have an identifier that
+     *                                already exists.
+     * @param array     $optionalArgs {
+     *                                Optional.
+     *
+     *     @type \Google\GAX\RetrySettings $retrySettings
      *          Retry settings to use for this call. If present, then
      *          $timeoutMillis is ignored.
      *     @type int $timeoutMillis
@@ -443,24 +444,24 @@ class ConfigServiceV2Api
      *          is not set.
      * }
      *
-     * @return google\logging\v2\LogSink
+     * @return \google\logging\v2\LogMetric
      *
-     * @throws Google\GAX\ApiException if the remote call fails
+     * @throws \Google\GAX\ApiException if the remote call fails
      */
-    public function createSink($parent, $sink, $optionalArgs = [])
+    public function createLogMetric($parent, $metric, $optionalArgs = [])
     {
-        $request = new CreateSinkRequest();
+        $request = new CreateLogMetricRequest();
         $request->setParent($parent);
-        $request->setSink($sink);
+        $request->setMetric($metric);
 
-        $mergedSettings = $this->defaultCallSettings['createSink']->merge(
+        $mergedSettings = $this->defaultCallSettings['createLogMetric']->merge(
             new CallSettings($optionalArgs)
         );
         $callable = ApiCallable::createApiCall(
-            $this->configServiceV2Stub,
-            'CreateSink',
+            $this->metricsServiceV2Stub,
+            'CreateLogMetric',
             $mergedSettings,
-            $this->descriptors['createSink']
+            $this->descriptors['createLogMetric']
         );
 
         return $callable(
@@ -470,32 +471,34 @@ class ConfigServiceV2Api
     }
 
     /**
-     * Updates or creates a sink.
+     * Creates or updates a logs-based metric.
      *
      * Sample code:
      * ```
      * try {
-     *     $configServiceV2Api = new ConfigServiceV2Api();
-     *     $formattedSinkName = ConfigServiceV2Api::formatSinkName("[PROJECT]", "[SINK]");
-     *     $sink = new LogSink();
-     *     $response = $configServiceV2Api->updateSink($formattedSinkName, $sink);
+     *     $metricsServiceV2Client = new MetricsServiceV2Client();
+     *     $formattedMetricName = MetricsServiceV2Client::formatMetricName("[PROJECT]", "[METRIC]");
+     *     $metric = new LogMetric();
+     *     $response = $metricsServiceV2Client->updateLogMetric($formattedMetricName, $metric);
      * } finally {
-     *     if (isset($configServiceV2Api)) {
-     *         $configServiceV2Api->close();
+     *     if (isset($metricsServiceV2Client)) {
+     *         $metricsServiceV2Client->close();
      *     }
      * }
      * ```
      *
-     * @param string  $sinkName     Required. The resource name of the sink to update, including the parent
-     *                              resource and the sink identifier.  If the sink does not exist, this method
-     *                              creates the sink.  Example: `"projects/my-project-id/sinks/my-sink-id"`.
-     * @param LogSink $sink         Required. The updated sink, whose name is the same identifier that appears
-     *                              as part of `sinkName`.  If `sinkName` does not exist, then
-     *                              this method creates a new sink.
-     * @param array   $optionalArgs {
-     *                              Optional.
+     * @param string $metricName The resource name of the metric to update:
      *
-     *     @type Google\GAX\RetrySettings $retrySettings
+     *     "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
+     *
+     * The updated metric must be provided in the request and it's
+     * `name` field must be the same as `[METRIC_ID]` If the metric
+     * does not exist in `[PROJECT_ID]`, then a new metric is created.
+     * @param LogMetric $metric       The updated metric.
+     * @param array     $optionalArgs {
+     *                                Optional.
+     *
+     *     @type \Google\GAX\RetrySettings $retrySettings
      *          Retry settings to use for this call. If present, then
      *          $timeoutMillis is ignored.
      *     @type int $timeoutMillis
@@ -503,24 +506,24 @@ class ConfigServiceV2Api
      *          is not set.
      * }
      *
-     * @return google\logging\v2\LogSink
+     * @return \google\logging\v2\LogMetric
      *
-     * @throws Google\GAX\ApiException if the remote call fails
+     * @throws \Google\GAX\ApiException if the remote call fails
      */
-    public function updateSink($sinkName, $sink, $optionalArgs = [])
+    public function updateLogMetric($metricName, $metric, $optionalArgs = [])
     {
-        $request = new UpdateSinkRequest();
-        $request->setSinkName($sinkName);
-        $request->setSink($sink);
+        $request = new UpdateLogMetricRequest();
+        $request->setMetricName($metricName);
+        $request->setMetric($metric);
 
-        $mergedSettings = $this->defaultCallSettings['updateSink']->merge(
+        $mergedSettings = $this->defaultCallSettings['updateLogMetric']->merge(
             new CallSettings($optionalArgs)
         );
         $callable = ApiCallable::createApiCall(
-            $this->configServiceV2Stub,
-            'UpdateSink',
+            $this->metricsServiceV2Stub,
+            'UpdateLogMetric',
             $mergedSettings,
-            $this->descriptors['updateSink']
+            $this->descriptors['updateLogMetric']
         );
 
         return $callable(
@@ -530,29 +533,28 @@ class ConfigServiceV2Api
     }
 
     /**
-     * Deletes a sink.
+     * Deletes a logs-based metric.
      *
      * Sample code:
      * ```
      * try {
-     *     $configServiceV2Api = new ConfigServiceV2Api();
-     *     $formattedSinkName = ConfigServiceV2Api::formatSinkName("[PROJECT]", "[SINK]");
-     *     $configServiceV2Api->deleteSink($formattedSinkName);
+     *     $metricsServiceV2Client = new MetricsServiceV2Client();
+     *     $formattedMetricName = MetricsServiceV2Client::formatMetricName("[PROJECT]", "[METRIC]");
+     *     $metricsServiceV2Client->deleteLogMetric($formattedMetricName);
      * } finally {
-     *     if (isset($configServiceV2Api)) {
-     *         $configServiceV2Api->close();
+     *     if (isset($metricsServiceV2Client)) {
+     *         $metricsServiceV2Client->close();
      *     }
      * }
      * ```
      *
-     * @param string $sinkName     Required. The resource name of the sink to delete, including the parent
-     *                             resource and the sink identifier.  Example:
-     *                             `"projects/my-project-id/sinks/my-sink-id"`.  It is an error if the sink
-     *                             does not exist.
-     * @param array  $optionalArgs {
-     *                             Optional.
+     * @param string $metricName The resource name of the metric to delete:
      *
-     *     @type Google\GAX\RetrySettings $retrySettings
+     *     "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
+     * @param array $optionalArgs {
+     *                            Optional.
+     *
+     *     @type \Google\GAX\RetrySettings $retrySettings
      *          Retry settings to use for this call. If present, then
      *          $timeoutMillis is ignored.
      *     @type int $timeoutMillis
@@ -560,21 +562,21 @@ class ConfigServiceV2Api
      *          is not set.
      * }
      *
-     * @throws Google\GAX\ApiException if the remote call fails
+     * @throws \Google\GAX\ApiException if the remote call fails
      */
-    public function deleteSink($sinkName, $optionalArgs = [])
+    public function deleteLogMetric($metricName, $optionalArgs = [])
     {
-        $request = new DeleteSinkRequest();
-        $request->setSinkName($sinkName);
+        $request = new DeleteLogMetricRequest();
+        $request->setMetricName($metricName);
 
-        $mergedSettings = $this->defaultCallSettings['deleteSink']->merge(
+        $mergedSettings = $this->defaultCallSettings['deleteLogMetric']->merge(
             new CallSettings($optionalArgs)
         );
         $callable = ApiCallable::createApiCall(
-            $this->configServiceV2Stub,
-            'DeleteSink',
+            $this->metricsServiceV2Stub,
+            'DeleteLogMetric',
             $mergedSettings,
-            $this->descriptors['deleteSink']
+            $this->descriptors['deleteLogMetric']
         );
 
         return $callable(
@@ -589,7 +591,7 @@ class ConfigServiceV2Api
      */
     public function close()
     {
-        $this->configServiceV2Stub->close();
+        $this->metricsServiceV2Stub->close();
     }
 
     private function createCredentialsCallback()


### PR DESCRIPTION
Please wait for proto-client-php v0.6 to be published before merging (now released)

Regenerates logging with updates protos
Fixes issues with sslCreds and credentialsProvider
Renames XApi classes to XClient
Adds leading backslashes to doc types