### PR TITLE
(BC Break) psr logger updates

### DIFF
--- a/src/Logging/LoggingClient.php
+++ b/src/Logging/LoggingClient.php
@@ -412,6 +412,8 @@ class LoggingClient
      * @param array $options [optional] {
      *     Configuration options.
      *
+     *     @type string $messageKey The key in the `jsonPayload` used to contain
+     *           the logged message. **Defaults to** `message`.
      *     @type array $resource The
      *           [monitored resource](https://cloud.google.com/logging/docs/api/reference/rest/Shared.Types/MonitoredResource)
      *           to associate log entries with. **Defaults to** type global.
@@ -423,7 +425,16 @@ class LoggingClient
      */
     public function psrLogger($name, array $options = [])
     {
-        return new PsrLogger($this->logger($name, $options));
+        $messageKey = null;
+
+        if (isset($options['messageKey'])) {
+            $messageKey = $options['messageKey'];
+            unset($options['messageKey']);
+        }
+
+        return $messageKey
+            ? new PsrLogger($this->logger($name, $options), $messageKey)
+            : new PsrLogger($this->logger($name, $options));
     }
 
     /**

--- a/src/Logging/PsrLogger.php
+++ b/src/Logging/PsrLogger.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Logging;
 
+use Monolog\Formatter\NormalizerFormatter;
+use Monolog\Processor\PsrLogMessageProcessor;
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -42,11 +44,19 @@ class PsrLogger implements LoggerInterface
     private $logger;
 
     /**
-     * @param Logger $logger The logger used to write entries.
+     * @var string The key to use for messages logged in the `jsonPayload`.
      */
-    public function __construct(Logger $logger)
+    private $messageKey;
+
+    /**
+     * @param Logger $logger The logger used to write entries.
+     * @param string $messageKey The key in the `jsonPayload` used to contain
+     *        the logged message. **Defaults to** `message`.
+     */
+    public function __construct(Logger $logger, $messageKey = 'message')
     {
         $this->logger = $logger;
+        $this->messageKey = $messageKey;
     }
 
     /**
@@ -195,22 +205,54 @@ class PsrLogger implements LoggerInterface
      * $psrLogger->log(Logger::ALERT, 'alert message');
      * ```
      *
+     * ```
+     * // Write a log entry using the context array with placeholders.
+     * use Google\Cloud\Logging\Logger;
+     *
+     * $psrLogger->log(Logger::ALERT, 'alert: {message}', [
+     *     'message' => 'my alert message'
+     * ]);
+     * ```
+     *
+     * ```
+     * // Log information regarding an HTTP request
+     * use Google\Cloud\Logging\Logger;
+     *
+     * $psrLogger->log(Logger::ALERT, 'alert message', [
+     *     'stackdriverOptions' => [
+     *         'httpRequest' => [
+     *             'requestMethod' => 'GET'
+     *         ]
+     *     ]
+     * ]);
+     * ```
+     *
      * @codingStandardsIgnoreStart
      * @param string|int $level The severity of the log entry.
      * @param string $message The message to log.
      * @param array $context {
-     *     @type array $resource The
+     *     Context is an associative array which can include placeholders to be
+     *     used in the `$message`. Placeholders must be delimited with a single
+     *     opening brace `{` and a single closing brace `}`. The context will be
+     *     added as additional information on the `jsonPayload`. Please note
+     *     that the key `stackdriverOptions` is reserved for logging Google
+     *     Stackdriver specific data.
+     *
+     *     @type array $stackdriverOptions['resource'] The
      *           [monitored resource](https://cloud.google.com/logging/docs/api/reference/rest/Shared.Types/MonitoredResource)
      *           to associate this log entry with. **Defaults to** type global.
-     *     @type array $httpRequest Information about the HTTP request
-     *           associated with this log entry, if applicable. Please see
+     *     @type array $stackdriverOptions['httpRequest'] Information about the
+     *           HTTP request associated with this log entry, if applicable.
+     *           Please see
      *           [the API docs](https://cloud.google.com/logging/docs/api/reference/rest/Shared.Types/LogEntry#httprequest)
      *           for more information.
-     *     @type array $labels A set of user-defined (key, value) data that
-     *           provides additional information about the log entry.
-     *     @type array $operation Additional information about a potentially
-     *           long-running operation with which a log entry is associated.
-     *           Please see [the API docs](https://cloud.google.com/logging/docs/api/reference/rest/Shared.Types/LogEntry#logentryoperation)
+     *     @type array $stackdriverOptions['labels'] A set of user-defined
+     *           (key, value) data that provides additional information about
+     *           the log entry.
+     *     @type array $stackdriverOptions['operation'] Additional information
+     *           about a potentially long-running operation with which a log
+     *           entry is associated. Please see
+     *           [the API docs](https://cloud.google.com/logging/docs/api/reference/rest/Shared.Types/LogEntry#logentryoperation)
      *           for more information.
      * }
      * @throws InvalidArgumentException
@@ -218,17 +260,29 @@ class PsrLogger implements LoggerInterface
      */
     public function log($level, $message, array $context = [])
     {
-        $message = (string) $message;
         $this->validateLogLevel($level);
+        $options = [];
 
         if (isset($context['exception']) && $context['exception'] instanceof \Exception) {
-            $message .= ' : ' . (string) $context['exception'];
-            unset($context['exception']);
+            $context['exception'] = (string) $context['exception'];
         }
 
+        if (isset($context['stackdriverOptions'])) {
+            $options = $context['stackdriverOptions'];
+            unset($context['stackdriverOptions']);
+        }
+
+        $formatter = new NormalizerFormatter();
+        $processor = new PsrLogMessageProcessor();
+        $processedData = $processor([
+            'message' => (string) $message,
+            'context' => $formatter->format($context)
+        ]);
+        $jsonPayload = [$this->messageKey => $processedData['message']];
+
         $entry = $this->logger->entry(
-            $message,
-            $context + [
+            $jsonPayload + $processedData['context'],
+            $options + [
                 'severity' => $level
             ]
         );

--- a/tests/system/Logging/WriteAndListEntryTest.php
+++ b/tests/system/Logging/WriteAndListEntryTest.php
@@ -232,7 +232,9 @@ class WriteAndListEntryTest extends LoggingTestCase
         ];
 
         $psrLogger->$level($data, [
-            'httpRequest' => $httpRequest
+            'stackdriverOptions' => [
+                'httpRequest' => $httpRequest
+            ]
         ]);
 
         $backoff = new ExponentialBackoff(8);
@@ -247,7 +249,7 @@ class WriteAndListEntryTest extends LoggingTestCase
         });
         $actualEntryInfo = $entries[0]->info();
 
-        $this->assertEquals($data, $actualEntryInfo['textPayload']);
+        $this->assertEquals($data, $actualEntryInfo['jsonPayload']['message']);
         $this->assertEquals($httpRequest['requestMethod'], $actualEntryInfo['httpRequest']['requestMethod']);
     }
 }

