### PR TITLE
accept base64 encoded key instead of bytes and make sha optional

### DIFF
--- a/src/Storage/Bucket.php
+++ b/src/Storage/Bucket.php
@@ -163,15 +163,11 @@ class Bucket
      *
      * ```
      * // Upload an object with a customer-supplied encryption key.
-     * $key = openssl_random_pseudo_bytes(32); // Make sure to remember your key.
-     * $options = [
-     *     'encryptionKey' => $key
-     *     'encryptionKeySHA256' => hash('SHA256', $key, true)
-     * ];
+     * $key = base64_encode(openssl_random_pseudo_bytes(32)); // Make sure to remember your key.
      *
      * $bucket->upload(
      *     fopen(__DIR__ . '/image.jpg', 'r'),
-     *     $options
+     *     ['encryptionKey' => $key]
      * );
      * ```
      *
@@ -202,11 +198,13 @@ class Bucket
      *           `"publicRead"`. **Defaults to** `"private"`.
      *     @type array $metadata The available options for metadata are outlined
      *           at the [JSON API docs](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request-body).
-     *     @type string $encryptionKey An AES-256 customer-supplied encryption
-     *           key. If provided one must also include an `encryptionKeySHA256`.
-     *     @type string $encryptionKeySHA256 The SHA256 hash of the
-     *           customer-supplied encryption key. If provided one must also
-     *           include an `encryptionKey`.
+     *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
+     *           encryption key.
+     *     @type string $encryptionKeySHA256 Base64 encoded SHA256 hash of the
+     *           customer-supplied encryption key. This value will be calculated
+     *           from the `encryptionKey` on your behalf if not provided, but
+     *           for best performance it is recommended to pass in a cached
+     *           version of the already calculated SHA.
      * }
      * @return StorageObject
      * @throws \InvalidArgumentException
@@ -281,11 +279,13 @@ class Bucket
      *           `"private"`.
      *     @type array $metadata The available options for metadata are outlined
      *           at the [JSON API docs](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request-body).
-     *     @type string $encryptionKey An AES-256 customer-supplied encryption
-     *           key. If provided one must also include an `encryptionKeySHA256`.
-     *     @type string $encryptionKeySHA256 The SHA256 hash of the
-     *           customer-supplied encryption key. If provided one must also
-     *           include an `encryptionKey`.
+     *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
+     *           encryption key.
+     *     @type string $encryptionKeySHA256 Base64 encoded SHA256 hash of the
+     *           customer-supplied encryption key. This value will be calculated
+     *           from the `encryptionKey` on your behalf if not provided, but
+     *           for best performance it is recommended to pass in a cached
+     *           version of the already calculated SHA.
      * }
      * @return ResumableUploader
      * @throws \InvalidArgumentException
@@ -320,14 +320,14 @@ class Bucket
      *     Configuration options.
      *
      *     @type string $generation Request a specific revision of the object.
-     *     @type string $encryptionKey An AES-256 customer-supplied encryption
-     *           key. It will be neccesary to provide this when a key was used
-     *           during the object's creation. If provided one must also include
-     *           an `encryptionKeySHA256`.
-     *     @type string $encryptionKeySHA256 The SHA256 hash of the
-     *           customer-supplied encryption key. It will be neccesary to
-     *           provide this when a key was used during the object's creation.
-     *           If provided one must also include an `encryptionKey`.
+     *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
+     *           encryption key. It will be neccesary to provide this when a key
+     *           was used during the object's creation.
+     *     @type string $encryptionKeySHA256 Base64 encoded SHA256 hash of the
+     *           customer-supplied encryption key. This value will be calculated
+     *           from the `encryptionKey` on your behalf if not provided, but
+     *           for best performance it is recommended to pass in a cached
+     *           version of the already calculated SHA.
      * }
      * @return StorageObject
      */

