### PR TITLE
introduce int64 object for 32 bit systems

### DIFF
--- a/src/Datastore/DatastoreClient.php
+++ b/src/Datastore/DatastoreClient.php
@@ -24,6 +24,7 @@ use Google\Cloud\Datastore\Query\GqlQuery;
 use Google\Cloud\Datastore\Query\Query;
 use Google\Cloud\Datastore\Query\QueryBuilder;
 use Google\Cloud\Datastore\Query\QueryInterface;
+use Google\Cloud\Int64;
 use InvalidArgumentException;
 use Psr\Cache\CacheItemPoolInterface;
 
@@ -130,13 +131,18 @@ class DatastoreClient
      *     @type array $scopes Scopes to be used for the request.
      *     @type string $namespaceId Partitions data under a namespace. Useful for
      *           [Multitenant Projects](https://cloud.google.com/datastore/docs/concepts/multitenancy).
+     *     @type bool $returnInt64AsObject Whether or not to return 64 bit
+     *           integers as their native type or as a
+     *           {@see Google\Cloud\Int64} object. This can be useful when
+     *           working on a 32 bit platform. **Defaults to** false.
      * }
      * @throws \InvalidArgumentException
      */
     public function __construct(array $config = [])
     {
         $config = $config + [
-            'namespaceId' => null
+            'namespaceId' => null,
+            'returnInt64AsObject' => false
         ];
 
         if (!isset($config['scopes'])) {
@@ -147,7 +153,7 @@ class DatastoreClient
 
         // The second parameter here should change to a variable
         // when gRPC support is added for variable encoding.
-        $this->entityMapper = new EntityMapper($this->projectId, true);
+        $this->entityMapper = new EntityMapper($this->projectId, true, $config['returnInt64AsObject']);
         $this->operation = new Operation(
             $this->connection,
             $this->projectId,
@@ -369,6 +375,23 @@ class DatastoreClient
     public function blob($value)
     {
         return new Blob($value);
+    }
+
+    /**
+     * Create an Int64 object. This can be used to work with 64 bit integers as
+     * a string value while on a 32 bit platform.
+     *
+     * Example:
+     * ```
+     * $int64 = $datastore->int64('9223372036854775807');
+     * ```
+     *
+     * @param string $value
+     * @return Int64
+     */
+    public function int64($value)
+    {
+        return new Int64($value);
     }
 
     /**

--- a/src/Datastore/DatastoreClient.php
+++ b/src/Datastore/DatastoreClient.php
@@ -131,10 +131,9 @@ class DatastoreClient
      *     @type array $scopes Scopes to be used for the request.
      *     @type string $namespaceId Partitions data under a namespace. Useful for
      *           [Multitenant Projects](https://cloud.google.com/datastore/docs/concepts/multitenancy).
-     *     @type bool $returnInt64AsObject Whether or not to return 64 bit
-     *           integers as their native type or as a
-     *           {@see Google\Cloud\Int64} object. This can be useful when
-     *           working on a 32 bit platform. **Defaults to** false.
+     *     @type bool $returnInt64AsObject If true, 64 bit integers will be
+     *           returned as a {@see Google\Cloud\Int64} object for 32 bit
+     *           platform compatibility. **Defaults to** false.
      * }
      * @throws \InvalidArgumentException
      */

--- a/src/Datastore/Entity.php
+++ b/src/Datastore/Entity.php
@@ -37,6 +37,7 @@ use Psr\Http\Message\StreamInterface;
  * | {@see Google\Cloud\Datastore\GeoPoint}     | `geoPointValue`                      |
  * | {@see Google\Cloud\Datastore\Entity}       | `entityValue`                        |
  * | {@see Google\Cloud\Datastore\Blob}         | `blobValue`                          |
+ * | {@see Google\Cloud\Int64}                  | `integerValue`                       |
  * | Associative Array                          | `entityValue` (No Key)               |
  * | Non-Associative Array                      | `arrayValue`                         |
  * | `float`                                    | `doubleValue`                        |

--- a/src/Datastore/EntityMapper.php
+++ b/src/Datastore/EntityMapper.php
@@ -34,6 +34,7 @@ class EntityMapper
     use DatastoreTrait;
 
     const DATE_FORMAT = 'Y-m-d\TH:i:s.uP';
+    const DATE_FORMAT_NO_MS = 'Y-m-d\TH:i:sP';
 
     /**
      * @var string
@@ -55,9 +56,9 @@ class EntityMapper
      *
      * @param string $projectId The datastore project ID
      * @param bool $encode Whether to encode blobs as base64.
-     * @param bool $returnInt64AsObject Whether or not to return 64 bit integers
-     *             as their native type or as a {@see Google\Cloud\Int64}
-     *             object. This can be useful when working on a 32 bit platform.
+     * @param @type bool $returnInt64AsObject If true, 64 bit integers will be
+     *              returned as a {@see Google\Cloud\Int64} object for 32 bit
+     *              platform compatibility.
      */
     public function __construct($projectId, $encode, $returnInt64AsObject)
     {
@@ -162,6 +163,10 @@ class EntityMapper
 
             case 'timestampValue':
                 $result = \DateTimeImmutable::createFromFormat(self::DATE_FORMAT, $value);
+
+                if (!$result) {
+                    $result = \DateTimeImmutable::createFromFormat(self::DATE_FORMAT_NO_MS, $value);
+                }
 
                 break;
 

--- a/src/Datastore/EntityMapper.php
+++ b/src/Datastore/EntityMapper.php
@@ -55,6 +55,9 @@ class EntityMapper
      *
      * @param string $projectId The datastore project ID
      * @param bool $encode Whether to encode blobs as base64.
+     * @param bool $returnInt64AsObject Whether or not to return 64 bit integers
+     *             as their native type or as a {@see Google\Cloud\Int64}
+     *             object. This can be useful when working on a 32 bit platform.
      */
     public function __construct($projectId, $encode, $returnInt64AsObject)
     {

--- a/src/Int64.php
+++ b/src/Int64.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud;
+
+/**
+ * Represents a 64 bit integer. This can be useful when working on a 32 bit
+ * platform.
+ *
+ * Example:
+ * ```
+ * $int64 = new Int64('9223372036854775807');
+ * ```
+ */
+class Int64
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $value The 64 bit integer value in string format.
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * Get the value.
+     *
+     * Example:
+     * ```
+     * $value = $int64->get();
+     * ```
+     *
+     * @return string
+     */
+    public function get()
+    {
+        return $this->value;
+    }
+}

--- a/src/Int64.php
+++ b/src/Int64.php
@@ -65,5 +65,4 @@ class Int64
     {
         return $this->value;
     }
-
 }

--- a/src/Int64.php
+++ b/src/Int64.php
@@ -55,4 +55,15 @@ class Int64
     {
         return $this->value;
     }
+
+    /**
+     * Provides a convenient way to access the value.
+     *
+     * @access private
+     */
+    public function __toString()
+    {
+        return $this->value;
+    }
+
 }

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -125,8 +125,14 @@ class ServiceBuilder
      * $datastore = $cloud->datastore();
      * ```
      *
-     * @param array $config [optional] Configuration options. See
-     *        {@see Google\Cloud\ServiceBuilder::__construct()} for the available options.
+     * @param array $config [optional] {
+     *     Configuration options. See
+     *     {@see Google\Cloud\ServiceBuilder::__construct()} for the other available options.
+     *
+     *     @type bool $returnInt64AsObject Whether or not to return 64 bit
+     *           integers as their native type or as a
+     *           {@see Google\Cloud\Int64} object. This can be useful when
+     *           working on a 32 bit platform. **Defaults to** false.
      * @return DatastoreClient
      */
     public function datastore(array $config = [])

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -129,10 +129,9 @@ class ServiceBuilder
      *     Configuration options. See
      *     {@see Google\Cloud\ServiceBuilder::__construct()} for the other available options.
      *
-     *     @type bool $returnInt64AsObject Whether or not to return 64 bit
-     *           integers as their native type or as a
-     *           {@see Google\Cloud\Int64} object. This can be useful when
-     *           working on a 32 bit platform. **Defaults to** false.
+     *     @type bool $returnInt64AsObject If true, 64 bit integers will be
+     *           returned as a {@see Google\Cloud\Int64} object for 32 bit
+     *           platform compatibility. **Defaults to** false.
      * @return DatastoreClient
      */
     public function datastore(array $config = [])

--- a/tests/system/Datastore/DatastoreTestCase.php
+++ b/tests/system/Datastore/DatastoreTestCase.php
@@ -25,6 +25,7 @@ class DatastoreTestCase extends \PHPUnit_Framework_TestCase
     const TESTING_PREFIX = 'gcloud_testing_';
 
     protected static $client;
+    protected static $returnInt64AsObjectClient;
     protected static $deletionQueue = [];
     private static $hasSetUp = false;
 
@@ -34,9 +35,14 @@ class DatastoreTestCase extends \PHPUnit_Framework_TestCase
             return;
         }
 
-        self::$client = new DatastoreClient([
+        $config = [
             'keyFilePath' => getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH'),
             'namespaceId' => uniqid(self::TESTING_PREFIX)
+        ];
+
+        self::$client = new DatastoreClient($config);
+        self::$returnInt64AsObjectClient = new DatastoreClient($config + [
+            'returnInt64AsObject' => true
         ]);
         self::$hasSetUp = true;
     }

--- a/tests/system/Datastore/SaveAndModifyTest.php
+++ b/tests/system/Datastore/SaveAndModifyTest.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Tests\System\Datastore;
 
+use Google\Cloud\Int64;
+
 class SaveAndModifyTest extends DatastoreTestCase
 {
     public function testEntityLifeCycle()
@@ -92,5 +94,22 @@ class SaveAndModifyTest extends DatastoreTestCase
         $entity = self::$client->lookup($key);
 
         $this->assertEquals([$entityDataKey => $entityDataValue], $entity->get());
+    }
+
+    public function testInsertInt64AsObject()
+    {
+        $entityDataKey = 'int64';
+        $intValue = '9223372036854775807';
+        $int64Object = new Int64($intValue);
+        $entity = self::$returnInt64AsObjectClient->entity('Int64');
+        $entity[$entityDataKey] = $int64Object;
+
+        self::$returnInt64AsObjectClient->insert($entity);
+        $key = $entity->key();
+        self::$deletionQueue[] = $key;
+        $entity = self::$returnInt64AsObjectClient->lookup($key);
+
+        $this->assertInstanceOf(Int64::class, $entity[$entityDataKey]);
+        $this->assertEquals($intValue, (string) $entity[$entityDataKey]);
     }
 }

--- a/tests/unit/Datastore/EntityMapperTest.php
+++ b/tests/unit/Datastore/EntityMapperTest.php
@@ -22,6 +22,7 @@ use Google\Cloud\Datastore\Entity;
 use Google\Cloud\Datastore\EntityMapper;
 use Google\Cloud\Datastore\GeoPoint;
 use Google\Cloud\Datastore\Key;
+use Google\Cloud\Int64;
 
 /**
  * @group datastore
@@ -34,7 +35,7 @@ class EntityMapperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->mapper = new EntityMapper('foo', true);
+        $this->mapper = new EntityMapper('foo', true, false);
     }
 
     public function testResponseToProperties()
@@ -525,7 +526,7 @@ class EntityMapperTest extends \PHPUnit_Framework_TestCase
         fwrite($stream, $string);
         rewind($stream);
 
-        $mapper = new EntityMapper('foo', false);
+        $mapper = new EntityMapper('foo', false, false);
         $res = $mapper->valueObject($stream);
 
         $this->assertEquals($string, $res['blobValue']);
@@ -551,7 +552,7 @@ class EntityMapperTest extends \PHPUnit_Framework_TestCase
 
     public function testObjectPropertyBlobNotEncoded()
     {
-        $mapper = new EntityMapper('foo', false);
+        $mapper = new EntityMapper('foo', false, false);
 
         $res = $mapper->valueObject(new Blob('hello world'));
 
@@ -635,5 +636,26 @@ class EntityMapperTest extends \PHPUnit_Framework_TestCase
         $res = $this->mapper->objectToRequest($e);
         $this->assertEquals('bar', $res['properties']['foo']['stringValue']);
         $this->assertEquals(10, $res['properties']['foo']['meaning']);
+    }
+
+    public function testReturnsInt64AsObject()
+    {
+        $int = '914241242';
+        $mapper = new EntityMapper('foo', true, true);
+        $res = $mapper->convertValue('integerValue', $int);
+
+        $this->assertInstanceOf(Int64::class, $res);
+        $this->assertEquals($int, $res->get());
+    }
+
+    public function testObjectPropertyInt64()
+    {
+        $int = '123239';
+        $int64 = new Int64($int);
+        $res = $this->mapper->objectProperty($int64);
+
+        $this->assertEquals([
+            'integerValue' => $int64->get()
+        ], $res);
     }
 }

--- a/tests/unit/Datastore/EntityTest.php
+++ b/tests/unit/Datastore/EntityTest.php
@@ -36,7 +36,7 @@ class EntityTest extends \PHPUnit_Framework_TestCase
             ['kind' => 'kind', 'name' => 'name']
         ]]);
 
-        $this->mapper = new EntityMapper('foo', true);
+        $this->mapper = new EntityMapper('foo', true, false);
     }
 
     public function testCreateEntity()

--- a/tests/unit/Datastore/OperationTest.php
+++ b/tests/unit/Datastore/OperationTest.php
@@ -37,7 +37,7 @@ class OperationTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
-        $this->mapper = new EntityMapper('foo', true);
+        $this->mapper = new EntityMapper('foo', true, false);
         $this->operation = new OperationStub($this->connection->reveal(), 'foo', '', $this->mapper);
     }
 

--- a/tests/unit/Datastore/Query/GqlQueryTest.php
+++ b/tests/unit/Datastore/Query/GqlQueryTest.php
@@ -29,7 +29,7 @@ class GqlQueryTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->mapper = new EntityMapper('foo', true);
+        $this->mapper = new EntityMapper('foo', true, false);
     }
 
     public function testBindingTypeAutomaticDetectionNamed()

--- a/tests/unit/Datastore/Query/QueryTest.php
+++ b/tests/unit/Datastore/Query/QueryTest.php
@@ -31,7 +31,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->mapper = new EntityMapper('foo', true);
+        $this->mapper = new EntityMapper('foo', true, false);
         $this->query = new Query($this->mapper);
     }
 

--- a/tests/unit/Int64Test.php
+++ b/tests/unit/Int64Test.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests;
+
+use Google\Cloud\Int64;
+
+/**
+ * @group root
+ */
+class Int64Test extends \PHPUnit_Framework_TestCase
+{
+    public function testGetsValue()
+    {
+        $int = '123';
+        $int64 = new Int64($int);
+
+        $this->assertEquals($int, $int64->get());
+    }
+}

--- a/tests/unit/Int64Test.php
+++ b/tests/unit/Int64Test.php
@@ -31,4 +31,12 @@ class Int64Test extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($int, $int64->get());
     }
+
+    public function testToString()
+    {
+        $int = '123';
+        $int64 = new Int64($int);
+
+        $this->assertEquals($int, (string) $int64);
+    }
 }


### PR DESCRIPTION
Closes https://github.com/GoogleCloudPlatform/google-cloud-php/issues/259

Sample:

```php
require 'vendor/autoload.php';
use Google\Cloud\Datastore\DatastoreClient;

$datastore = new DatastoreClient([
    'returnInt64AsObject' => true
]);

$key = $datastore->key('Example', 100);
$entity = $datastore->entity($key);
$entity['int64Example'] = $datastore->int64('9223372036854775807');
$datastore->insert($entity);

$entity = $datastore->lookup($key);
echo $entity['int64Example']->get(); // '9223372036854775807'
```
