### PR TITLE
Prepare v0.20.1

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -6,6 +6,7 @@
     "defaultService": "servicebuilder",
     "markdown": "php",
     "versions": [
+        "v0.20.1",
         "v0.20.0",
         "v0.13.2",
         "v0.13.1",

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -48,7 +48,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class ServiceBuilder
 {
-    const VERSION = '0.20.0';
+    const VERSION = '0.20.1';
 
     /**
      * @var array Configuration options to be used between clients.


### PR DESCRIPTION
## Google Cloud PHP v0.20.1

## What's New?

* Google Cloud API REST Service Definitions can now be overridden by implementors. This is an advanced feature which should be used carefully, but in certain cases can allow for early access of new features not yet supported by Google Cloud PHP. (#289)

## What's Fixed?

* A documentation mistake which incorrectly marked a keyFile configuration parameter as a string has been fixed. (#297)