### PR TITLE
V0.13.1

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -6,6 +6,7 @@
     "defaultService": "servicebuilder",
     "markdown": "php",
     "versions": [
+        "v0.13.1",
         "v0.13.0",
         "v0.12.0",
         "v0.11.1",

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -48,7 +48,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class ServiceBuilder
 {
-    const VERSION = '0.13.0';
+    const VERSION = '0.13.1';
 
     /**
      * @var array Configuration options to be used between clients.


### PR DESCRIPTION
## Google Cloud PHP v0.13.1

### What's Updated

* Google Cloud Logging now uses `resourceName` instead of `projectId` for
  logging entries. (#235 and #253)

### What's Fixed

* The version of `google/auth` has been updated to prevent conflicts when using
  other Google libraries which rely on auth. (#256)
* Connection options are removed after being set as URI parameters. This fixes
  a failure case in the Pub/Sub emulator.  (#251)
* When using gRPC, google-cloud-php now uses the correct key name for
  application version. (#247)