### PR TITLE
Bigquery params and type mapping

### DIFF
--- a/docs/toc.json
+++ b/docs/toc.json
@@ -39,8 +39,14 @@
             "title": "BigQuery",
             "type": "bigquery/bigqueryclient",
             "nav": [{
+                "title": "Bytes",
+                "type": "bigquery/bytes"
+            }, {
                 "title": "Dataset",
                 "type": "bigquery/dataset"
+            }, {
+                "title": "Date",
+                "type": "bigquery/date"
             }, {
                 "title": "InsertResponse",
                 "type": "bigquery/insertresponse"
@@ -50,9 +56,15 @@
             }, {
                 "title": "QueryResults",
                 "type": "bigquery/queryresults"
-            },{
+            }, {
                 "title": "Table",
                 "type": "bigquery/table"
+            }, {
+                "title": "Time",
+                "type": "bigquery/time"
+            }, {
+                "title": "Timestamp",
+                "type": "bigquery/timestamp"
             }]
         },
         {

--- a/src/BigQuery/BigQueryClient.php
+++ b/src/BigQuery/BigQueryClient.php
@@ -17,10 +17,12 @@
 
 namespace Google\Cloud\BigQuery;
 
+use Google\Cloud\ArrayTrait;
 use Google\Cloud\BigQuery\Connection\ConnectionInterface;
 use Google\Cloud\BigQuery\Connection\Rest;
 use Google\Cloud\ClientTrait;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Google Cloud BigQuery client. Allows you to create, manage, share and query
@@ -45,6 +47,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class BigQueryClient
 {
+    use ArrayTrait;
     use ClientTrait;
     use JobConfigurationTrait;
 
@@ -55,6 +58,11 @@ class BigQueryClient
      * @var ConnectionInterface $connection Represents a connection to BigQuery.
      */
     protected $connection;
+
+    /**
+     * @var ValueMapper $mapper Maps values between PHP and BigQuery.
+     */
+    private $mapper;
 
     /**
      * Create a BigQuery client.
@@ -89,6 +97,7 @@ class BigQueryClient
         }
 
         $this->connection = new Rest($this->configureAuthentication($config));
+        $this->mapper = new ValueMapper();
     }
 
     /**
@@ -97,9 +106,76 @@ class BigQueryClient
      * the case that the query does not complete in the specified timeout, you
      * are able to poll the query's status until it is complete.
      *
+     * Queries constructed using
+     * [standard SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+     * can take advantage of parametriziation.
+     *
+     * Refer to the table below for a guide on how parameter types are mapped to
+     * their BigQuery equivalents.
+     *
+     * | **PHP Type**                               | **BigQuery Data Type**               |
+     * |--------------------------------------------|--------------------------------------|
+     * | `\DateTimeInterface`                       | `DATETIME`                           |
+     * | {@see Google\Cloud\BigQuery\Bytes}         | `BYTES`                              |
+     * | {@see Google\Cloud\BigQuery\Date}          | `DATE`                               |
+     * | {@see Google\Cloud\BigQuery\Time}          | `TIME`                               |
+     * | {@see Google\Cloud\BigQuery\Timestamp}     | `TIMESTAMP`                          |
+     * | Associative Array                          | `STRUCT`                             |
+     * | Non-Associative Array                      | `ARRAY`                              |
+     * | `float`                                    | `FLOAT64`                            |
+     * | `int`                                      | `INT64`                              |
+     * | `string`                                   | `STRING`                             |
+     * | `resource`                                 | `BYTES`                              |
+     * | `bool`                                     | `BOOL`                               |
+     * | `object` (Outside types specified above)   | **ERROR** `InvalidArgumentException` |
+     *
      * Example:
      * ```
      * $queryResults = $bigQuery->runQuery('SELECT * FROM [bigquery-public-data:usa_names.usa_1910_2013]');
+     *
+     * $isComplete = $queryResults->isComplete();
+     *
+     * while (!$isComplete) {
+     *     sleep(1); // let's wait for a moment...
+     *     $queryResults->reload(); // trigger a network request
+     *     $isComplete = $queryResults->isComplete(); // check the query's status
+     * }
+     *
+     * foreach ($queryResults->rows() as $row) {
+     *     echo $row['name'];
+     * }
+     * ```
+     *
+     * ```
+     * // Construct a query utilizing named parameters.
+     * $query = 'SELECT * FROM `bigquery-public-data.usa_names.usa_1910_2013` WHERE name = @name';
+     * $queryResults = $bigQuery->runQuery($query, [
+     *     'parameters' => [
+     *         'name' => 'Annie'
+     *     ]
+     * ]);
+     *
+     * $isComplete = $queryResults->isComplete();
+     *
+     * while (!$isComplete) {
+     *     sleep(1); // let's wait for a moment...
+     *     $queryResults->reload(); // trigger a network request
+     *     $isComplete = $queryResults->isComplete(); // check the query's status
+     * }
+     *
+     * foreach ($queryResults->rows() as $row) {
+     *     echo $row['name'];
+     * }
+     * ```
+     *
+     * ```
+     * // Construct a query utilizing positional parameters.
+     * $query = 'SELECT * FROM `bigquery-public-data.usa_names.usa_1910_2013` WHERE number > ?';
+     * $queryResults = $bigQuery->runQuery($query, [
+     *     'parameters' => [
+     *         15
+     *     ]
+     * ]);
      *
      * $isComplete = $queryResults->isComplete();
      *
@@ -134,11 +210,20 @@ class BigQueryClient
      *           cache.
      *     @type bool $useLegacySql Specifies whether to use BigQuery's legacy
      *           SQL dialect for this query.
+     *     @type array $parameters Only available for standard SQL queries.
+     *           When providing a non-associative array positional parameters
+     *           (`?`) will be used. When providing an associative array
+     *           named parameters will be used (`@name`).
      * }
      * @return QueryResults
      */
     public function runQuery($query, array $options = [])
     {
+        if (isset($options['parameters'])) {
+            $options += $this->formatQueryParameters($options['parameters']);
+            unset($options['parameters']);
+        }
+
         $response = $this->connection->query([
             'projectId' => $this->projectId,
             'query' => $query
@@ -157,6 +242,11 @@ class BigQueryClient
      * Runs a BigQuery SQL query in an asynchronous fashion. Running a query
      * in this fashion requires you to poll for the status before being able
      * to access results.
+     *
+     * Queries constructed using
+     * [standard SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+     * can take advantage of parametriziation. For more details and examples
+     * please see {@see Google\Cloud\BigQuery\BigQueryClient::runQuery()}.
      *
      * Example:
      * ```
@@ -182,6 +272,10 @@ class BigQueryClient
      * @param array $options [optional] {
      *     Configuration options.
      *
+     *     @type array $parameters Only available for standard SQL queries.
+     *           When providing a non-associative array positional parameters
+     *           (`?`) will be used. When providing an associative array
+     *           named parameters will be used (`@name`).
      *     @type array $jobConfig Configuration settings for a query job are
      *           outlined in the [API Docs for `configuration.query`](https://goo.gl/PuRa3I).
      *           If not provided default settings will be used.
@@ -190,6 +284,15 @@ class BigQueryClient
      */
     public function runQueryAsJob($query, array $options = [])
     {
+        if (isset($options['parameters'])) {
+            if (!isset($options['jobConfig'])) {
+                $options['jobConfig'] = [];
+            }
+
+            $options['jobConfig'] += $this->formatQueryParameters($options['parameters']);
+            unset($options['parameters']);
+        }
+
         $config = $this->buildJobConfig(
             'query',
             $this->projectId,
@@ -371,5 +474,95 @@ class BigQueryClient
         ] + $options);
 
         return new Dataset($this->connection, $id, $this->projectId, $response);
+    }
+
+    /**
+     * Create a Bytes object.
+     *
+     * Example:
+     * ```
+     * $bytes = $bigQuery->bytes('hello world');
+     * ```
+     *
+     * @param string|resource|StreamInterface $value
+     * @return Bytes
+     */
+    public function bytes($value)
+    {
+        return new Bytes($value);
+    }
+
+    /**
+     * Create a Date object.
+     *
+     * Example:
+     * ```
+     * $date = $bigQuery->date(new \DateTime());
+     * ```
+     *
+     * @param \DateTimeInterface $value
+     * @return Date
+     */
+    public function date(\DateTimeInterface $value)
+    {
+        return new Date($value);
+    }
+
+    /**
+     * Create a Time object.
+     *
+     * Example:
+     * ```
+     * $time = $bigQuery->time(new \DateTime());
+     * ```
+     *
+     * @param \DateTimeInterface $value
+     * @return Time
+     */
+    public function time(\DateTimeInterface $value)
+    {
+        return new Time($value);
+    }
+
+    /**
+     * Create a Timestamp object.
+     *
+     * Example:
+     * ```
+     * $timestamp = $bigQuery->timestamp(new \DateTime());
+     * ```
+     *
+     * @param \DateTimeInterface $value
+     * @return Timestamp
+     */
+    public function timestamp(\DateTimeInterface $value)
+    {
+        return new Timestamp($value);
+    }
+
+    /**
+     * Formats query parameters for the API.
+     *
+     * @param array $parameters The parameters to format.
+     * @return array
+     */
+    private function formatQueryParameters(array $parameters)
+    {
+        $options = [
+            'parameterMode' => $this->isAssoc($parameters) ? 'named' : 'positional',
+            'useLegacySql' => false
+        ];
+
+        foreach ($parameters as $name => $value) {
+            $param = $this->mapper->toParameter($value);
+
+            if ($options['parameterMode'] === 'named') {
+                 $param += ['name' => $name];
+            }
+
+            $options['queryParameters'][] = $param;
+        }
+
+        return $options;
     }
 }

--- a/src/BigQuery/BigQueryClient.php
+++ b/src/BigQuery/BigQueryClient.php
@@ -484,7 +484,7 @@ class BigQueryClient
      * $bytes = $bigQuery->bytes('hello world');
      * ```
      *
-     * @param string|resource|StreamInterface $value
+     * @param string|resource|StreamInterface $value The bytes value.
      * @return Bytes
      */
     public function bytes($value)
@@ -500,7 +500,7 @@ class BigQueryClient
      * $date = $bigQuery->date(new \DateTime());
      * ```
      *
-     * @param \DateTimeInterface $value
+     * @param \DateTimeInterface $value The date value.
      * @return Date
      */
     public function date(\DateTimeInterface $value)
@@ -516,7 +516,7 @@ class BigQueryClient
      * $time = $bigQuery->time(new \DateTime());
      * ```
      *
-     * @param \DateTimeInterface $value
+     * @param \DateTimeInterface $value The time value.
      * @return Time
      */
     public function time(\DateTimeInterface $value)
@@ -532,7 +532,7 @@ class BigQueryClient
      * $timestamp = $bigQuery->timestamp(new \DateTime());
      * ```
      *
-     * @param \DateTimeInterface $value
+     * @param \DateTimeInterface $value The timestamp value.
      * @return Timestamp
      */
     public function timestamp(\DateTimeInterface $value)

--- a/src/BigQuery/BigQueryClient.php
+++ b/src/BigQuery/BigQueryClient.php
@@ -131,7 +131,7 @@ class BigQueryClient
      *
      * Example:
      * ```
-     * $queryResults = $bigQuery->runQuery('SELECT * FROM [bigquery-public-data:usa_names.usa_1910_2013]');
+     * $queryResults = $bigQuery->runQuery('SELECT * FROM [bigquery-public-data:github_repos.commits] LIMIT 100');
      *
      * $isComplete = $queryResults->isComplete();
      *
@@ -142,16 +142,18 @@ class BigQueryClient
      * }
      *
      * foreach ($queryResults->rows() as $row) {
-     *     echo $row['name'];
+     *     echo $row['commit'];
      * }
      * ```
      *
      * ```
      * // Construct a query utilizing named parameters.
-     * $query = 'SELECT * FROM `bigquery-public-data.usa_names.usa_1910_2013` WHERE name = @name';
+     * $query = 'SELECT * FROM `bigquery-public-data.github_repos.commits`' .
+     *          'WHERE author.date < @date AND message = @message LIMIT 100';
      * $queryResults = $bigQuery->runQuery($query, [
      *     'parameters' => [
-     *         'name' => 'Annie'
+     *         'date' => $bigQuery->timestamp(new \DateTime()),
+     *         'message' => 'A commit message.'
      *     ]
      * ]);
      *
@@ -164,17 +166,15 @@ class BigQueryClient
      * }
      *
      * foreach ($queryResults->rows() as $row) {
-     *     echo $row['name'];
+     *     echo $row['commit'];
      * }
      * ```
      *
      * ```
      * // Construct a query utilizing positional parameters.
-     * $query = 'SELECT * FROM `bigquery-public-data.usa_names.usa_1910_2013` WHERE number > ?';
+     * $query = 'SELECT * FROM `bigquery-public-data.github_repos.commits` WHERE message = ? LIMIT 100';
      * $queryResults = $bigQuery->runQuery($query, [
-     *     'parameters' => [
-     *         15
-     *     ]
+     *     'parameters' => ['A commit message.']
      * ]);
      *
      * $isComplete = $queryResults->isComplete();
@@ -186,7 +186,7 @@ class BigQueryClient
      * }
      *
      * foreach ($queryResults->rows() as $row) {
-     *     echo $row['name'];
+     *     echo $row['commit'];
      * }
      * ```
      *
@@ -250,7 +250,7 @@ class BigQueryClient
      *
      * Example:
      * ```
-     * $job = $bigQuery->runQueryAsJob('SELECT * FROM [bigquery-public-data:usa_names.usa_1910_2013]');
+     * $job = $bigQuery->runQueryAsJob('SELECT * FROM [bigquery-public-data:github_repos.commits] LIMIT 100');
      *
      * $isComplete = false;
      * $queryResults = $job->queryResults();
@@ -262,7 +262,7 @@ class BigQueryClient
      * }
      *
      * foreach ($queryResults->rows() as $row) {
-     *     echo $row['name'];
+     *     echo $row['commit'];
      * }
      * ```
      *

--- a/src/BigQuery/Bytes.php
+++ b/src/BigQuery/Bytes.php
@@ -32,7 +32,7 @@ class Bytes implements ValueInterface
     private $value;
 
     /**
-     * @param string|resource|StreamInterface $value The bytes.
+     * @param string|resource|StreamInterface $value The bytes value.
      */
     public function __construct($value)
     {
@@ -40,6 +40,8 @@ class Bytes implements ValueInterface
     }
 
     /**
+     * Get the bytes as a stream.
+     *
      * @return StreamInterface
      */
     public function get()
@@ -48,6 +50,8 @@ class Bytes implements ValueInterface
     }
 
     /**
+     * Get the type.
+     *
      * @return string
      */
     public function type()
@@ -56,6 +60,8 @@ class Bytes implements ValueInterface
     }
 
     /**
+     * Format the value for the API.
+     *
      * @return string
      */
     public function toApi()

--- a/src/BigQuery/Bytes.php
+++ b/src/BigQuery/Bytes.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+use GuzzleHttp\Psr7;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Represents a value with a data type of
+ * [bytes](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#bytes-type).
+ */
+class Bytes implements ValueInterface
+{
+    /**
+     * @var string|resource|StreamInterface
+     */
+    private $value;
+
+    /**
+     * @param string|resource|StreamInterface $value The bytes.
+     */
+    public function __construct($value)
+    {
+        $this->value = Psr7\stream_for($value);
+    }
+
+    /**
+     * @return StreamInterface
+     */
+    public function get()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return string
+     */
+    public function type()
+    {
+        return ValueMapper::TYPE_BYTES;
+    }
+
+    /**
+     * @return string
+     */
+    public function toApi()
+    {
+        return base64_encode((string) $this->value);
+    }
+}

--- a/src/BigQuery/Bytes.php
+++ b/src/BigQuery/Bytes.php
@@ -23,6 +23,11 @@ use Psr\Http\Message\StreamInterface;
 /**
  * Represents a value with a data type of
  * [bytes](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#bytes-type).
+ *
+ * Example:
+ * ```
+ * $bytes = $bigQuery->bytes('hello world');
+ * ```
  */
 class Bytes implements ValueInterface
 {
@@ -60,12 +65,22 @@ class Bytes implements ValueInterface
     }
 
     /**
-     * Format the value for the API.
+     * Format the value as a string.
      *
      * @return string
      */
-    public function toApi()
+    public function formatAsString()
     {
         return base64_encode((string) $this->value);
+    }
+
+    /**
+     * Format the value as a string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->formatAsString();
     }
 }

--- a/src/BigQuery/Connection/ServiceDefinition/bigquery-v2.json
+++ b/src/BigQuery/Connection/ServiceDefinition/bigquery-v2.json
@@ -1,15 +1,35 @@
 {
+  "kind": "discovery#restDescription",
+  "etag": "\"tbys6C40o18GZwyMen5GMkdK-3s/38ec4LBichi45rs7Z88p5kE7xpM\"",
+  "discoveryVersion": "v1",
+  "id": "bigquery:v2",
+  "name": "bigquery",
+  "version": "v2",
+  "revision": "20161029",
+  "title": "BigQuery API",
+  "description": "A data platform for customers to create, manage, share and query data.",
+  "ownerDomain": "google.com",
+  "ownerName": "Google",
+  "icons": {
+    "x16": "https://www.google.com/images/icons/product/search-16.gif",
+    "x32": "https://www.google.com/images/icons/product/search-32.gif"
+  },
+  "documentationLink": "https://cloud.google.com/bigquery/",
+  "protocol": "rest",
+  "baseUrl": "https://www.googleapis.com/bigquery/v2/",
+  "basePath": "/bigquery/v2/",
+  "rootUrl": "https://www.googleapis.com/",
+  "servicePath": "bigquery/v2/",
+  "batchPath": "batch",
   "parameters": {
     "alt": {
       "type": "string",
       "description": "Data format for the response.",
       "default": "json",
       "enum": [
-        "csv",
         "json"
       ],
       "enumDescriptions": [
-        "Responses with Content-Type of text/csv",
         "Responses with Content-Type of application/json"
       ],
       "location": "query"
@@ -46,6 +66,33 @@
       "location": "query"
     }
   },
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/bigquery": {
+          "description": "View and manage your data in Google BigQuery"
+        },
+        "https://www.googleapis.com/auth/bigquery.insertdata": {
+          "description": "Insert data into Google BigQuery"
+        },
+        "https://www.googleapis.com/auth/cloud-platform": {
+          "description": "View and manage your data across Google Cloud Platform services"
+        },
+        "https://www.googleapis.com/auth/cloud-platform.read-only": {
+          "description": "View your data across Google Cloud Platform services"
+        },
+        "https://www.googleapis.com/auth/devstorage.full_control": {
+          "description": "Manage your data and permissions in Google Cloud Storage"
+        },
+        "https://www.googleapis.com/auth/devstorage.read_only": {
+          "description": "View your data in Google Cloud Storage"
+        },
+        "https://www.googleapis.com/auth/devstorage.read_write": {
+          "description": "Manage your data in Google Cloud Storage"
+        }
+      }
+    }
+  },
   "schemas": {
     "BigtableColumn": {
       "id": "BigtableColumn",
@@ -73,7 +120,7 @@
         },
         "type": {
           "type": "string",
-          "description": "[Optional] The type to convert the value in cells of this column. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive) - BYTES STRING INTEGER FLOAT BOOLEAN Defaut type is BYTES. 'type' can also be set at the column family level. However, the setting at this level takes precedence if 'type' is set at both levels."
+          "description": "[Optional] The type to convert the value in cells of this column. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive) - BYTES STRING INTEGER FLOAT BOOLEAN Default type is BYTES. 'type' can also be set at the column family level. However, the setting at this level takes precedence if 'type' is set at both levels."
         }
       }
     },
@@ -102,7 +149,7 @@
         },
         "type": {
           "type": "string",
-          "description": "[Optional] The type to convert the value in cells of this column family. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive) - BYTES STRING INTEGER FLOAT BOOLEAN Defaut type is BYTES. This can be overridden for a specific column by listing that column in 'columns' and specifying a type for it."
+          "description": "[Optional] The type to convert the value in cells of this column family. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive) - BYTES STRING INTEGER FLOAT BOOLEAN Default type is BYTES. This can be overridden for a specific column by listing that column in 'columns' and specifying a type for it."
         }
       }
     },
@@ -120,6 +167,10 @@
         "ignoreUnspecifiedColumnFamilies": {
           "type": "boolean",
           "description": "[Optional] If field is true, then the column families that are not specified in columnFamilies list are not exposed in the table schema. Otherwise, they are read with BYTES type values. The default value is false."
+        },
+        "readRowkeyAsString": {
+          "type": "boolean",
+          "description": "[Optional] If field is true, then the rowkey column families will be read and converted to string. Otherwise they are read with BYTES type values and users need to manually cast them with CAST if necessary. The default value is false."
         }
       }
     },
@@ -141,7 +192,7 @@
         },
         "fieldDelimiter": {
           "type": "string",
-          "description": "[Optional] The separator for fields in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. BigQuery also supports the escape sequence \"\t\" to specify a tab separator. The default value is a comma (',')."
+          "description": "[Optional] The separator for fields in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. BigQuery also supports the escape sequence \"\\t\" to specify a tab separator. The default value is a comma (',')."
         },
         "quote": {
           "type": "string",
@@ -150,9 +201,9 @@
           "pattern": ".?"
         },
         "skipLeadingRows": {
-          "type": "integer",
+          "type": "string",
           "description": "[Optional] The number of rows at the top of a CSV file that BigQuery will skip when reading the data. The default value is 0. This property is useful if you have header rows in the file that should be skipped.",
-          "format": "int32"
+          "format": "int64"
         }
       }
     },
@@ -204,7 +255,7 @@
         },
         "defaultTableExpirationMs": {
           "type": "string",
-          "description": "[Experimental] The default lifetime of all tables in the dataset, in milliseconds. The minimum value is 3600000 milliseconds (one hour). Once this property is set, all newly-created tables in the dataset will have an expirationTime property set to the creation time plus the value in this property, and changing the value will only affect new tables, not existing ones. When the expirationTime for a given table is reached, that table will be deleted automatically. If a table's expirationTime is modified or removed before the table expires, or if you provide an explicit expirationTime when creating a table, that value takes precedence over the default expiration time indicated by this property.",
+          "description": "[Optional] The default lifetime of all tables in the dataset, in milliseconds. The minimum value is 3600000 milliseconds (one hour). Once this property is set, all newly-created tables in the dataset will have an expirationTime property set to the creation time plus the value in this property, and changing the value will only affect new tables, not existing ones. When the expirationTime for a given table is reached, that table will be deleted automatically. If a table's expirationTime is modified or removed before the table expires, or if you provide an explicit expirationTime when creating a table, that value takes precedence over the default expiration time indicated by this property.",
           "format": "int64"
         },
         "description": {
@@ -227,6 +278,13 @@
           "type": "string",
           "description": "[Output-only] The resource type.",
           "default": "bigquery#dataset"
+        },
+        "labels": {
+          "type": "object",
+          "description": "[Experimental] The labels associated with this dataset. You can use these to organize and group your datasets. You can set this property when inserting or updating a dataset. See Labeling Datasets for more information.",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "lastModifiedTime": {
           "type": "string",
@@ -269,6 +327,13 @@
                 "type": "string",
                 "description": "The resource type. This property always returns the value \"bigquery#dataset\".",
                 "default": "bigquery#dataset"
+              },
+              "labels": {
+                "type": "object",
+                "description": "[Experimental] The labels associated with this dataset. You can use these to organize and group your datasets.",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             }
           }
@@ -443,6 +508,10 @@
           "$ref": "CsvOptions",
           "description": "Additional properties to set if sourceFormat is set to CSV."
         },
+        "googleSheetsOptions": {
+          "$ref": "GoogleSheetsOptions",
+          "description": "[Optional] Additional options if sourceFormat is set to GOOGLE_SHEETS."
+        },
         "ignoreUnknownValues": {
           "type": "boolean",
           "description": "[Optional] Indicates if BigQuery should allow extra values that are not represented in the table schema. If true, the extra values are ignored. If false, records with extra columns are treated as bad records, and if there are too many bad records, an invalid error is returned in the job result. The default value is false. The sourceFormat property determines what BigQuery treats as an extra value: CSV: Trailing columns JSON: Named values that don't match any column names Google Cloud Bigtable: This setting is ignored. Google Cloud Datastore backups: This setting is ignored. Avro: This setting is ignored."
@@ -458,11 +527,11 @@
         },
         "sourceFormat": {
           "type": "string",
-          "description": "[Required] The data format. For CSV files, specify \"CSV\". For newline-delimited JSON, specify \"NEWLINE_DELIMITED_JSON\". For Avro files, specify \"AVRO\". For Google Cloud Datastore backups, specify \"DATASTORE_BACKUP\". [Experimental] For Google Cloud Bigtable, specify \"BIGTABLE\". Please note that reading from Google Cloud Bigtable is experimental and has to be enabled for your project. Please contact Google Cloud Support to enable this for your project."
+          "description": "[Required] The data format. For CSV files, specify \"CSV\". For Google sheets, specify \"GOOGLE_SHEETS\". For newline-delimited JSON, specify \"NEWLINE_DELIMITED_JSON\". For Avro files, specify \"AVRO\". For Google Cloud Datastore backups, specify \"DATASTORE_BACKUP\". [Experimental] For Google Cloud Bigtable, specify \"BIGTABLE\". Please note that reading from Google Cloud Bigtable is experimental and has to be enabled for your project. Please contact Google Cloud Support to enable this for your project."
         },
         "sourceUris": {
           "type": "array",
-          "description": "[Required] The fully-qualified URIs that point to your data in Google Cloud. For Google Cloud Storage URIs: Each URI can contain one '*' wildcard character and it must come after the 'bucket' name. Size limits related to load jobs apply to external data sources, plus an additional limit of 10 GB maximum size across all URIs. For Google Cloud Bigtable URIs: Exactly one URI can be specified and it has be a fully specified and valid HTTPS URL for a Google Cloud Bigtable table. For Google Cloud Datastore backups, exactly one URI can be specified, and it must end with '.backup_info'. Also, the '*' wildcard character is not allowed.",
+          "description": "[Required] The fully-qualified URIs that point to your data in Google Cloud. For Google Cloud Storage URIs: Each URI can contain one '*' wildcard character and it must come after the 'bucket' name. Size limits related to load jobs apply to external data sources. For Google Cloud Bigtable URIs: Exactly one URI can be specified and it has be a fully specified and valid HTTPS URL for a Google Cloud Bigtable table. For Google Cloud Datastore backups, exactly one URI can be specified, and it must end with '.backup_info'. Also, the '*' wildcard character is not allowed.",
           "items": {
             "type": "string"
           }
@@ -501,6 +570,11 @@
           "description": "The resource type of the response.",
           "default": "bigquery#getQueryResultsResponse"
         },
+        "numDmlAffectedRows": {
+          "type": "string",
+          "description": "[Output-only, Experimental] The number of rows affected by a DML statement. Present only for DML statements INSERT, UPDATE or DELETE.",
+          "format": "int64"
+        },
         "pageToken": {
           "type": "string",
           "description": "A token used for paging results."
@@ -525,6 +599,17 @@
           "type": "string",
           "description": "The total number of rows in the complete query result set, which can be more than the number of rows in this single page of results. Present only when the query completes successfully.",
           "format": "uint64"
+        }
+      }
+    },
+    "GoogleSheetsOptions": {
+      "id": "GoogleSheetsOptions",
+      "type": "object",
+      "properties": {
+        "skipLeadingRows": {
+          "type": "string",
+          "description": "[Optional] The number of rows at the top of a sheet that BigQuery will skip when reading the data. The default value is 0. This property is useful if you have header rows that should be skipped. When autodetect is on, behavior is the following: * skipLeadingRows unspecified - Autodetect tries to detect headers in the first row. If they are not detected, the row is read as data. Otherwise data is read starting from the second row. * skipLeadingRows is 0 - Instructs autodetect that there are no headers and data should be read starting from the first row. * skipLeadingRows = N > 0 - Autodetect skips N-1 rows and tries to detect headers in row N. If headers are not detected, row N is just skipped. Otherwise row N is used to extract column names for the detected schema.",
+          "format": "int64"
         }
       }
     },
@@ -602,6 +687,13 @@
           "$ref": "JobConfigurationExtract",
           "description": "[Pick one] Configures an extract job."
         },
+        "labels": {
+          "type": "object",
+          "description": "[Experimental] The labels associated with this job. You can use these to organize and group your jobs. Label keys and values can be no longer than 63 characters, can only contain letters, numeric characters, underscores and dashes. International characters are allowed. Label values are optional. Label keys must start with a letter and must be unique within a dataset. Both keys and values are additionally constrained to be <= 128 bytes in size.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "load": {
           "$ref": "JobConfigurationLoad",
           "description": "[Pick one] Configures a load job."
@@ -662,6 +754,10 @@
           "type": "boolean",
           "description": "Indicates if BigQuery should allow quoted data sections that contain newline characters in a CSV file. The default value is false."
         },
+        "autodetect": {
+          "type": "boolean",
+          "description": "[Experimental] Indicates if we should automatically infer the options and schema for CSV and JSON sources."
+        },
         "createDisposition": {
           "type": "string",
           "description": "[Optional] Specifies whether the job is allowed to create new tables. The following values are supported: CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table. CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result. The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion."
@@ -676,7 +772,7 @@
         },
         "fieldDelimiter": {
           "type": "string",
-          "description": "[Optional] The separator for fields in a CSV file. The separator can be any ISO-8859-1 single-byte character. To use a character in the range 128-255, you must encode the character as UTF8. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. BigQuery also supports the escape sequence \"\t\" to specify a tab separator. The default value is a comma (',')."
+          "description": "[Optional] The separator for fields in a CSV file. The separator can be any ISO-8859-1 single-byte character. To use a character in the range 128-255, you must encode the character as UTF8. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. BigQuery also supports the escape sequence \"\\t\" to specify a tab separator. The default value is a comma (',')."
         },
         "ignoreUnknownValues": {
           "type": "boolean",
@@ -712,6 +808,13 @@
           "type": "string",
           "description": "[Deprecated] The format of the schemaInline property."
         },
+        "schemaUpdateOptions": {
+          "type": "array",
+          "description": "[Experimental] Allows the schema of the desitination table to be updated as a side effect of the load job. Schema update options are supported in two cases: when writeDisposition is WRITE_APPEND; when writeDisposition is WRITE_TRUNCATE and the destination table is a partition of a table, specified by partition decorators. For normal tables, WRITE_TRUNCATE will always overwrite the schema. One or more of the following values are specified: ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema. ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original schema to nullable.",
+          "items": {
+            "type": "string"
+          }
+        },
         "skipLeadingRows": {
           "type": "integer",
           "description": "[Optional] The number of rows at the top of a CSV file that BigQuery will skip when loading the data. The default value is 0. This property is useful if you have header rows in the file that should be skipped.",
@@ -719,7 +822,7 @@
         },
         "sourceFormat": {
           "type": "string",
-          "description": "[Optional] The format of the data files. For CSV files, specify \"CSV\". For datastore backups, specify \"DATASTORE_BACKUP\". For newline-delimited JSON, specify \"NEWLINE_DELIMITED_JSON\". The default value is CSV."
+          "description": "[Optional] The format of the data files. For CSV files, specify \"CSV\". For datastore backups, specify \"DATASTORE_BACKUP\". For newline-delimited JSON, specify \"NEWLINE_DELIMITED_JSON\". For Avro, specify \"AVRO\". The default value is CSV."
         },
         "sourceUris": {
           "type": "array",
@@ -765,6 +868,15 @@
           "default": "1",
           "format": "int32"
         },
+        "maximumBytesBilled": {
+          "type": "string",
+          "description": "[Optional] Limits the bytes billed for this job. Queries that will have bytes billed beyond this limit will fail (without incurring a charge). If unspecified, this will be set to your project default.",
+          "format": "int64"
+        },
+        "parameterMode": {
+          "type": "string",
+          "description": "[Experimental] Standard SQL only. Whether to use positional (?) or named (@myparam) query parameters in this query."
+        },
         "preserveNulls": {
           "type": "boolean",
           "description": "[Deprecated] This property is deprecated."
@@ -777,6 +889,20 @@
           "type": "string",
           "description": "[Required] BigQuery SQL query to execute."
         },
+        "queryParameters": {
+          "type": "array",
+          "description": "Query parameters for standard SQL queries.",
+          "items": {
+            "$ref": "QueryParameter"
+          }
+        },
+        "schemaUpdateOptions": {
+          "type": "array",
+          "description": "[Experimental] Allows the schema of the destination table to be updated as a side effect of the query job. Schema update options are supported in two cases: when writeDisposition is WRITE_APPEND; when writeDisposition is WRITE_TRUNCATE and the destination table is a partition of a table, specified by partition decorators. For normal tables, WRITE_TRUNCATE will always overwrite the schema. One or more of the following values are specified: ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema. ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original schema to nullable.",
+          "items": {
+            "type": "string"
+          }
+        },
         "tableDefinitions": {
           "type": "object",
           "description": "[Optional] If querying an external data source outside of BigQuery, describes the data format, location and other properties of the data source. By defining these properties, the data source can then be queried as if it were a standard BigQuery table.",
@@ -786,7 +912,7 @@
         },
         "useLegacySql": {
           "type": "boolean",
-          "description": "[Experimental] Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query will use BigQuery's updated SQL dialect with improved standards compliance. When using BigQuery's updated SQL, the values of allowLargeResults and flattenResults are ignored. Queries with useLegacySql set to false will be run as if allowLargeResults is true and flattenResults is false."
+          "description": "Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query will use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/ When useLegacySql is set to false, the values of allowLargeResults and flattenResults are ignored; query will be run as if allowLargeResults is true and flattenResults is false."
         },
         "useQueryCache": {
           "type": "boolean",
@@ -975,9 +1101,14 @@
           "type": "boolean",
           "description": "[Output-only] Whether the query result was fetched from the query cache."
         },
+        "numDmlAffectedRows": {
+          "type": "string",
+          "description": "[Output-only, Experimental] The number of rows affected by a DML statement. Present only for DML statements INSERT, UPDATE or DELETE.",
+          "format": "int64"
+        },
         "queryPlan": {
           "type": "array",
-          "description": "[Output-only, Experimental] Describes execution plan for the query as a list of stages.",
+          "description": "[Output-only, Experimental] Describes execution plan for the query.",
           "items": {
             "$ref": "ExplainQueryStage"
           }
@@ -989,6 +1120,10 @@
             "$ref": "TableReference"
           }
         },
+        "schema": {
+          "$ref": "TableSchema",
+          "description": "[Output-only, Experimental] The schema of the results. Present only for successful dry run of non-legacy SQL queries."
+        },
         "totalBytesBilled": {
           "type": "string",
           "description": "[Output-only] Total bytes billed for the job.",
@@ -998,6 +1133,13 @@
           "type": "string",
           "description": "[Output-only] Total bytes processed for the job.",
           "format": "int64"
+        },
+        "undeclaredQueryParameters": {
+          "type": "array",
+          "description": "[Output-only, Experimental] Standard SQL only: list of undeclared query parameters detected during a dry run validation.",
+          "items": {
+            "$ref": "QueryParameter"
+          }
         }
       }
     },
@@ -1139,6 +1281,83 @@
         }
       }
     },
+    "QueryParameter": {
+      "id": "QueryParameter",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "[Optional] If unset, this is a positional parameter. Otherwise, should be unique within a query."
+        },
+        "parameterType": {
+          "$ref": "QueryParameterType",
+          "description": "[Required] The type of this parameter."
+        },
+        "parameterValue": {
+          "$ref": "QueryParameterValue",
+          "description": "[Required] The value of this parameter."
+        }
+      }
+    },
+    "QueryParameterType": {
+      "id": "QueryParameterType",
+      "type": "object",
+      "properties": {
+        "arrayType": {
+          "$ref": "QueryParameterType",
+          "description": "[Optional] The type of the array's elements, if this is an array."
+        },
+        "structTypes": {
+          "type": "array",
+          "description": "[Optional] The types of the fields of this struct, in order, if this is a struct.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string",
+                "description": "[Optional] Human-oriented description of the field."
+              },
+              "name": {
+                "type": "string",
+                "description": "[Optional] The name of this field."
+              },
+              "type": {
+                "$ref": "QueryParameterType",
+                "description": "[Required] The type of this field."
+              }
+            }
+          }
+        },
+        "type": {
+          "type": "string",
+          "description": "[Required] The top level type of this field."
+        }
+      }
+    },
+    "QueryParameterValue": {
+      "id": "QueryParameterValue",
+      "type": "object",
+      "properties": {
+        "arrayValues": {
+          "type": "array",
+          "description": "[Optional] The array values, if this is an array type.",
+          "items": {
+            "$ref": "QueryParameterValue"
+          }
+        },
+        "structValues": {
+          "type": "object",
+          "description": "[Optional] The struct field values, in order of the struct type's declaration.",
+          "additionalProperties": {
+            "$ref": "QueryParameterValue"
+          }
+        },
+        "value": {
+          "type": "string",
+          "description": "[Optional] The value of this value, if a simple scalar type."
+        }
+      }
+    },
     "QueryRequest": {
       "id": "QueryRequest",
       "type": "object",
@@ -1161,6 +1380,10 @@
           "description": "[Optional] The maximum number of rows of data to return per page of results. Setting this flag to a small value such as 1000 and then paging through results might improve reliability when the query result set is large. In addition to this limit, responses are also limited to 10 MB. By default, there is no maximum row count, and only the byte limit applies.",
           "format": "uint32"
         },
+        "parameterMode": {
+          "type": "string",
+          "description": "[Experimental] Standard SQL only. Whether to use positional (?) or named (@myparam) query parameters in this query."
+        },
         "preserveNulls": {
           "type": "boolean",
           "description": "[Deprecated] This property is deprecated."
@@ -1174,6 +1397,13 @@
             ]
           }
         },
+        "queryParameters": {
+          "type": "array",
+          "description": "[Experimental] Query parameters for Standard SQL queries.",
+          "items": {
+            "$ref": "QueryParameter"
+          }
+        },
         "timeoutMs": {
           "type": "integer",
           "description": "[Optional] How long to wait for the query to complete, in milliseconds, before the request times out and returns. Note that this is only a timeout for the request, not the query. If the query takes longer to run than the timeout value, the call returns without any results and with the 'jobComplete' flag set to false. You can call GetQueryResults() to wait for the query to complete and read the results. The default value is 10000 milliseconds (10 seconds).",
@@ -1181,7 +1411,8 @@
         },
         "useLegacySql": {
           "type": "boolean",
-          "description": "[Experimental] Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query will use BigQuery's updated SQL dialect with improved standards compliance. When using BigQuery's updated SQL, the values of allowLargeResults and flattenResults are ignored. Queries with useLegacySql set to false will be run as if allowLargeResults is true and flattenResults is false."
+          "description": "Specifies whether to use BigQuery's legacy SQL dialect for this query. The default value is true. If set to false, the query will use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/ When useLegacySql is set to false, the values of allowLargeResults and flattenResults are ignored; query will be run as if allowLargeResults is true and flattenResults is false.",
+          "default": "true"
         },
         "useQueryCache": {
           "type": "boolean",
@@ -1217,6 +1448,11 @@
           "type": "string",
           "description": "The resource type.",
           "default": "bigquery#queryResponse"
+        },
+        "numDmlAffectedRows": {
+          "type": "string",
+          "description": "[Output-only, Experimental] The number of rows affected by a DML statement. Present only for DML statements INSERT, UPDATE or DELETE.",
+          "format": "int64"
         },
         "pageToken": {
           "type": "string",
@@ -1319,6 +1555,11 @@
           "description": "[Output-only] The size of this table in bytes, excluding any data in the streaming buffer.",
           "format": "int64"
         },
+        "numLongTermBytes": {
+          "type": "string",
+          "description": "[Output-only] The number of bytes in the table that are considered \"long-term storage\".",
+          "format": "int64"
+        },
         "numRows": {
           "type": "string",
           "description": "[Output-only] The number of rows of data in this table, excluding any data in the streaming buffer.",
@@ -1339,6 +1580,10 @@
         "tableReference": {
           "$ref": "TableReference",
           "description": "[Required] Reference describing the ID of this table."
+        },
+        "timePartitioning": {
+          "$ref": "TimePartitioning",
+          "description": "[Experimental] If specified, configures time-based partitioning for this table."
         },
         "type": {
           "type": "string",
@@ -1487,7 +1732,7 @@
         },
         "type": {
           "type": "string",
-          "description": "[Required] The field data type. Possible values include STRING, INTEGER, FLOAT, BOOLEAN, TIMESTAMP or RECORD (where RECORD indicates that the field contains a nested schema)."
+          "description": "[Required] The field data type. Possible values include STRING, BYTES, INTEGER, FLOAT, BOOLEAN, TIMESTAMP, DATE, TIME, DATETIME, or RECORD (where RECORD indicates that the field contains a nested schema)."
         }
       }
     },
@@ -1604,6 +1849,21 @@
         }
       }
     },
+    "TimePartitioning": {
+      "id": "TimePartitioning",
+      "type": "object",
+      "properties": {
+        "expirationMs": {
+          "type": "string",
+          "description": "[Optional] Number of milliseconds for which to keep the storage for a partition.",
+          "format": "int64"
+        },
+        "type": {
+          "type": "string",
+          "description": "[Required] The only type supported is DAY, which will generate one partition per day based on data loading time."
+        }
+      }
+    },
     "UserDefinedFunctionResource": {
       "id": "UserDefinedFunctionResource",
       "type": "object",
@@ -1625,6 +1885,10 @@
         "query": {
           "type": "string",
           "description": "[Required] A query that BigQuery executes when the view is referenced."
+        },
+        "useLegacySql": {
+          "type": "boolean",
+          "description": "Specifies whether to use BigQuery's legacy SQL for this view. The default value is true. If set to false, the view will use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/ Queries and views that reference this view must use the same flag value."
         },
         "userDefinedFunctionResources": {
           "type": "array",
@@ -1742,6 +2006,11 @@
               "description": "Whether to list all datasets, including hidden ones",
               "location": "query"
             },
+            "filter": {
+              "type": "string",
+              "description": "An expression for filtering the results of the request by label. The syntax is \"labels.<name>[:<value>]\". Multiple filters can be ANDed together by connecting with a space. Example: \"labels.department:receiving labels.active\". See Filtering datasets using labels for details.",
+              "location": "query"
+            },
             "maxResults": {
               "type": "integer",
               "description": "The maximum number of results to return",
@@ -1846,7 +2115,7 @@
       "methods": {
         "cancel": {
           "id": "bigquery.jobs.cancel",
-          "path": "project/{projectId}/jobs/{jobId}/cancel",
+          "path": "projects/{projectId}/jobs/{jobId}/cancel",
           "httpMethod": "POST",
           "description": "Requests that a job be cancelled. This call will return immediately, and the client will need to poll for the job status to see if the cancel completed successfully. Cancelled jobs may still incur costs.",
           "parameters": {

--- a/src/BigQuery/Date.php
+++ b/src/BigQuery/Date.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+/**
+ * Represents a value with a data type of
+ * [Date](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#date-type).
+ */
+class Date implements ValueInterface
+{
+    const FORMAT = 'Y-m-d';
+
+    /**
+     * @var \DateTimeInterface
+     */
+    protected $value;
+
+    /**
+     * @param \DateTimeInterface $value
+     */
+    public function __construct(\DateTimeInterface $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function get()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return string
+     */
+    public function type()
+    {
+        return ValueMapper::TYPE_DATE;
+    }
+
+    /**
+     * @return string
+     */
+    public function toApi()
+    {
+        return $this->value->format(self::FORMAT);
+    }
+}

--- a/src/BigQuery/Date.php
+++ b/src/BigQuery/Date.php
@@ -31,7 +31,7 @@ class Date implements ValueInterface
     protected $value;
 
     /**
-     * @param \DateTimeInterface $value
+     * @param \DateTimeInterface $value The date value.
      */
     public function __construct(\DateTimeInterface $value)
     {
@@ -39,6 +39,8 @@ class Date implements ValueInterface
     }
 
     /**
+     * Get the underlying `\DateTimeInterface` implementation.
+     *
      * @return \DateTimeInterface
      */
     public function get()
@@ -47,6 +49,8 @@ class Date implements ValueInterface
     }
 
     /**
+     * Get the type.
+     *
      * @return string
      */
     public function type()
@@ -55,6 +59,8 @@ class Date implements ValueInterface
     }
 
     /**
+     * Format the value for the API.
+     *
      * @return string
      */
     public function toApi()

--- a/src/BigQuery/Date.php
+++ b/src/BigQuery/Date.php
@@ -20,6 +20,11 @@ namespace Google\Cloud\BigQuery;
 /**
  * Represents a value with a data type of
  * [Date](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#date-type).
+ *
+ * Example:
+ * ```
+ * $date = $bigQuery->date(new \DateTime('1995-02-04'));
+ * ```
  */
 class Date implements ValueInterface
 {
@@ -59,12 +64,22 @@ class Date implements ValueInterface
     }
 
     /**
-     * Format the value for the API.
+     * Format the value as a string.
      *
      * @return string
      */
-    public function toApi()
+    public function formatAsString()
     {
         return $this->value->format(self::FORMAT);
+    }
+
+    /**
+     * Format the value as a string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->formatAsString();
     }
 }

--- a/src/BigQuery/Job.php
+++ b/src/BigQuery/Job.php
@@ -43,20 +43,32 @@ class Job
     private $info;
 
     /**
+     * @var ValueMapper $mapper Maps values between PHP and BigQuery.
+     */
+    private $mapper;
+
+    /**
      * @param ConnectionInterface $connection Represents a connection to
      *        BigQuery.
      * @param string $id The job's ID.
      * @param string $projectId The project's ID.
      * @param array $info [optional] The job's metadata.
+     * @param ValueMapper $mapper Maps values between PHP and BigQuery.
      */
-    public function __construct(ConnectionInterface $connection, $id, $projectId, array $info = [])
-    {
+    public function __construct(
+        ConnectionInterface $connection,
+        $id,
+        $projectId,
+        array $info = [],
+        ValueMapper $mapper = null
+    ) {
         $this->connection = $connection;
         $this->info = $info;
         $this->identity = [
             'jobId' => $id,
             'projectId' => $projectId
         ];
+        $this->mapper = $mapper;
     }
 
     /**
@@ -139,7 +151,8 @@ class Job
             $this->identity['jobId'],
             $this->identity['projectId'],
             $response,
-            $options
+            $options,
+            $this->mapper
         );
     }
 

--- a/src/BigQuery/QueryResults.php
+++ b/src/BigQuery/QueryResults.php
@@ -106,15 +106,7 @@ class QueryResults
         while (true) {
             $options['pageToken'] = isset($this->info['pageToken']) ? $this->info['pageToken'] : null;
 
-            foreach ($this->info['rows'] as $row) {
-                $mergedRow = [];
-
-                foreach ($row['f'] as $key => $value) {
-                    $mergedRow[$schema[$key]['name']] = $value['v'];
-                }
-
-                yield $mergedRow;
-            }
+            yield $this->extractValues($schema, $this->info['rows']);
 
             if (!$options['pageToken']) {
                 return;
@@ -124,6 +116,99 @@ class QueryResults
         }
     }
 
+    /**
+     * Extract values from query response.
+     *
+     * @param $schema
+     * @param $rows
+     * @return array
+     * @throws GoogleException
+     */
+    public function extractValues($schema, array $rows)
+    {
+        $output = [];
+
+        if ($rows === null) {
+            return null;
+        }
+
+        foreach ($rows as $row) {
+            if ($row === null) {
+                continue;
+            }
+
+            if (!array_key_exists('f', $row)) {
+                throw new GoogleException('Bad response - missing key "f" for a row.');
+            }
+
+            foreach ($row['f'] as $key => $value) {
+
+                $fieldSchema = $schema[$key];
+                $fieldName = $fieldSchema['name'];
+
+                if ($this->isRepeatedRecord($fieldSchema)) {
+
+                    if (!array_key_exists('v', $value)) {
+                        throw new GoogleException('Bad response - missing key "v" for a repeated record field.');
+                    }
+
+                    foreach ($value['v'] as $record) {
+                        $output[$fieldName][] = $this->extractValues($fieldSchema['fields'], $record);
+                    }
+
+                } elseif ($this->isSingleRecord($fieldSchema)) {
+
+                    $output[$fieldName] = $this->extractValues($fieldSchema['fields'], $value);
+
+                } elseif ($this->isScalar($fieldSchema)) {
+
+                    if (!array_key_exists('v', $value)) {
+                        throw new GoogleException('Bad response - missing key "v" for a single value field.');
+                    }
+
+                    $output[$fieldName] = $this->getScalarValue($value['v'], $fieldSchema);
+                }
+            }
+        }
+        return $output;
+    }
+
+    private function isRepeatedRecord($fieldSchema)
+    {
+        return ($fieldSchema['type'] === 'RECORD' && $fieldSchema['mode'] === 'REPEATED');
+    }
+
+    private function isSingleRecord($fieldSchema)
+    {
+        return ($fieldSchema['type'] === 'RECORD');
+    }
+
+    private function isScalar($fieldSchema)
+    {
+        return ($fieldSchema['type'] !== 'RECORD');
+    }
+
+    private function getScalarValue($value, $fieldSchema)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($fieldSchema['type'] === 'TIMESTAMP') {
+
+            $date = new \DateTime();
+            $date->setTimestamp($value);
+            $output = $date->format('Y-m-d H:i:s T');
+
+        } else {
+
+            $output = $value;
+
+        }
+
+        return $output;
+    }    
+    
     /**
      * Checks the query's completeness. Useful in combination with
      * {@see Google\Cloud\BigQuery\QueryResults::reload()} to poll for query status.

--- a/src/BigQuery/QueryResults.php
+++ b/src/BigQuery/QueryResults.php
@@ -46,6 +46,11 @@ class QueryResults
     private $info;
 
     /**
+     * @var ValueMapper $mapper Maps values between PHP and BigQuery.
+     */
+    private $mapper;
+
+    /**
      * @var array The options to use when reloading query data.
      */
     private $reloadOptions;
@@ -57,9 +62,16 @@ class QueryResults
      * @param string $projectId The project's ID.
      * @param array $info The query result's metadata.
      * @param array $reloadOptions The options to use when reloading query data.
+     * @param ValueMapper $mapper Maps values between PHP and BigQuery.
      */
-    public function __construct(ConnectionInterface $connection, $jobId, $projectId, array $info, array $reloadOptions)
-    {
+    public function __construct(
+        ConnectionInterface $connection,
+        $jobId,
+        $projectId,
+        array $info,
+        array $reloadOptions,
+        ValueMapper $mapper
+    ) {
         $this->connection = $connection;
         $this->info = $info;
         $this->reloadOptions = $reloadOptions;
@@ -67,12 +79,31 @@ class QueryResults
             'jobId' => $jobId,
             'projectId' => $projectId
         ];
+        $this->mapper = $mapper;
     }
 
     /**
      * Retrieves the rows associated with the query and merges them together
      * with the table's schema. It is recommended to check the completeness of
      * the query before attempting to access rows.
+     *
+     * Refer to the table below for a guide on how BigQuery types are mapped as
+     * they come back from the API.
+     *
+     * | **PHP Type**                               | **BigQuery Data Type**               |
+     * |--------------------------------------------|--------------------------------------|
+     * | `\DateTimeInterface`                       | `DATETIME`                           |
+     * | {@see Google\Cloud\BigQuery\Bytes}         | `BYTES`                              |
+     * | {@see Google\Cloud\BigQuery\Date}          | `DATE`                               |
+     * | {@see Google\Cloud\Int64}                  | `INTEGER`                            |
+     * | {@see Google\Cloud\BigQuery\Time}          | `TIME`                               |
+     * | {@see Google\Cloud\BigQuery\Timestamp}     | `TIMESTAMP`                          |
+     * | Associative Array                          | `RECORD`                             |
+     * | Non-Associative Array                      | `RECORD` (Repeated)                  |
+     * | `float`                                    | `FLOAT`                              |
+     * | `int`                                      | `INTEGER`                            |
+     * | `string`                                   | `STRING`                             |
+     * | `bool`                                     | `BOOLEAN`                            |
      *
      * Example:
      * ```
@@ -106,8 +137,23 @@ class QueryResults
         while (true) {
             $options['pageToken'] = isset($this->info['pageToken']) ? $this->info['pageToken'] : null;
 
-            foreach ($this->extractValues($schema, $this->info['rows']) as $index => $row) {
-                yield $index => $row;
+            foreach ($this->info['rows'] as $row) {
+                $mergedRow = [];
+
+                if ($row === null) {
+                    continue;
+                }
+
+                if (!array_key_exists('f', $row)) {
+                    throw new GoogleException('Bad response - missing key "f" for a row.');
+                }
+
+                foreach ($row['f'] as $key => $value) {
+                    $fieldSchema = $schema[$key];
+                    $mergedRow[$fieldSchema['name']] = $this->mapper->fromBigQuery($value, $fieldSchema);
+                }
+
+                yield $mergedRow;
             }
 
             if (!$options['pageToken']) {
@@ -118,109 +164,6 @@ class QueryResults
         }
     }
 
-    /**
-     * Extract values from query response.
-     *
-     * @param $schema
-     * @param $rows
-     * @return array
-     * @throws GoogleException
-     */
-    public function extractValues($schema, array $rows)
-    {
-        $output = [];
-
-        if ($rows === null) {
-            return null;
-        }
-
-        foreach ($rows as $rowIndex => $row) {
-            if ($row === null) {
-                continue;
-            }
-
-            if (!array_key_exists('f', $row)) {
-                throw new GoogleException('Bad response - missing key "f" for a row.');
-            }
-
-            $mergedFields = [];
-
-            foreach ($row['f'] as $key => $value) {
-
-                $fieldSchema = $schema[$key];
-                $fieldName = $fieldSchema['name'];
-
-                if ($this->isRepeatedRecord($fieldSchema)) {
-
-                    if (!array_key_exists('v', $value)) {
-                        throw new GoogleException('Bad response - missing key "v" for a repeated record field.');
-                    }
-
-                    foreach ($value['v'] as $record) {
-                        $mergedFields[$fieldName][] = $this->extractValues($fieldSchema['fields'], $record);
-                    }
-
-                } elseif ($this->isSingleRecord($fieldSchema)) {
-
-                    $mergedFields[$fieldName] = $this->extractValues($fieldSchema['fields'], $value);
-
-                } elseif ($this->isScalar($fieldSchema)) {
-
-                    if (!array_key_exists('v', $value)) {
-                        throw new GoogleException('Bad response - missing key "v" for a single value field.');
-                    }
-
-                    $mergedFields[$fieldName] = $this->getScalarValue($value['v'], $fieldSchema);
-                }
-            }
-
-            if (is_numeric($rowIndex)) {
-                $output[] = $mergedFields;
-            }
-            else {
-                $output = $mergedFields;
-            }
-        }
-
-        return $output;
-    }
-
-    private function isRepeatedRecord($fieldSchema)
-    {
-        return ($fieldSchema['type'] === 'RECORD' && $fieldSchema['mode'] === 'REPEATED');
-    }
-
-    private function isSingleRecord($fieldSchema)
-    {
-        return ($fieldSchema['type'] === 'RECORD');
-    }
-
-    private function isScalar($fieldSchema)
-    {
-        return ($fieldSchema['type'] !== 'RECORD');
-    }
-
-    private function getScalarValue($value, $fieldSchema)
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        if ($fieldSchema['type'] === 'TIMESTAMP') {
-
-            $date = new \DateTime();
-            $date->setTimestamp($value);
-            $output = $date->format('Y-m-d H:i:s T');
-
-        } else {
-
-            $output = $value;
-
-        }
-
-        return $output;
-    }    
-    
     /**
      * Checks the query's completeness. Useful in combination with
      * {@see Google\Cloud\BigQuery\QueryResults::reload()} to poll for query status.

--- a/src/BigQuery/Time.php
+++ b/src/BigQuery/Time.php
@@ -20,6 +20,11 @@ namespace Google\Cloud\BigQuery;
 /**
  * Represents a value with a data type of
  * [Time](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#time-type).
+ *
+ * Example:
+ * ```
+ * $time = $bigQuery->time(new \DateTime('12:15:00.482172'));
+ * ```
  */
 class Time implements ValueInterface
 {
@@ -59,12 +64,22 @@ class Time implements ValueInterface
     }
 
     /**
-     * Format the value for the API.
+     * Format the value as a string.
      *
      * @return string
      */
-    public function toApi()
+    public function formatAsString()
     {
         return $this->value->format(self::FORMAT);
+    }
+
+    /**
+     * Format the value as a string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->formatAsString();
     }
 }

--- a/src/BigQuery/Time.php
+++ b/src/BigQuery/Time.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+/**
+ * Represents a value with a data type of
+ * [Time](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#time-type).
+ */
+class Time implements ValueInterface
+{
+    const FORMAT = 'H:i:s.u';
+
+    /**
+     * @var \DateTimeInterface
+     */
+    private $value;
+
+    /**
+     * @param \DateTimeInterface $value
+     */
+    public function __construct(\DateTimeInterface $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function get()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return string
+     */
+    public function type()
+    {
+        return ValueMapper::TYPE_TIME;
+    }
+
+    /**
+     * @return string
+     */
+    public function toApi()
+    {
+        return $this->value->format(self::FORMAT);
+    }
+}

--- a/src/BigQuery/Time.php
+++ b/src/BigQuery/Time.php
@@ -31,7 +31,7 @@ class Time implements ValueInterface
     private $value;
 
     /**
-     * @param \DateTimeInterface $value
+     * @param \DateTimeInterface $value The time value.
      */
     public function __construct(\DateTimeInterface $value)
     {
@@ -39,6 +39,8 @@ class Time implements ValueInterface
     }
 
     /**
+     * Get the underlying `\DateTimeInterface` implementation.
+     *
      * @return \DateTimeInterface
      */
     public function get()
@@ -47,6 +49,8 @@ class Time implements ValueInterface
     }
 
     /**
+     * Get the type.
+     *
      * @return string
      */
     public function type()
@@ -55,6 +59,8 @@ class Time implements ValueInterface
     }
 
     /**
+     * Format the value for the API.
+     *
      * @return string
      */
     public function toApi()

--- a/src/BigQuery/Timestamp.php
+++ b/src/BigQuery/Timestamp.php
@@ -20,6 +20,11 @@ namespace Google\Cloud\BigQuery;
 /**
  * Represents a value with a data type of
  * [Timestamp](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp-type).
+ *
+ * Example:
+ * ```
+ * $timestamp = $bigQuery->timestamp(new \DateTime('2003-02-05 11:15:02.421827Z'));
+ * ```
  */
 class Timestamp implements ValueInterface
 {
@@ -59,12 +64,22 @@ class Timestamp implements ValueInterface
     }
 
     /**
-     * Format the value for the API.
+     * Format the value as a string.
      *
      * @return string
      */
-    public function toApi()
+    public function formatAsString()
     {
         return $this->value->format(self::FORMAT);
+    }
+
+    /**
+     * Format the value as a string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->formatAsString();
     }
 }

--- a/src/BigQuery/Timestamp.php
+++ b/src/BigQuery/Timestamp.php
@@ -31,7 +31,7 @@ class Timestamp implements ValueInterface
     private $value;
 
     /**
-     * @param \DateTimeInterface $value
+     * @param \DateTimeInterface $value The timestamp value.
      */
     public function __construct(\DateTimeInterface $value)
     {
@@ -39,6 +39,8 @@ class Timestamp implements ValueInterface
     }
 
     /**
+     * Get the underlying `\DateTimeInterface` implementation.
+     *
      * @return \DateTimeInterface
      */
     public function get()
@@ -47,6 +49,8 @@ class Timestamp implements ValueInterface
     }
 
     /**
+     * Get the type.
+     *
      * @return string
      */
     public function type()
