### PR TITLE
Test PHP 7.1 compatibility and fix regressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
         - php: 5.5.38
         - php: 5.6.25
         - php: 7.0
+        - php: 7.1
         - php: hhvm
           group: edge
     fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,10 @@ init:
 
 environment:
   matrix:
-    - PHP_VERSION: "5.5.37-nts-Win32-VC11-x64"
-    - PHP_VERSION: "5.6.25-nts-Win32-VC11-x64"
-    - PHP_VERSION: "7.0.9-nts-Win32-VC14-x64"
+    - PHP_VERSION: "5.5.38-nts-Win32-VC11-x64"
+    - PHP_VERSION: "5.6.29-nts-Win32-VC11-x64"
+    - PHP_VERSION: "7.0.14-nts-Win32-VC14-x64"
+    - PHP_VERSION: "7.1.0-nts-Win32-VC14-x64"
 
 install:
   - cinst -y OpenSSL.Light

--- a/appveyor_install_php.ps1
+++ b/appveyor_install_php.ps1
@@ -1,2 +1,3 @@
-appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-$env:PHP_VERSION.zip
+appveyor DownloadFile http://windows.php.net/downloads/releases/php-$env:PHP_VERSION.zip
+
 7z x php-$env:PHP_VERSION.zip -oc:\tools\php

--- a/appveyor_install_php.ps1
+++ b/appveyor_install_php.ps1
@@ -1,3 +1,13 @@
-appveyor DownloadFile http://windows.php.net/downloads/releases/php-$env:PHP_VERSION.zip
+$file = "php-$env:PHP_VERSION.zip"
+$archiveUrl = "http://windows.php.net/downloads/releases/archives/$file"
+$url = "http://windows.php.net/downloads/releases/$file"
+$projectPath = "C:\projects\google-cloud"
+$client = New-Object NET.WebClient
 
-7z x php-$env:PHP_VERSION.zip -oc:\tools\php
+try {
+    $client.DownloadFile($url, "$projectPath\$file")
+} catch {
+    $client.DownloadFile($archiveUrl, "$projectPath\$file")
+}
+
+7z x $file -oc:\tools\php

--- a/tests/unit/Datastore/EntityMapperTest.php
+++ b/tests/unit/Datastore/EntityMapperTest.php
@@ -561,9 +561,10 @@ class EntityMapperTest extends \PHPUnit_Framework_TestCase
 
     public function testObjectPropertyDateTime()
     {
-        $res = $this->mapper->valueObject(new \DateTimeImmutable);
+        $dateTime = new \DateTimeImmutable;
+        $res = $this->mapper->valueObject($dateTime);
 
-        $this->assertEquals((new \DateTimeImmutable())->format(self::DATE_FORMAT), $res['timestampValue']);
+        $this->assertEquals($dateTime->format(self::DATE_FORMAT), $res['timestampValue']);
     }
 
     public function testObjectPropertyKey()


### PR DESCRIPTION
This introduces PHP 7.1 testing with travis since it's the new stable release since December 1st.