--- a/src/Storage/StorageObject.php
+++ b/src/Storage/StorageObject.php
@@ -249,14 +249,14 @@ class StorageObject
      *           `authenticatedRead`, `bucketOwnerFullControl`,
      *           `bucketOwnerRead`, `private`, `projectPrivate`, and
      *           `publicRead`.
-     *     @type string $encryptionKey An AES-256 customer-supplied encryption
-     *           key. It will be neccesary to provide this when a key was used
-     *           during the object's creation. If provided one must also include
-     *           an `encryptionKeySHA256`.
-     *     @type string $encryptionKeySHA256 The SHA256 hash of the
-     *           customer-supplied encryption key. It will be neccesary to
-     *           provide this when a key was used during the object's creation.
-     *           If provided one must also include an `encryptionKey`.
+     *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
+     *           encryption key. It will be neccesary to provide this when a key
+     *           was used during the object's creation.
+     *     @type string $encryptionKeySHA256 Base64 encoded SHA256 hash of the
+     *           customer-supplied encryption key. This value will be calculated
+     *           from the `encryptionKey` on your behalf if not provided, but
+     *           for best performance it is recommended to pass in a cached
+     *           version of the already calculated SHA.
      *     @type string $ifGenerationMatch Makes the operation conditional on
      *           whether the destination object's current generation matches the
      *           given value.
@@ -334,15 +334,11 @@ class StorageObject
      * ```
      * // Rotate customer-supplied encryption keys.
      * $key = file_get_contents(__DIR__ . '/key.txt');
-     * $hash = hash('SHA256', $key, true);
-     * $destinationKey = openssl_random_pseudo_bytes(32); // Make sure to remember your key.
-     * $destinationHash = hash('SHA256', $destinationKey, true);
+     * $destinationKey = base64_encode(openssl_random_pseudo_bytes(32)); // Make sure to remember your key.
      *
      * $rewrittenObject = $object->rewrite('otherBucket', [
      *     'encryptionKey' => $key,
-     *     'encryptionKeySHA256' => $hash,
-     *     'destinationEncryptionKey' => $destinationKey,
-     *     'destinationEncryptionKeySHA256' => $destinationHash
+     *     'destinationEncryptionKey' => $destinationKey
      * ]);
      * ```
      *
@@ -367,21 +363,23 @@ class StorageObject
      *           integral multiple of 1 MiB (1048576). Also, this only applies
      *           to requests where the source and destination span locations
      *           and/or storage classes.
-     *     @type string $encryptionKey An AES-256 customer-supplied encryption
-     *           key. It will be neccesary to provide this when a key was used
-     *           during the object's creation. If provided one must also include
-     *           an `encryptionKeySHA256`.
-     *     @type string $encryptionKeySHA256 The SHA256 hash of the
-     *           customer-supplied encryption key. It will be neccesary to
-     *           provide this when a key was used during the object's creation.
-     *           If provided one must also include an `encryptionKey`.
-     *     @type string $destinationEncryptionKey An AES-256 customer-supplied
-     *           encryption key that will be used to encrypt the rewritten
-     *           object. If provided one must also include a
-     *           `destinationEncryptionKeySHA256`.
-     *     @type string $destinationEncryptionKeySHA256 The SHA256 hash of the
-     *           customer-supplied destination encryption key. If provided one
-     *           must also include a `destinationEncryptionKey`.
+     *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
+     *           encryption key. It will be neccesary to provide this when a key
+     *           was used during the object's creation.
+     *     @type string $encryptionKeySHA256 Base64 encoded SHA256 hash of the
+     *           customer-supplied encryption key. This value will be calculated
+     *           from the `encryptionKey` on your behalf if not provided, but
+     *           for best performance it is recommended to pass in a cached
+     *           version of the already calculated SHA.
+     *     @type string $destinationEncryptionKey A base64 encoded AES-256
+     *           customer-supplied encryption key that will be used to encrypt
+     *           the rewritten object.
+     *     @type string $destinationEncryptionKeySHA256 Base64 encoded SHA256
+     *           hash of the customer-supplied destination encryption key. This
+     *           value will be calculated from the `destinationEncryptionKey` on
+     *           your behalf if not provided, but for best performance it is
+     *           recommended to pass in a cached version of the already
+     *           calculated SHA.
      *     @type string $ifGenerationMatch Makes the operation conditional on
      *           whether the destination object's current generation matches the
      *           given value.
