### PR TITLE
Prepare v0.13.2

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -6,6 +6,7 @@
     "defaultService": "servicebuilder",
     "markdown": "php",
     "versions": [
+        "v0.13.2",
         "v0.13.1",
         "v0.13.0",
         "v0.12.0",

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -48,7 +48,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class ServiceBuilder
 {
-    const VERSION = '0.13.1';
+    const VERSION = '0.13.2';
 
     /**
      * @var array Configuration options to be used between clients.


### PR DESCRIPTION
## Google Cloud PHP v0.13.2

### What's Fixed?

* Fixed the `google/auth` version conflict with `google/apiclient` for real
  this time. (#262)