@@ -55,6 +59,8 @@ class Timestamp implements ValueInterface
     }
 
     /**
+     * Format the value for the API.
+     *
      * @return string
      */
     public function toApi()

--- a/src/BigQuery/Timestamp.php
+++ b/src/BigQuery/Timestamp.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+/**
+ * Represents a value with a data type of
+ * [Timestamp](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp-type).
+ */
+class Timestamp implements ValueInterface
+{
+    const FORMAT = 'Y-m-d H:i:s.uP';
+
+    /**
+     * @var \DateTimeInterface
+     */
+    private $value;
+
+    /**
+     * @param \DateTimeInterface $value
+     */
+    public function __construct(\DateTimeInterface $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function get()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return string
+     */
+    public function type()
+    {
+        return ValueMapper::TYPE_TIMESTAMP;
+    }
+
+    /**
+     * @return string
+     */
+    public function toApi()
+    {
+        return $this->value->format(self::FORMAT);
+    }
+}

--- a/src/BigQuery/ValueInterface.php
+++ b/src/BigQuery/ValueInterface.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+/**
+ * Contract for various BigQuery values.
+ */
+interface ValueInterface
+{
+    /**
+     * @return string
+     */
+    public function type();
+
+    /**
+     * @return string
+     */
+    public function toApi();
+}

--- a/src/BigQuery/ValueInterface.php
+++ b/src/BigQuery/ValueInterface.php
@@ -28,7 +28,17 @@ interface ValueInterface
     public function type();
 
     /**
+     * @return mixed
+     */
+    public function get();
+
+    /**
      * @return string
      */
-    public function toApi();
+    public function formatAsString();
+
+    /**
+     * @return string
+     */
+    public function __toString();
 }

