### PR TITLE
Prepare v0.21.1

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -7,6 +7,7 @@
     "matchPartialServiceId": true,
     "markdown": "php",
     "versions": [
+        "v0.21.1",
         "v0.21.0",
         "v0.20.2",
         "v0.20.1",

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -48,7 +48,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class ServiceBuilder
 {
-    const VERSION = '0.21.0';
+    const VERSION = '0.21.1';
 
     /**
      * @var array Configuration options to be used between clients.


### PR DESCRIPTION
## Google Cloud PHP v0.21.1

### Cloud Storage

* Fixed a bug in which PHP was emitting `E_NOTICE` messages when storage object
  info was incomplete or missing. (#347)