@@ -459,14 +457,14 @@ class StorageObject
      *           `authenticatedRead`, `bucketOwnerFullControl`,
      *           `bucketOwnerRead`, `private`, `projectPrivate`, and
      *           `publicRead`.
-     *     @type string $encryptionKey An AES-256 customer-supplied encryption
-     *           key. It will be neccesary to provide this when a key was used
-     *           during the object's creation. If provided one must also include
-     *           an `encryptionKeySHA256`.
-     *     @type string $encryptionKeySHA256 The SHA256 hash of the
-     *           customer-supplied encryption key. It will be neccesary to
-     *           provide this when a key was used during the object's creation.
-     *           If provided one must also include an `encryptionKey`.
+     *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
+     *           encryption key. It will be neccesary to provide this when a key
+     *           was used during the object's creation.
+     *     @type string $encryptionKeySHA256 Base64 encoded SHA256 hash of the
+     *           customer-supplied encryption key. This value will be calculated
+     *           from the `encryptionKey` on your behalf if not provided, but
+     *           for best performance it is recommended to pass in a cached
+     *           version of the already calculated SHA.
      *     @type string $ifGenerationMatch Makes the operation conditional on
      *           whether the destination object's current generation matches the
      *           given value.
@@ -676,16 +674,14 @@ class StorageObject
      * @param array $options [optional] {
      *     Configuration options.
      *
-     *     @type string $encryptionKey An AES-256 customer-supplied encryption
-     *           key. It will be neccesary to provide this when a key was used
-     *           during the object's creation in order to retrieve the MD5 hash
-     *           and CRC32C checksum. If provided one must also include an
-     *           `encryptionKeySHA256`.
-     *     @type string $encryptionKeySHA256 The SHA256 hash of the
-     *           customer-supplied encryption key. It will be neccesary to
-     *           provide this when a key was used during the object's creation
-     *           in order to retrieve the MD5 hash and CRC32C checksum. If
-     *           provided one must also include an `encryptionKey`.
+     *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
+     *           encryption key. It will be neccesary to provide this when a key
+     *           was used during the object's creation.
+     *     @type string $encryptionKeySHA256 Base64 encoded SHA256 hash of the
+     *           customer-supplied encryption key. This value will be calculated
+     *           from the `encryptionKey` on your behalf if not provided, but
+     *           for best performance it is recommended to pass in a cached
+     *           version of the already calculated SHA.
      *     @type string $ifGenerationMatch Makes the operation conditional on
      *           whether the object's current generation matches the given
      *           value.

--- a/tests/system/Storage/ManageObjectsTest.php
+++ b/tests/system/Storage/ManageObjectsTest.php
@@ -113,29 +113,25 @@ class ManageObjectsTest extends StorageTestCase
     public function testRotatesCustomerSuppliedEncrpytion()
     {
         $data = 'somedata';
-        $key = openssl_random_pseudo_bytes(32);
-        $sha = hash('SHA256', $key, true);
+        $key = base64_encode(openssl_random_pseudo_bytes(32));
         $options = [
             'name' => uniqid(self::TESTING_PREFIX),
-            'encryptionKey' => $key,
-            'encryptionKeySHA256' => $sha
+            'encryptionKey' => $key
         ];
         $object = self::$bucket->upload($data, $options);
         self::$deletionQueue[] = $object;
 
-        $dkey = openssl_random_pseudo_bytes(32);
-        $dsha = hash('SHA256', $dkey, true);
+        $dkey = base64_encode(openssl_random_pseudo_bytes(32));
+        $dsha = base64_encode(hash('SHA256', base64_decode($dkey), true));
         $rewriteOptions = [
             'name' => uniqid(self::TESTING_PREFIX),
             'encryptionKey' => $key,
-            'encryptionKeySHA256' => $sha,
-            'destinationEncryptionKey' => $dkey,
-            'destinationEncryptionKeySHA256' => $dsha
+            'destinationEncryptionKey' => $dkey
         ];
 
         $rewrittenObject = $object->rewrite(self::$bucket, $rewriteOptions);
 
-        $this->assertEquals(base64_encode($dsha), $rewrittenObject->info()['customerEncryption']['keySha256']);
+        $this->assertEquals($dsha, $rewrittenObject->info()['customerEncryption']['keySha256']);
         $rewrittenObject->delete();
     }
 

--- a/tests/system/Storage/UploadObjectsTest.php
+++ b/tests/system/Storage/UploadObjectsTest.php
@@ -78,18 +78,17 @@ class UploadObjectsTest extends StorageTestCase
     public function testUploadsObjectWithCustomerSuppliedEncryption()
     {
         $data = 'somedata';
-        $key = openssl_random_pseudo_bytes(32);
-        $sha = hash('SHA256', $key, true);
+        $key = base64_encode(openssl_random_pseudo_bytes(32));
+        $sha = base64_encode(hash('SHA256', base64_decode($key), true));
         $options = [
             'name' => uniqid(self::TESTING_PREFIX),
-            'encryptionKey' => $key,
-            'encryptionKeySHA256' => $sha
+            'encryptionKey' => $key
         ];
 
         $object = self::$bucket->upload($data, $options);
         self::$deletionQueue[] = $object;
 
-        $this->assertEquals(base64_encode($sha), $object->info()['customerEncryption']['keySha256']);
+        $this->assertEquals($sha, $object->info()['customerEncryption']['keySha256']);
         $this->assertEquals(strlen($data), $object->info()['size']);
     }
 }