--- a/src/BigQuery/ValueMapper.php
+++ b/src/BigQuery/ValueMapper.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+use Google\Cloud\ArrayTrait;
+
+/**
+ * Maps values to their expected BigQuery types.
+ */
+class ValueMapper
+{
+    use ArrayTrait;
+
+    const TYPE_BOOL = 'BOOL';
+    const TYPE_INT64 = 'INT64';
+    const TYPE_FLOAT64 = 'FLOAT64';
+    const TYPE_STRING = 'STRING';
+    const TYPE_BYTES = 'BYTES';
+    const TYPE_DATE = 'DATE';
+    const TYPE_DATETIME = 'DATETIME';
+    const TYPE_TIME = 'TIME';
+    const TYPE_TIMESTAMP = 'TIMESTAMP';
+    const TYPE_ARRAY = 'ARRAY';
+    const TYPE_STRUCT = 'STRUCT';
+
+    const DATETIME_FORMAT = 'Y-m-d H:i:s.u';
+
+    /**
+     * Maps a value to the expected parameter format.
+     *
+     * @param mixed $value The value to map.
+     * @return array
+     * @throws \InvalidArgumentException
+     */
+    public function toParameter($value)
+    {
+        $pValue = ['value' => $value];
+        $type = gettype($value);
+
+        switch ($type) {
+            case 'boolean':
+                $pType['type'] = self::TYPE_BOOL;
+
+                break;
+            case 'integer':
+                $pType['type'] = self::TYPE_INT64;
+
+                break;
+            case 'double':
+                $pType['type'] = self::TYPE_FLOAT64;
+
+                break;
+            case 'string':
+                $pType['type'] = self::TYPE_STRING;
+
+                break;
+            case 'resource':
+                $pType['type'] = self::TYPE_BYTES;
+                $pValue['value'] = base64_encode(stream_get_contents($value));
+
+                break;
+            case 'object':
+                list($pType, $pValue) = $this->objectToParameter($value);
+
+                break;
+            case 'array':
+                list($pType, $pValue) = $this->isAssoc($value)
+                    ? $this->assocArrayToParameter($value)
+                    : $this->arrayToParameter($value);
+
+                break;
+            default:
+                throw new \InvalidArgumentException(sprintf(
+                    'Unrecognized value type %s. Please ensure you are using the latest version of google/cloud.',
+                    $type
+                ));
+
+                break;
+        }
+
+        return [
+            'parameterType' => $pType,
+            'parameterValue' => $pValue
+        ];
+    }
+
+    /**
+     * @param mixed $object The object to map.
+     * @return array
+     * @throws \InvalidArgumentException
+     */
+    private function objectToParameter($object)
+    {
+        if ($object instanceof ValueInterface) {
+            return [
+                ['type' => $object->type()],
+                ['value' => $object->toApi()]
+            ];
+        }
+
+        if ($object instanceof \DateTimeInterface) {
+            return [
+                ['type' => self::TYPE_DATETIME],
+                ['value' => $object->format(self::DATETIME_FORMAT)]
+            ];
+        }
+
+        throw new \InvalidArgumentException(sprintf(
+            'Unrecognized object %s. Please ensure you are using the latest version of google/cloud.',
+            get_class($object)
+        ));
+    }
+
+    /**
+     * @param array $array The array to map.
+     * @return array
+     */
+    private function arrayToParameter(array $array)
+    {
+        $type = [];
+        $values = [];
+
+        foreach ($array as $value) {
+            $param = $this->toParameter($value);
+            $type = $param['parameterType'];
+            $values[] = $param['parameterValue'];
+        }
+
+        return [
+            [
+                'type' => self::TYPE_ARRAY,
+                'arrayType' => $type
+            ],
+            ['arrayValues' => $values]
+        ];
+    }
+
+    /**
+     * @param array $struct The struct to map.
+     * @return array
+     */
+    private function assocArrayToParameter(array $struct)
+    {
+        $types = [];
+        $values = [];
+
+        foreach ($struct as $name => $value) {
+            $param = $this->toParameter($value);
+            $types[] = [
+                'name' => $name,
+                'type' => $param['parameterType']
+            ];
+            $values[$name] = $param['parameterValue'];
+        }
+
+        return [
+            [
+                'type' => self::TYPE_STRUCT,
+                'structTypes' => $types
+            ],
+            ['structValues' => $values]
+        ];
+    }
+}

