### PR TITLE
Prepare v0.20.2

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -7,6 +7,7 @@
     "matchPartialServiceId": true,
     "markdown": "php",
     "versions": [
+        "v0.20.2",
         "v0.20.1",
         "v0.20.0",
         "v0.13.2",

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -48,7 +48,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class ServiceBuilder
 {
-    const VERSION = '0.20.1';
+    const VERSION = '0.20.2';
 
     /**
      * @var array Configuration options to be used between clients.


### PR DESCRIPTION
## Google Cloud PHP v0.20.2

### What's New?

* Added support for Stackdriver Monitoring via a generated gRPC client. See
  `Google\Cloud\Monitoring\V3` for more information. (#308)
* Google Translate has been renamed Google Cloud Transation. At this time there
  are no code changes required. Changes are limited to documentation. (#291)

### What's Updated?

* PubSub and Logging generated gRPC clients have been updated. (#305)
* PHP 7.1 compatibility is now tested as part of our normal continuous
  integration process. Thanks to @cedricziel for the PR! (#303)

### What's Fixed?

* Fixed Storage error in which `predefinedAcl` was assigned a value which was
  not always a sensible default. Thanks to @amoiseiev for the PR! (#313)
* Fixed bug in which falsey values were incorrectly filtered out by
  `array_filter()`. (#318)
* Fixed invalid translation response when strings is not zero-indexed. Thanks to
  @povils for the PR! (#321)