--- a/tests/unit/Storage/EncryptionTraitTest.php
+++ b/tests/unit/Storage/EncryptionTraitTest.php
@@ -42,22 +42,12 @@ class EncryptionTraitTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testFormatEncryptionHeadersThrowsExceptionWithoutBothKeyAndHash()
-    {
-        $this->trait->formatEncryptionHeaders([
-            'encryptionKey' => 'abcd'
-        ]);
-    }
-
     public function encryptionProvider()
     {
-        $key = 'abcd';
-        $hash = '1234';
-        $destinationKey = 'efgh';
-        $destinationHash = '5678';
+        $key = base64_encode('abcd');
+        $hash = base64_encode(hash('SHA256', base64_decode($key), true));
+        $destinationKey = base64_encode('efgh');
+        $destinationHash = base64_encode(hash('SHA256', base64_decode($destinationKey), true));
 
         return [
             [
@@ -69,6 +59,16 @@ class EncryptionTraitTest extends \PHPUnit_Framework_TestCase
                 [
                     'encryptionKey' => $key,
                     'encryptionKeySHA256' => $hash
+                ]
+            ],
+            [
+                [
+                    'httpOptions' => [
+                        'headers' => $this->getEncryptionHeaders($key, $hash)
+                    ]
+                ],
+                [
+                    'encryptionKey' => $key
                 ]
             ],
             [
@@ -111,8 +111,8 @@ class EncryptionTraitTest extends \PHPUnit_Framework_TestCase
     {
         return [
             'x-goog-encryption-algorithm' => 'AES256',
-            'x-goog-encryption-key' => base64_encode($key),
-            'x-goog-encryption-key-sha256' => base64_encode($hash)
+            'x-goog-encryption-key' => $key,
+            'x-goog-encryption-key-sha256' => $hash
         ];
     }
 
@@ -120,8 +120,8 @@ class EncryptionTraitTest extends \PHPUnit_Framework_TestCase
     {
         return [
             'x-goog-copy-source-encryption-algorithm' => 'AES256',
-            'x-goog-copy-source-encryption-key' => base64_encode($key),
-            'x-goog-copy-source-encryption-key-sha256' => base64_encode($hash)
+            'x-goog-copy-source-encryption-key' => $key,
+            'x-goog-copy-source-encryption-key-sha256' => $hash
         ];
     }
 }

--- a/tests/unit/Storage/StorageObjectTest.php
+++ b/tests/unit/Storage/StorageObjectTest.php
@@ -86,8 +86,8 @@ class StorageObjectTest extends \PHPUnit_Framework_TestCase
         $destinationBucket = 'bucket2';
         $objectName = 'object.txt';
         $acl = 'private';
-        $key = 'abcd';
-        $hash = '1234';
+        $key = base64_encode('abcd');
+        $hash = base64_encode('1234');
         $this->connection->copyObject([
                 'sourceBucket' => $sourceBucket,
                 'sourceObject' => $objectName,
@@ -97,8 +97,8 @@ class StorageObjectTest extends \PHPUnit_Framework_TestCase
                 'httpOptions' => [
                     'headers' => [
                         'x-goog-encryption-algorithm' => 'AES256',
-                        'x-goog-encryption-key' => base64_encode($key),
-                        'x-goog-encryption-key-sha256' => base64_encode($hash),
+                        'x-goog-encryption-key' => $key,
+                        'x-goog-encryption-key-sha256' => $hash,
                     ]
                 ]
             ])
@@ -166,10 +166,10 @@ class StorageObjectTest extends \PHPUnit_Framework_TestCase
         $destinationBucket = 'bucket2';
         $objectName = 'object.txt';
         $acl = 'private';
-        $key = 'abcd';
-        $hash = '1234';
-        $destinationKey = 'efgh';
-        $destinationHash = '5678';
+        $key = base64_encode('abcd');
+        $hash = base64_encode('1234');
+        $destinationKey = base64_encode('efgh');
+        $destinationHash = base64_encode('5678');
         $this->connection->rewriteObject([
                 'sourceBucket' => $sourceBucket,
                 'sourceObject' => $objectName,
@@ -179,11 +179,11 @@ class StorageObjectTest extends \PHPUnit_Framework_TestCase
                 'httpOptions' => [
                     'headers' => [
                         'x-goog-copy-source-encryption-algorithm' => 'AES256',
-                        'x-goog-copy-source-encryption-key' => base64_encode($key),
-                        'x-goog-copy-source-encryption-key-sha256' => base64_encode($hash),
+                        'x-goog-copy-source-encryption-key' => $key,
+                        'x-goog-copy-source-encryption-key-sha256' => $hash,
                         'x-goog-encryption-algorithm' => 'AES256',
-                        'x-goog-encryption-key' => base64_encode($destinationKey),
-                        'x-goog-encryption-key-sha256' => base64_encode($destinationHash),
+                        'x-goog-encryption-key' => $destinationKey,
+                        'x-goog-encryption-key-sha256' => $destinationHash,
                     ]
                 ]
             ])
@@ -272,8 +272,8 @@ class StorageObjectTest extends \PHPUnit_Framework_TestCase
         $objectName = 'object.txt';
         $newObjectName = 'new-name.txt';
         $acl = 'private';
-        $key = 'abcd';
-        $hash = '1234';
+        $key = base64_encode('abcd');
+        $hash = base64_encode('1234');
         $this->connection->copyObject([
                 'sourceBucket' => $sourceBucket,
                 'sourceObject' => $objectName,
@@ -283,8 +283,8 @@ class StorageObjectTest extends \PHPUnit_Framework_TestCase
                 'httpOptions' => [
                     'headers' => [
                         'x-goog-encryption-algorithm' => 'AES256',
-                        'x-goog-encryption-key' => base64_encode($key),
-                        'x-goog-encryption-key-sha256' => base64_encode($hash),
+                        'x-goog-encryption-key' => $key,
+                        'x-goog-encryption-key-sha256' => $hash,
                     ]
                 ]
             ])
@@ -310,8 +310,8 @@ class StorageObjectTest extends \PHPUnit_Framework_TestCase
 
     public function testDownloadsAsString()
     {
-        $key = 'abcd';
-        $hash = '1234';
+        $key = base64_encode('abcd');
+        $hash = base64_encode('1234');
         $bucket = 'bucket';
         $object = 'object.txt';
         $stream = Psr7\stream_for($string = 'abcdefg');
@@ -322,8 +322,8 @@ class StorageObjectTest extends \PHPUnit_Framework_TestCase
                 'httpOptions' => [
                     'headers' => [
                         'x-goog-encryption-algorithm' => 'AES256',
-                        'x-goog-encryption-key' => base64_encode($key),
-                        'x-goog-encryption-key-sha256' => base64_encode($hash),
+                        'x-goog-encryption-key' => $key,
+                        'x-goog-encryption-key-sha256' => $hash,
                     ]
                 ]
             ])
@@ -340,8 +340,8 @@ class StorageObjectTest extends \PHPUnit_Framework_TestCase
 
     public function testDownloadsToFile()
     {
-        $key = 'abcd';
-        $hash = '1234';
+        $key = base64_encode('abcd');
+        $hash = base64_encode('1234');
         $bucket = 'bucket';
         $object = 'object.txt';
         $stream = Psr7\stream_for($string = 'abcdefg');
@@ -352,8 +352,8 @@ class StorageObjectTest extends \PHPUnit_Framework_TestCase
                 'httpOptions' => [
                     'headers' => [
                         'x-goog-encryption-algorithm' => 'AES256',
-                        'x-goog-encryption-key' => base64_encode($key),
-                        'x-goog-encryption-key-sha256' => base64_encode($hash),
+                        'x-goog-encryption-key' => $key,
+                        'x-goog-encryption-key-sha256' => $hash,
                     ]
                 ]
             ])