--- a/src/BigQuery/ValueMapper.php
+++ b/src/BigQuery/ValueMapper.php
@@ -18,17 +18,22 @@
 namespace Google\Cloud\BigQuery;
 
 use Google\Cloud\ArrayTrait;
+use Google\Cloud\Int64;
 
 /**
- * Maps values to their expected BigQuery types.
+ * Maps values to their expected BigQuery types. This class is intended for
+ * internal use only.
  */
 class ValueMapper
 {
     use ArrayTrait;
 
     const TYPE_BOOL = 'BOOL';
+    const TYPE_BOOLEAN = 'BOOLEAN';
     const TYPE_INT64 = 'INT64';
+    const TYPE_INTEGER = 'INTEGER';
     const TYPE_FLOAT64 = 'FLOAT64';
+    const TYPE_FLOAT = 'FLOAT';
     const TYPE_STRING = 'STRING';
     const TYPE_BYTES = 'BYTES';
     const TYPE_DATE = 'DATE';
@@ -37,8 +42,84 @@ class ValueMapper
     const TYPE_TIMESTAMP = 'TIMESTAMP';
     const TYPE_ARRAY = 'ARRAY';
     const TYPE_STRUCT = 'STRUCT';
+    const TYPE_RECORD = 'RECORD';
 
     const DATETIME_FORMAT = 'Y-m-d H:i:s.u';
+
+    /**
+     * @var bool $returnInt64AsObject If true, 64 bit integers will be returned
+     *      as a {@see Google\Cloud\Int64} object for 32 bit platform
+     *      compatibility.
+     */
+    private $returnInt64AsObject;
+
+    /**
+     * @param bool $returnInt64AsObject If true, 64 bit integers will be
+     *        returned as a {@see Google\Cloud\Int64} object for 32 bit
+     *        platform compatibility.
+     */
+    public function __construct($returnInt64AsObject)
+    {
+        $this->returnInt64AsObject = $returnInt64AsObject;
+    }
+
+    /**
+     * Maps a value coming from BigQuery to the expected format for use in the
+     * library.
+     *
+     * @param array $value The value to map.
+     * @param array $schema The schema describing the value.
+     * @throws \InvalidArgumentException
+     */
+    public function fromBigQuery(array $value, array $schema)
+    {
+        $value = $value['v'];
+
+        if (isset($schema['mode'])) {
+            if ($schema['mode'] === 'REPEATED') {
+                return $this->repeatedValueFromBigQuery($value, $schema);
+            }
+
+            if ($schema['mode'] === 'NULLABLE' && $value === null) {
+                return $value;
+            }
+        }
+
+        switch ($schema['type']) {
+            case self::TYPE_BOOLEAN:
+                return $value === 'true' ? true : false;
+            case self::TYPE_INTEGER:
+                return $this->returnInt64AsObject
+                    ? new Int64($value)
+                    : (int) $value;
+            case self::TYPE_FLOAT:
+                return (float) $value;
+            case self::TYPE_STRING:
+                return (string) $value;
+            case self::TYPE_BYTES:
+                return new Bytes(base64_decode($value));
+            case self::TYPE_DATE:
+                return new Date(new \DateTime($value));
+            case self::TYPE_DATETIME:
+                return new \DateTime($value);
+            case self::TYPE_TIME:
+                return new Time(new \DateTime($value));
+            case self::TYPE_TIMESTAMP:
+                $timestamp = new \DateTime();
+                $timestamp->setTimestamp((float) $value);
+
+                return new Timestamp($timestamp);
+            case self::TYPE_RECORD:
+                return $this->recordFromBigQuery($value, $schema['fields']);
+            default:
+                throw new \InvalidArgumentException(sprintf(
+                    'Unrecognized value type %s. Please ensure you are using the latest version of google/cloud.',
+                    $schema['type']
+                ));
+
+                break;
+        }
+    }
 
     /**
      * Maps a value to the expected parameter format.
@@ -100,6 +181,39 @@ class ValueMapper
     }
 
     /**
+     * @param array $value The value to map.
+     * @param array $schema The schema describing the value.
+     * @return array
+     */
+    private function recordFromBigQuery(array $value, array $schema)
+    {
+        $record = [];
+
+        foreach ($value['f'] as $key => $val) {
+            $record[$schema[$key]['name']] = $this->fromBigQuery($val, $schema[$key]);
+        }
+
+        return $record;
+    }
+
+    /**
+     * @param array $value The value to map.
+     * @param array $schema The schema describing the value.
+     * @return array
+     */
+    private function repeatedValueFromBigQuery(array $value, array $schema)
+    {
+        $repeatedValues = [];
+
+        foreach ($value as $repeatedValue) {
+            unset($schema['mode']);
+            $repeatedValues[] = $this->fromBigQuery($repeatedValue, $schema);
+        }
+
+        return $repeatedValues;
+    }
+
+    /**
      * @param mixed $object The object to map.
      * @return array
      * @throws \InvalidArgumentException
@@ -109,7 +223,7 @@ class ValueMapper
         if ($object instanceof ValueInterface) {
             return [
                 ['type' => $object->type()],
-                ['value' => $object->toApi()]
+                ['value' => (string) $object]
             ];
         }
 
@@ -117,6 +231,13 @@ class ValueMapper
             return [
                 ['type' => self::TYPE_DATETIME],
                 ['value' => $object->format(self::DATETIME_FORMAT)]
+            ];
+        }
+
+        if ($object instanceof Int64) {
+            return [
+                ['type' => self::TYPE_INT64],
+                ['value' => $object->get()]
             ];
         }
 

--- a/src/Datastore/DatastoreClient.php
+++ b/src/Datastore/DatastoreClient.php
@@ -139,14 +139,11 @@ class DatastoreClient
      */
     public function __construct(array $config = [])
     {
-        $config = $config + [
+        $config += [
             'namespaceId' => null,
-            'returnInt64AsObject' => false
+            'returnInt64AsObject' => false,
+            'scopes' => [self::FULL_CONTROL_SCOPE]
         ];
-
-        if (!isset($config['scopes'])) {
-            $config['scopes'] = [self::FULL_CONTROL_SCOPE];
-        }
 
         $this->connection = new Rest($this->configureAuthentication($config));
 

--- a/src/Datastore/EntityMapper.php
+++ b/src/Datastore/EntityMapper.php
@@ -56,9 +56,9 @@ class EntityMapper
      *
      * @param string $projectId The datastore project ID
      * @param bool $encode Whether to encode blobs as base64.
-     * @param @type bool $returnInt64AsObject If true, 64 bit integers will be
-     *              returned as a {@see Google\Cloud\Int64} object for 32 bit
-     *              platform compatibility.
+     * @param bool $returnInt64AsObject If true, 64 bit integers will be
+     *        returned as a {@see Google\Cloud\Int64} object for 32 bit
+     *        platform compatibility.
      */
     public function __construct($projectId, $encode, $returnInt64AsObject)
     {

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -106,8 +106,13 @@ class ServiceBuilder
      * $bigQuery = $cloud->bigQuery();
      * ```
      *
-     * @param array $config [optional] Configuration options. See
-     *        {@see Google\Cloud\ServiceBuilder::__construct()} for the available options.
+     * @param array $config [optional] {
+     *     Configuration options. See
+     *     {@see Google\Cloud\ServiceBuilder::__construct()} for the other available options.
+     *
+     *     @type bool $returnInt64AsObject If true, 64 bit integers will be
+     *           returned as a {@see Google\Cloud\Int64} object for 32 bit
+     *           platform compatibility. **Defaults to** false.
      * @return BigQueryClient
      */
     public function bigQuery(array $config = [])

--- a/tests/system/BigQuery/LoadDataAndQueryTest.php
+++ b/tests/system/BigQuery/LoadDataAndQueryTest.php
@@ -143,7 +143,7 @@ class LoadDataAndQueryTest extends BigQueryTestCase
     {
         $results = self::$client->runQuery(
             sprintf(
-                'SELECT * FROM `%s.%s` WHERE city = @city',
+                'SELECT * FROM [%s.%s]',
                 self::$dataset->id(),
                 self::$table->id()
             )

--- a/tests/system/BigQuery/LoadDataAndQueryTest.php
+++ b/tests/system/BigQuery/LoadDataAndQueryTest.php
@@ -143,7 +143,7 @@ class LoadDataAndQueryTest extends BigQueryTestCase
     {
         $results = self::$client->runQuery(
             sprintf(
-                'SELECT * FROM [%s.%s]',
+                'SELECT * FROM `%s.%s` WHERE city = @city',
                 self::$dataset->id(),
                 self::$table->id()
             )
@@ -164,6 +164,82 @@ class LoadDataAndQueryTest extends BigQueryTestCase
         $actualRows = count(iterator_to_array($results->rows()));
 
         $this->assertEquals(self::$expectedRows, $actualRows);
+    }
+
+    public function testRunQueryWithNamedParameters()
+    {
+        $date = '2000-01-01';
+        $query = 'WITH data AS'
+            . '(SELECT "Dave" as name, DATE("1999-01-01") as date, 1.1 as floatNum, 1 as intNum, true as boolVal '
+            . 'UNION ALL '
+            . 'SELECT "John" as name, DATE("2000-01-01") as date, 1.2 as floatNum, 2 as intNum, false as boolVal) '
+            . 'SELECT * FROM data '
+            . 'WHERE name = @name AND date >= @date AND floatNum = @numbers.floatNum AND intNum = @numbers.intNum AND boolVal = @boolVal';
+
+        $results = self::$client->runQuery($query, [
+            'parameters' => [
+                'name' => 'John',
+                'date' => self::$client->date(new \DateTime($date)),
+                'numbers' => [
+                    'floatNum' => 1.2,
+                    'intNum' => 2,
+                ],
+                'boolVal' => false
+            ]
+        ]);
+        $backoff = new ExponentialBackoff(8);
+        $backoff->execute(function () use ($results) {
+            $results->reload();
+
+            if (!$results->isComplete()) {
+                throw new \Exception();
+            }
+        });
+
+        if (!$results->isComplete()) {
+            $this->fail('Query did not complete within the allotted time.');
+        }
+
+        $actualRows = iterator_to_array($results->rows());
+        $expectedRows = [
+            [
+                'name' => 'John',
+                'floatNum' => '1.2',
+                'intNum' => '2',
+                'boolVal' => 'false',
+                'date' => $date
+            ]
+        ];
+
+        $this->assertEquals($expectedRows, $actualRows);
+    }
+
+    public function testRunQueryWithPositionalParameters()
+    {
+        $results = self::$client->runQuery('SELECT 1 IN UNNEST(?) AS arr', [
+            'parameters' => [
+                [1, 2, 3]
+            ]
+        ]);
+        $backoff = new ExponentialBackoff(8);
+        $backoff->execute(function () use ($results) {
+            $results->reload();
+
+            if (!$results->isComplete()) {
+                throw new \Exception();
+            }
+        });
+
+        if (!$results->isComplete()) {
+            $this->fail('Query did not complete within the allotted time.');
+        }
+
+        $actualRows = iterator_to_array($results->rows());
+        $expectedRows = [
+            ['arr' => 'true']
+        ];
+
+        $this->assertEquals($expectedRows, $actualRows);
     }
 
     /**
@@ -195,5 +271,83 @@ class LoadDataAndQueryTest extends BigQueryTestCase
         $actualRows = count(iterator_to_array($results->rows()));
 
         $this->assertEquals(self::$expectedRows, $actualRows);
+    }
+
+    public function testRunQueryAsJobWithNamedParameters()
+    {
+        $date = '2000-01-01';
+        $query = 'WITH data AS'
+            . '(SELECT "Dave" as name, DATE("1999-01-01") as date, 1.1 as floatNum, 1 as intNum, true as boolVal '
+            . 'UNION ALL '
+            . 'SELECT "John" as name, DATE("2000-01-01") as date, 1.2 as floatNum, 2 as intNum, false as boolVal) '
+            . 'SELECT * FROM data '
+            . 'WHERE name = @name AND date >= @date AND floatNum = @numbers.floatNum AND intNum = @numbers.intNum AND boolVal = @boolVal';
+
+        $job = self::$client->runQueryAsJob($query, [
+            'parameters' => [
+                'name' => 'John',
+                'date' => self::$client->date(new \DateTime($date)),
+                'numbers' => [
+                    'floatNum' => 1.2,
+                    'intNum' => 2,
+                ],
+                'boolVal' => false
+            ]
+        ]);
+        $results = $job->queryResults();
+        $backoff = new ExponentialBackoff(8);
+        $backoff->execute(function () use ($results) {
+            $results->reload();
+
+            if (!$results->isComplete()) {
+                throw new \Exception();
+            }
+        });
+
+        if (!$results->isComplete()) {
+            $this->fail('Query did not complete within the allotted time.');
+        }
+
+        $actualRows = iterator_to_array($results->rows());
+        $expectedRows = [
+            [
+                'name' => 'John',
+                'floatNum' => '1.2',
+                'intNum' => '2',
+                'boolVal' => 'false',
+                'date' => $date
+            ]
+        ];
+
+        $this->assertEquals($expectedRows, $actualRows);
+    }
+
+    public function testRunQueryAsJobWithPositionalParameters()
+    {
+        $job = self::$client->runQueryAsJob('SELECT 1 IN UNNEST(?) AS arr', [
+            'parameters' => [
+                [1, 2, 3]
+            ]
+        ]);
+        $results = $job->queryResults();
+        $backoff = new ExponentialBackoff(8);
+        $backoff->execute(function () use ($results) {
+            $results->reload();
+
+            if (!$results->isComplete()) {
+                throw new \Exception();
+            }
+        });
+
+        if (!$results->isComplete()) {
+            $this->fail('Query did not complete within the allotted time.');
+        }
+
+        $actualRows = iterator_to_array($results->rows());
+        $expectedRows = [
+            ['arr' => 'true']
+        ];
+
+        $this->assertEquals($expectedRows, $actualRows);
     }
 }

--- a/tests/system/BigQuery/LoadDataAndQueryTest.php
+++ b/tests/system/BigQuery/LoadDataAndQueryTest.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Tests\System\BigQuery;
 
+use Google\Cloud\BigQuery\Date;
 use Google\Cloud\ExponentialBackoff;
 use GuzzleHttp\Psr7;
 
@@ -170,9 +171,9 @@ class LoadDataAndQueryTest extends BigQueryTestCase
     {
         $date = '2000-01-01';
         $query = 'WITH data AS'
-            . '(SELECT "Dave" as name, DATE("1999-01-01") as date, 1.1 as floatNum, 1 as intNum, true as boolVal '
+            . '(SELECT "Dave" as name, DATE("1999-01-01") as date, 1.1 as floatNum, 1 as intNum, false as boolVal '
             . 'UNION ALL '
-            . 'SELECT "John" as name, DATE("2000-01-01") as date, 1.2 as floatNum, 2 as intNum, false as boolVal) '
+            . 'SELECT "John" as name, DATE("2000-01-01") as date, 1.2 as floatNum, 2 as intNum, true as boolVal) '
             . 'SELECT * FROM data '
             . 'WHERE name = @name AND date >= @date AND floatNum = @numbers.floatNum AND intNum = @numbers.intNum AND boolVal = @boolVal';
 
@@ -184,7 +185,7 @@ class LoadDataAndQueryTest extends BigQueryTestCase
                     'floatNum' => 1.2,
                     'intNum' => 2,
                 ],
-                'boolVal' => false
+                'boolVal' => true
             ]
         ]);
         $backoff = new ExponentialBackoff(8);
@@ -204,10 +205,10 @@ class LoadDataAndQueryTest extends BigQueryTestCase
         $expectedRows = [
             [
                 'name' => 'John',
-                'floatNum' => '1.2',
-                'intNum' => '2',
-                'boolVal' => 'false',
-                'date' => $date
+                'floatNum' => 1.2,
+                'intNum' => 2,
+                'boolVal' => true,
+                'date' => new Date(new \DateTime($date))
             ]
         ];
 
@@ -236,7 +237,7 @@ class LoadDataAndQueryTest extends BigQueryTestCase
 
         $actualRows = iterator_to_array($results->rows());
         $expectedRows = [
-            ['arr' => 'true']
+            ['arr' => true]
         ];
 
         $this->assertEquals($expectedRows, $actualRows);
@@ -312,10 +313,10 @@ class LoadDataAndQueryTest extends BigQueryTestCase
         $expectedRows = [
             [
                 'name' => 'John',
-                'floatNum' => '1.2',
-                'intNum' => '2',
-                'boolVal' => 'false',
-                'date' => $date
+                'floatNum' => 1.2,
+                'intNum' => 2,
+                'boolVal' => false,
+                'date' => new Date(new \DateTime($date))
             ]
         ];
 
@@ -345,7 +346,7 @@ class LoadDataAndQueryTest extends BigQueryTestCase
 
         $actualRows = iterator_to_array($results->rows());
         $expectedRows = [
-            ['arr' => 'true']
+            ['arr' => true]
         ];
 
         $this->assertEquals($expectedRows, $actualRows);

--- a/tests/unit/BigQuery/BytesTest.php
+++ b/tests/unit/BigQuery/BytesTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\BigQuery;
+
+use Google\Cloud\BigQuery\Bytes;
+use GuzzleHttp\Psr7;
+
+/**
+ * @group bigquery
+ */
+class BytesTest extends \PHPUnit_Framework_TestCase
+{
+    public $value = '1234';
+
+    /**
+     * @dataProvider valueProvider
+     */
+    public function testGetWithMultipleIncomingValues($value)
+    {
+        $bytes = new Bytes($value);
+
+        $this->assertEquals($this->value, (string) $bytes->get());
+    }
+
+    public function valueProvider()
+    {
+        $fh = fopen('php://temp', 'r+');
+        fwrite($fh, $this->value);
+        rewind($fh);
+
+        return [
+            [$this->value],
+            [$fh],
+            [Psr7\stream_for($this->value)]
+        ];
+    }
+
+    public function testGetsType()
+    {
+        $bytes = new Bytes($this->value);
+
+        $this->assertEquals('BYTES', $bytes->type());
+    }
+
+    public function testToApi()
+    {
+        $bytes = new Bytes($this->value);
+
+        $this->assertEquals(base64_encode($this->value), $bytes->toApi());
+    }
+}

--- a/tests/unit/BigQuery/BytesTest.php
+++ b/tests/unit/BigQuery/BytesTest.php
@@ -57,10 +57,12 @@ class BytesTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('BYTES', $bytes->type());
     }
 
-    public function testToApi()
+    public function testToString()
     {
         $bytes = new Bytes($this->value);
+        $expected = base64_encode($this->value);
 
-        $this->assertEquals(base64_encode($this->value), $bytes->toApi());
+        $this->assertEquals($expected, (string) $bytes);
+        $this->assertEquals($expected, $bytes->formatAsString());
     }
 }

--- a/tests/unit/BigQuery/DateTest.php
+++ b/tests/unit/BigQuery/DateTest.php
@@ -39,11 +39,13 @@ class DateTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('DATE', $date->type());
     }
 
-    public function testToApi()
+    public function testStringFormatting()
     {
         $value = new \DateTime();
         $date = new Date($value);
+        $expected = $value->format('Y-m-d');
 
-        $this->assertEquals($value->format('Y-m-d'), $date->toApi());
+        $this->assertEquals($expected, (string) $date);
+        $this->assertEquals($expected, $date->formatAsString());
     }
 }

--- a/tests/unit/BigQuery/DateTest.php
+++ b/tests/unit/BigQuery/DateTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\BigQuery;
+
+use Google\Cloud\BigQuery\Date;
+
+/**
+ * @group bigquery
+ */
+class DateTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGet()
+    {
+        $value = new \DateTime();
+        $date = new Date($value);
+
+        $this->assertEquals($value, $date->get());
+    }
+
+    public function testGetsType()
+    {
+        $date = new Date(new \DateTime());
+
+        $this->assertEquals('DATE', $date->type());
+    }
+
+    public function testToApi()
+    {
+        $value = new \DateTime();
+        $date = new Date($value);
+
+        $this->assertEquals($value->format('Y-m-d'), $date->toApi());
+    }
+}

--- a/tests/unit/BigQuery/JobTest.php
+++ b/tests/unit/BigQuery/JobTest.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Tests\BigQuery;
 use Google\Cloud\BigQuery\Connection\ConnectionInterface;
 use Google\Cloud\BigQuery\Job;
 use Google\Cloud\BigQuery\QueryResults;
+use Google\Cloud\BigQuery\ValueMapper;
 use Google\Cloud\Exception\NotFoundException;
 use Prophecy\Argument;
 
@@ -40,7 +41,8 @@ class JobTest extends \PHPUnit_Framework_TestCase
 
     public function getJob($connection, array $data = [])
     {
-        return new Job($connection->reveal(), $this->jobId, $this->projectId, $data);
+        $mapper = $this->prophesize(ValueMapper::class);
+        return new Job($connection->reveal(), $this->jobId, $this->projectId, $data, $mapper->reveal());
     }
 
     public function testDoesExistTrue()

--- a/tests/unit/BigQuery/QueryResultsTest.php
+++ b/tests/unit/BigQuery/QueryResultsTest.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Tests\BigQuery;
 
 use Google\Cloud\BigQuery\Connection\ConnectionInterface;
 use Google\Cloud\BigQuery\QueryResults;
+use Google\Cloud\BigQuery\ValueMapper;
 use Prophecy\Argument;
 
 /**
@@ -35,7 +36,12 @@ class QueryResultsTest extends \PHPUnit_Framework_TestCase
             ['f' => [['v' => 'Alton']]]
         ],
         'schema' => [
-            'fields' => [['name' => 'first_name']]
+            'fields' => [
+                [
+                    'name' => 'first_name',
+                    'type' => 'STRING'
+                ]
+            ]
         ]
     ];
 
@@ -46,7 +52,14 @@ class QueryResultsTest extends \PHPUnit_Framework_TestCase
 
     public function getQueryResults($connection, array $data = [])
     {
-        return new QueryResults($connection->reveal(), $this->jobId, $this->projectId, $data, []);
+        return new QueryResults(
+            $connection->reveal(),
+            $this->jobId,
+            $this->projectId,
+            $data,
+            [],
+            new ValueMapper(false)
+        );
     }
 
     /**

--- a/tests/unit/BigQuery/TimeTest.php
+++ b/tests/unit/BigQuery/TimeTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\BigQuery;
+
+use Google\Cloud\BigQuery\Time;
+
+/**
+ * @group bigquery
+ */
+class TimeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGet()
+    {
+        $value = new \DateTime();
+        $time = new Time($value);
+
+        $this->assertEquals($value, $time->get());
+    }
+
+    public function testGetsType()
+    {
+        $time = new Time(new \DateTime());
+
+        $this->assertEquals('TIME', $time->type());
+    }
+
+    public function testToApi()
+    {
+        $value = new \DateTime();
+        $time = new Time($value);
+
+        $this->assertEquals($value->format('H:i:s.u'), $time->toApi());
+    }
+}

--- a/tests/unit/BigQuery/TimeTest.php
+++ b/tests/unit/BigQuery/TimeTest.php
@@ -39,11 +39,13 @@ class TimeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('TIME', $time->type());
     }
 
-    public function testToApi()
+    public function testToString()
     {
         $value = new \DateTime();
         $time = new Time($value);
+        $expected = $value->format('H:i:s.u');
 
-        $this->assertEquals($value->format('H:i:s.u'), $time->toApi());
+        $this->assertEquals($expected, (string) $time);
+        $this->assertEquals($expected, $time->formatAsString());
     }
 }

--- a/tests/unit/BigQuery/TimestampTest.php
+++ b/tests/unit/BigQuery/TimestampTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\BigQuery;
+
+use Google\Cloud\BigQuery\Timestamp;
+
+/**
+ * @group bigquery
+ */
+class TimestampTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGet()
+    {
+        $value = new \DateTime();
+        $timestamp = new Timestamp($value);
+
+        $this->assertEquals($value, $timestamp->get());
+    }
+
+    public function testGetsType()
+    {
+        $timestamp = new Timestamp(new \DateTime());
+
+        $this->assertEquals('TIMESTAMP', $timestamp->type());
+    }
+
+    public function testToApi()
+    {
+        $value = new \DateTime();
+        $timestamp = new Timestamp($value);
+
+        $this->assertEquals($value->format('Y-m-d H:i:s.uP'), $timestamp->toApi());
+    }
+}

--- a/tests/unit/BigQuery/TimestampTest.php
+++ b/tests/unit/BigQuery/TimestampTest.php
@@ -39,11 +39,13 @@ class TimestampTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('TIMESTAMP', $timestamp->type());
     }
 
-    public function testToApi()
+    public function testToString()
     {
         $value = new \DateTime();
         $timestamp = new Timestamp($value);
+        $expected = $value->format('Y-m-d H:i:s.uP');
 
-        $this->assertEquals($value->format('Y-m-d H:i:s.uP'), $timestamp->toApi());
+        $this->assertEquals($expected, (string) $timestamp);
+        $this->assertEquals($expected, $timestamp->formatAsString());
     }
 }

--- a/tests/unit/BigQuery/ValueMapperTest.php
+++ b/tests/unit/BigQuery/ValueMapperTest.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\BigQuery;
+
+use Google\Cloud\BigQuery\Date;
+use Google\Cloud\BigQuery\ValueMapper;
+
+/**
+ * @group bigquery
+ */
+class ValueMapperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowsExceptionWithUnhandledClass()
+    {
+        $mapper = new ValueMapper();
+        $mapper->toParameter(new \stdClass());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowsExceptionWithUnhandledType()
+    {
+        $f = fopen('php://temp','r');
+        fclose($f);
+        $mapper = new ValueMapper();
+        $mapper->toParameter($f);
+    }
+
+    /**
+     * @dataProvider valueProvider
+     */
+    public function testMapsToParameter($value, $expected)
+    {
+        if (is_resource($value)) {
+            rewind($value);
+        }
+        $mapper = new ValueMapper();
+        $actual = $mapper->toParameter($value);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function valueProvider()
+    {
+        $bool = false;
+        $int = 1234;
+        $float = 1.234;
+        $string = 'string';
+        $resource = fopen('php://temp', 'r+');
+        fwrite($resource, $string);
+        rewind($resource);
+        $dt = new \DateTime();
+        $date = new Date($dt);
+        $array = [1, 2, 3];
+        $struct = [
+            'key1' => 1,
+            'key2' => 'string'
+        ];
+
+        return [
+            [
+                $string,
+                [
+                    'parameterType' => [
+                        'type' => 'STRING'
+                    ],
+                    'parameterValue' => [
+                        'value' => $string
+                    ]
+                ]
+            ],
+            [
+                $bool,
+                [
+                    'parameterType' => [
+                        'type' => 'BOOL'
+                    ],
+                    'parameterValue' => [
+                        'value' => $bool
+                    ]
+                ]
+            ],
+            [
+                $int,
+                [
+                    'parameterType' => [
+                        'type' => 'INT64'
+                    ],
+                    'parameterValue' => [
+                        'value' => $int
+                    ]
+                ]
+            ],
+            [
+                $float,
+                [
+                    'parameterType' => [
+                        'type' => 'FLOAT64'
+                    ],
+                    'parameterValue' => [
+                        'value' => $float
+                    ]
+                ]
+            ],
+            [
+                $resource,
+                [
+                    'parameterType' => [
+                        'type' => 'BYTES'
+                    ],
+                    'parameterValue' => [
+                        'value' => base64_encode(stream_get_contents($resource))
+                    ]
+                ]
+            ],
+            [
+                $date,
+                [
+                    'parameterType' => [
+                        'type' => 'DATE'
+                    ],
+                    'parameterValue' => [
+                        'value' => $dt->format('Y-m-d')
+                    ]
+                ]
+            ],
+            [
+                $dt,
+                [
+                    'parameterType' => [
+                        'type' => 'DATETIME'
+                    ],
+                    'parameterValue' => [
+                        'value' => $dt->format('Y-m-d H:i:s.u')
+                    ]
+                ]
+            ],
+            [
+                $array,
+                [
+                    'parameterType' => [
+                        'type' => 'ARRAY',
+                        'arrayType' => [
+                            'type' => 'INT64'
+                        ]
+                    ],
+                    'parameterValue' => [
+                        'arrayValues' => [
+                            ['value' => $array[0]],
+                            ['value' => $array[1]],
+                            ['value' => $array[2]]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                $struct,
+                [
+                    'parameterType' => [
+                        'type' => 'STRUCT',
+                        'structTypes' => [
+                            [
+                                'name' => 'key1',
+                                'type' => [
+                                    'type' => 'INT64'
+                                ]
+                            ],
+                            [
+                                'name' => 'key2',
+                                'type' => [
+                                    'type' => 'STRING'
+                                ]
+                            ]
+                        ]
+                    ],
+                    'parameterValue' => [
+                        'structValues' => [
+                            'key1' => ['value' => $struct['key1']],
+                            'key2' => ['value' => $struct['key2']],
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
Closes https://github.com/GoogleCloudPlatform/google-cloud-php/issues/246

Sample:

```php
$bq = new BigQueryClient();

// Named parameters
$bq->runQuery('SELECT * FROM people WHERE name = @name and birthDate >= @date', [
    'parameters' => [
        'name' => 'David',
        'date' => $bq->date(new \DateTime('1970-01-01'))
    ]
]);

// Positional parameters
$bq->runQuery('SELECT * FROM people WHERE name = ?', [
    'parameters' => ['David']
]);
```

When running a query returned types are now mapped appropriately. The following table includes a mapping:

```
| **PHP Type**                               | **BigQuery Data Type**               |
|--------------------------------------------|--------------------------------------|
| `\DateTimeInterface`                       | `DATETIME`                           |
| {@see Google\Cloud\BigQuery\Bytes}         | `BYTES`                              |
| {@see Google\Cloud\BigQuery\Date}          | `DATE`                               |
| {@see Google\Cloud\Int64}                  | `INTEGER`                            |
| {@see Google\Cloud\BigQuery\Time}          | `TIME`                               |
| {@see Google\Cloud\BigQuery\Timestamp}     | `TIMESTAMP`                          |
| Associative Array                          | `RECORD`                             |
| Non-Associative Array                      | `RECORD` (Repeated)                  |
| `float`                                    | `FLOAT`                              |
| `int`                                      | `INTEGER`                            |
| `string`                                   | `STRING`                             |
| `bool`                                     | `BOOLEAN`                            |
```

Also, big shoutout to @jrhodes-sitback for his help on the work with nested records.