### PR TITLE
Bump gax version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "erusev/parsedown": "^1.6",
         "vierbergenlars/php-semver": "^3.0",
         "google/proto-client-php": "^0.6",
-        "google/gax": "^0.4"
+        "google/gax": "^0.5"
     },
     "suggest": {
         "google/gax": "Required to support gRPC",


### PR DESCRIPTION
Bump the gax version to 0.5

The current gax version is incompatible with grpc 1.0.1 which was recently released on pecl, and which rejects the Authorization header provided by gax.