### PR TITLE
Update system tests

### DIFF
--- a/tests/system/BigQuery/LoadDataAndQueryTest.php
+++ b/tests/system/BigQuery/LoadDataAndQueryTest.php
@@ -21,6 +21,9 @@ use Google\Cloud\BigQuery\Date;
 use Google\Cloud\ExponentialBackoff;
 use GuzzleHttp\Psr7;
 
+/**
+ * @group bigquery
+ */
 class LoadDataAndQueryTest extends BigQueryTestCase
 {
     private static $expectedRows = 0;

--- a/tests/system/BigQuery/ManageDatasetsTest.php
+++ b/tests/system/BigQuery/ManageDatasetsTest.php
@@ -17,6 +17,9 @@
 
 namespace Google\Cloud\Tests\System\BigQuery;
 
+/**
+ * @group bigquery
+ */
 class ManageDatasetsTest extends BigQueryTestCase
 {
     public function testListDatasets()

--- a/tests/system/BigQuery/ManageJobsTest.php
+++ b/tests/system/BigQuery/ManageJobsTest.php
@@ -19,6 +19,9 @@ namespace Google\Cloud\Tests\System\BigQuery;
 
 use Google\Cloud\BigQuery\Job;
 
+/**
+ * @group bigquery
+ */
 class ManageJobsTest extends BigQueryTestCase
 {
     public function testListJobs()

--- a/tests/system/BigQuery/ManageTablesTest.php
+++ b/tests/system/BigQuery/ManageTablesTest.php
@@ -19,6 +19,9 @@ namespace Google\Cloud\Tests\System\BigQuery;
 
 use Google\Cloud\ExponentialBackoff;
 
+/**
+ * @group bigquery
+ */
 class ManageTablesTest extends BigQueryTestCase
 {
     public function testListTables()

--- a/tests/system/Datastore/AllocateKeyTest.php
+++ b/tests/system/Datastore/AllocateKeyTest.php
@@ -17,6 +17,9 @@
 
 namespace Google\Cloud\Tests\System\Datastore;
 
+/**
+ * @group datastore
+ */
 class AllocateKeyTest extends DatastoreTestCase
 {
     public function testAllocateId()

--- a/tests/system/Datastore/RunQueryTest.php
+++ b/tests/system/Datastore/RunQueryTest.php
@@ -17,6 +17,9 @@
 
 namespace Google\Cloud\Tests\System\Datastore;
 
+/**
+ * @group datastore
+ */
 class RunQueryTest extends DatastoreTestCase
 {
     private static $ancestor;

--- a/tests/system/Datastore/RunTransactionTest.php
+++ b/tests/system/Datastore/RunTransactionTest.php
@@ -17,6 +17,9 @@
 
 namespace Google\Cloud\Tests\System\Datastore;
 
+/**
+ * @group datastore
+ */
 class RunTransactionTest extends DatastoreTestCase
 {
     public function testRunTransactions()

--- a/tests/system/Datastore/SaveAndModifyTest.php
+++ b/tests/system/Datastore/SaveAndModifyTest.php
@@ -19,6 +19,9 @@ namespace Google\Cloud\Tests\System\Datastore;
 
 use Google\Cloud\Int64;
 
+/**
+ * @group datastore
+ */
 class SaveAndModifyTest extends DatastoreTestCase
 {
     public function testEntityLifeCycle()

--- a/tests/system/Logging/ManageMetricsTest.php
+++ b/tests/system/Logging/ManageMetricsTest.php
@@ -17,6 +17,9 @@
 
 namespace Google\Cloud\Tests\System\Logging;
 
+/**
+ * @group logging
+ */
 class ManageMetricsTest extends LoggingTestCase
 {
     /**

--- a/tests/system/Logging/ManageSinksTest.php
+++ b/tests/system/Logging/ManageSinksTest.php
@@ -17,6 +17,9 @@
 
 namespace Google\Cloud\Tests\System\Logging;
 
+/**
+ * @group logging
+ */
 class ManageSinksTest extends LoggingTestCase
 {
     /**

--- a/tests/system/Logging/WriteAndListEntryTest.php
+++ b/tests/system/Logging/WriteAndListEntryTest.php
@@ -19,6 +19,9 @@ namespace Google\Cloud\Tests\System\Logging;
 
 use Google\Cloud\ExponentialBackoff;
 
+/**
+ * @group logging
+ */
 class WriteAndListEntryTest extends LoggingTestCase
 {
     /**

--- a/tests/system/NaturalLanguage/AnalyzeTest.php
+++ b/tests/system/NaturalLanguage/AnalyzeTest.php
@@ -17,6 +17,9 @@
 
 namespace Google\Cloud\Tests\System\NaturalLanguage;
 
+/**
+ * @group naturallanguage
+ */
 class AnalyzeTest extends NaturalLanguageTestCase
 {
     /**

--- a/tests/system/PubSub/ManageIAMPoliciesTest.php
+++ b/tests/system/PubSub/ManageIAMPoliciesTest.php
@@ -17,6 +17,9 @@
 
 namespace Google\Cloud\Tests\System\PubSub;
 
+/**
+ * @group pubsub
+ */
 class ManageIAMPoliciesTest extends PubSubTestCase
 {
     /**

--- a/tests/system/PubSub/ManageSubscriptionsTest.php
+++ b/tests/system/PubSub/ManageSubscriptionsTest.php
@@ -17,6 +17,9 @@
 
 namespace Google\Cloud\Tests\System\PubSub;
 
+/**
+ * @group pubsub
+ */
 class ManageSubscriptionsTest extends PubSubTestCase
 {
     /**
@@ -63,7 +66,8 @@ class ManageSubscriptionsTest extends PubSubTestCase
     {
         $foundSubs = [];
         foreach ($subs as $sub) {
-            $sName = end(explode('/', $sub->name()));
+            $nameParts = explode('/', $sub->name());
+            $sName = end($nameParts);
             foreach ($expectedSubs as $key => $expectedSub) {
                 if ($sName === $expectedSub) {
                     $foundSubs[$key] = $sName;

--- a/tests/system/PubSub/ManageTopicsTest.php
+++ b/tests/system/PubSub/ManageTopicsTest.php
@@ -17,6 +17,9 @@
 
 namespace Google\Cloud\Tests\System\PubSub;
 
+/**
+ * @group pubsub
+ */
 class ManageTopicsTest extends PubSubTestCase
 {
     /**
@@ -37,7 +40,8 @@ class ManageTopicsTest extends PubSubTestCase
         $topics = $client->topics();
 
         foreach ($topics as $topic) {
-            $tName = end(explode('/', $topic->name()));
+            $nameParts = explode('/', $topic->name());
+            $tName = end($nameParts);
             foreach ($topicsToCreate as $key => $topicToCreate) {
                 if ($tName === $topicToCreate) {
                     $foundTopics[$key] = $tName;

--- a/tests/system/PubSub/PublishAndPullTest.php
+++ b/tests/system/PubSub/PublishAndPullTest.php
@@ -17,6 +17,9 @@
 
 namespace Google\Cloud\Tests\System\PubSub;
 
+/**
+ * @group pubsub
+ */
 class PublishAndPullTest extends PubSubTestCase
 {
     /**

--- a/tests/system/Storage/ManageAclTest.php
+++ b/tests/system/Storage/ManageAclTest.php
@@ -20,6 +20,9 @@ namespace Google\Cloud\Tests\System\Storage;
 use Google\Cloud\Storage\Acl;
 use Google\Cloud\Exception\NotFoundException;
 
+/**
+ * @group storage
+ */
 class ManageAclTest extends StorageTestCase
 {
     public function testManageBucketAcl()

--- a/tests/system/Storage/ManageBucketsTest.php
+++ b/tests/system/Storage/ManageBucketsTest.php
@@ -17,6 +17,9 @@
 
 namespace Google\Cloud\Tests\System\Storage;
 
+/**
+ * @group storage
+ */
 class ManageBucketsTest extends StorageTestCase
 {
     public function testListsBuckets()

--- a/tests/system/Storage/ManageObjectsTest.php
+++ b/tests/system/Storage/ManageObjectsTest.php
@@ -19,6 +19,9 @@ namespace Google\Cloud\Tests\System\Storage;
 
 use Psr\Http\Message\StreamInterface;
 
+/**
+ * @group storage
+ */
 class ManageObjectsTest extends StorageTestCase
 {
     public function testListsObjects()

--- a/tests/system/Storage/UploadObjectsTest.php
+++ b/tests/system/Storage/UploadObjectsTest.php
@@ -19,6 +19,9 @@ namespace Google\Cloud\Tests\System\Storage;
 
 use GuzzleHttp\Psr7;
 
+/**
+ * @group storage
+ */
 class UploadObjectsTest extends StorageTestCase
 {
     public function testUploadsObjectFromStringWithMetadata()


### PR DESCRIPTION
Add groups to system tests to ease running a subset, and
fix strict standards pass-by-reference errors.