### PR TITLE
fixing #312. Making Rest helper set predefinedAcl to null by default.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "guzzlehttp/guzzle": "^5.3|^6.0",
         "guzzlehttp/psr7": "^1.2",
         "monolog/monolog": "~1",
-        "psr/http-message": "1.0.*"
+        "psr/http-message": "1.0.*",
+        "protobuf-php/protobuf": "^0.1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*",

--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,7 @@
         "guzzlehttp/guzzle": "^5.3|^6.0",
         "guzzlehttp/psr7": "^1.2",
         "monolog/monolog": "~1",
-        "psr/http-message": "1.0.*",
-        "protobuf-php/protobuf": "^0.1.3"
+        "psr/http-message": "1.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*",

--- a/src/Storage/Bucket.php
+++ b/src/Storage/Bucket.php
@@ -201,7 +201,7 @@ class Bucket
      *           Acceptable values include,
      *           `"authenticatedRead"`, `"bucketOwnerFullControl"`,
      *           `"bucketOwnerRead"`, `"private"`, `"projectPrivate"`, and
-     *           `"publicRead"`. **Defaults to** `null`.
+     *           `"publicRead"`.
      *     @type array $metadata The available options for metadata are outlined
      *           at the [JSON API docs](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request-body).
      *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
@@ -281,8 +281,7 @@ class Bucket
      *     @type string $predefinedAcl Predefined ACL to apply to the object.
      *           Acceptable values include `"authenticatedRead`",
      *           `"bucketOwnerFullControl`", `"bucketOwnerRead`", `"private`",
-     *           `"projectPrivate`", and `"publicRead"`. **Defaults to**
-     *           `null`.
+     *           `"projectPrivate`", and `"publicRead"`.
      *     @type array $metadata The available options for metadata are outlined
      *           at the [JSON API docs](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request-body).
      *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
@@ -529,8 +528,7 @@ class Bucket
      *     @type string $predefinedAcl Predefined ACL to apply to the composed
      *           object. Acceptable values include, `"authenticatedRead"`,
      *           `"bucketOwnerFullControl"`, `"bucketOwnerRead"`, `"private"`,
-     *           `"projectPrivate"`, and `"publicRead"`. **Defaults to**
-     *           `null`.
+     *           `"projectPrivate"`, and `"publicRead"`.
      *     @type array $metadata Metadata to apply to the composed object. The
      *           available options for metadata are outlined at the
      *           [JSON API docs](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request-body).

--- a/src/Storage/Bucket.php
+++ b/src/Storage/Bucket.php
@@ -201,7 +201,7 @@ class Bucket
      *           Acceptable values include,
      *           `"authenticatedRead"`, `"bucketOwnerFullControl"`,
      *           `"bucketOwnerRead"`, `"private"`, `"projectPrivate"`, and
-     *           `"publicRead"`. **Defaults to** `"private"`.
+     *           `"publicRead"`. **Defaults to** `null`.
      *     @type array $metadata The available options for metadata are outlined
      *           at the [JSON API docs](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request-body).
      *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
@@ -282,7 +282,7 @@ class Bucket
      *           Acceptable values include `"authenticatedRead`",
      *           `"bucketOwnerFullControl`", `"bucketOwnerRead`", `"private`",
      *           `"projectPrivate`", and `"publicRead"`. **Defaults to**
-     *           `"private"`.
+     *           `null`.
      *     @type array $metadata The available options for metadata are outlined
      *           at the [JSON API docs](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request-body).
      *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
@@ -530,7 +530,7 @@ class Bucket
      *           object. Acceptable values include, `"authenticatedRead"`,
      *           `"bucketOwnerFullControl"`, `"bucketOwnerRead"`, `"private"`,
      *           `"projectPrivate"`, and `"publicRead"`. **Defaults to**
-     *           `"private"`.
+     *           `null`.
      *     @type array $metadata Metadata to apply to the composed object. The
      *           available options for metadata are outlined at the
      *           [JSON API docs](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request-body).

--- a/src/Storage/Connection/Rest.php
+++ b/src/Storage/Connection/Rest.php
@@ -270,7 +270,7 @@ class Rest implements ConnectionInterface
             'name' => null,
             'validate' => true,
             'resumable' => null,
-            'predefinedAcl' => 'private',
+            'predefinedAcl' => null,
             'metadata' => []
         ];
 


### PR DESCRIPTION
fixing #312. Making Rest helper set predefinedAcl to null by default for GCS objects.