--- a/tests/unit/Logging/PsrLoggerCompatabilityTest.php
+++ b/tests/unit/Logging/PsrLoggerCompatabilityTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Logging;
+
+use Google\Cloud\Logging\Connection\ConnectionInterface;
+use Google\Cloud\Logging\Logger;
+use Google\Cloud\Logging\PsrLogger;
+use Psr\Log\Test\LoggerInterfaceTest;
+use Prophecy\Argument;
+
+/**
+ * @group logging
+ */
+class PsrLoggerCompatabilityTest extends LoggerInterfaceTest
+{
+    public static $logs = [];
+
+    public function setUp()
+    {
+        self::$logs = [];
+    }
+
+    public function getLogger()
+    {
+        $connection = $this->prophesize(ConnectionInterface::class);
+        $connection->writeEntries(Argument::any())
+            ->will(function ($entries) {
+                $map = Logger::getLogLevelMap();
+                $entry = $entries[0]['entries'][0];
+                $severity = is_int($entry['severity'])
+                    ? strtolower($map[$entry['severity']])
+                    : $entry['severity'];
+
+                self::$logs[] = sprintf('%s %s',
+                    $severity,
+                    $entry['jsonPayload']['message']
+                );
+            });
+        $logger = new Logger($connection->reveal(), 'my-log', 'projectId');;
+
+        return new PsrLogger($logger);
+    }
+
+    public function getLogs()
+    {
+        return self::$logs;
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/GoogleCloudPlatform/google-cloud-php/issues/267

Messages logged through the `PsrLogger` now log as `jsonPayload` with a customizable key containing the message contents instead of as `textPayload`. Placeholders are supported and any additional info in the context array is to be logged as part of the `jsonPayload`. In order to support logging stackdriver specific data (such as labels) the `stackdriverOptions` key has been reserved.

Much thanks to @CaptainJojo for the original report.