@@ -391,8 +391,8 @@ class StorageObjectTest extends \PHPUnit_Framework_TestCase
 
     public function testGetBodyWithExtraOptions()
     {
-        $key = 'abcd';
-        $hash = '1234';
+        $key = base64_encode('abcd');
+        $hash = base64_encode('1234');
         $bucket = 'bucket';
         $object = 'object.txt';
         $stream = Psr7\stream_for($string = 'abcdefg');
@@ -403,8 +403,8 @@ class StorageObjectTest extends \PHPUnit_Framework_TestCase
             'httpOptions' => [
                 'headers' => [
                     'x-goog-encryption-algorithm' => 'AES256',
-                    'x-goog-encryption-key' => base64_encode($key),
-                    'x-goog-encryption-key-sha256' => base64_encode($hash),
+                    'x-goog-encryption-key' => $key,
+                    'x-goog-encryption-key-sha256' => $hash
                 ]
             ]
         ])
@@ -436,8 +436,8 @@ class StorageObjectTest extends \PHPUnit_Framework_TestCase
 
     public function testGetsInfoWithReload()
     {
-        $key = 'abcd';
-        $hash = '1234';
+        $key = base64_encode('abcd');
+        $hash = base64_encode('1234');
         $bucket = 'bucket';
         $object = 'object.txt';
         $objectInfo = [
@@ -453,8 +453,8 @@ class StorageObjectTest extends \PHPUnit_Framework_TestCase
                 'httpOptions' => [
                     'headers' => [
                         'x-goog-encryption-algorithm' => 'AES256',
-                        'x-goog-encryption-key' => base64_encode($key),
-                        'x-goog-encryption-key-sha256' => base64_encode($hash),
+                        'x-goog-encryption-key' => $key,
+                        'x-goog-encryption-key-sha256' => $hash,
                     ]
                 ]
             ])


### PR DESCRIPTION
Closes: https://github.com/GoogleCloudPlatform/google-cloud-php/issues/266

@bshaffer Does this line up well with what you were thinking?