### PR TITLE
Prepare v0.20.0

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -6,6 +6,7 @@
     "defaultService": "servicebuilder",
     "markdown": "php",
     "versions": [
+        "v0.20.0",
         "v0.13.2",
         "v0.13.1",
         "v0.13.0",

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -48,7 +48,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class ServiceBuilder
 {
-    const VERSION = '0.13.2';
+    const VERSION = '0.20.0';
 
     /**
      * @var array Configuration options to be used between clients.


### PR DESCRIPTION
## Google Cloud PHP v0.20.0

### What happened to v0.14.0 through 0.19.0?

Have you heard? We're going beta with our four major APIs! (BigQuery, Datastore,
Logging and Storage.) We've skipped a few numbers to highlight the fact that
this isn't just another minor release.

### What's New?

* Datastore and BigQuery can now optionally represent integer values as an
  object called `Google\Cloud\Int64`. This change improves support for 32-bit
  environments, including Windows on PHP versions older than 7.0.0. To enable
  integers-as-object, pass `['returnInt64AsObject' => true]` in the DatastoreClient
  and BigQueryClient constructor or factory method (`ServiceBuilder::datastore()`,
  `ServiceBuilder::bigQuery()`). (#282)

* BigQuery now supports Query value parameterization! Both named and positional
  parameters are supported. (#271)

### What's Updated?

* [BC Break] Stackdriver Logging now uses "global" as its default resource
  type. (#242)

  * The signature for `Google\Cloud\Logging\Logger::entry()` has changed. Rather
    than accepting a resource as its second argument, a resource can be provided
    as `$options['resource']`, or by specifying a resource when constructing
    a Logger instance.
  * The signature for `Google\Cloud\Logging\LoggingClient::psrLogger()` no
    longer accepts a resource as its second argument. Instead, the second
    argument accepts an `$options` array, which has a `resource` key available.

* [BC Break] Stackdriver Logging's PSR-3 Logger has been updated to better
  support log context and to implement message placeholder interpolation. (#284)

  * If you are providing any of the stackdriver logging values (httpRequest,
    resource, labels, operation), those must be provided as members of
    `$context['stackdriverOptions']`.

* [BC Break] Google Cloud Storage has been updated to simplify file encryption.
  Encryption keys are now supplied by a single option,
  `$options['encryptionKey']`, which is expected to be base64-encoded. (#272)

  The following methods have been updated:
  * `Google\Cloud\Storage\Bucket::upload()`
  * `Google\Cloud\Storage\Bucket::object()`
  * `Google\Cloud\Storage\StorageObject::copy()`
  * `Google\Cloud\Storage\StorageObject::rewrite()`
  * `Google\Cloud\Storage\StorageObkect::rename()`
  * `Google\Cloud\Storage\StorageObject::reload()`


### What's Fixed?

* Datastore has been updated to support microseconds in DateTime values. (#278)
* A bug in Natural Language in which analyzeSyntax calls failed due to a missing
  parameter has been fixed. As part of this change, Natural Language now uses v1
  of the Google Natural Language API. (#281)