### PR TITLE
Add snippet tests and ReaderInterface for Compute

### DIFF
--- a/src/Compute/Metadata.php
+++ b/src/Compute/Metadata.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Compute;
 
 use Google\Cloud\Compute\Metadata\Readers\StreamReader;
+use Google\Cloud\Compute\Metadata\Readers\ReaderInterface;
 
 /**
  * A library for accessing the Google Compute Engine (GCE) metadata.
@@ -27,12 +28,17 @@ use Google\Cloud\Compute\Metadata\Readers\StreamReader;
  *
  * You can get the GCE metadata values very easily like:
  *
+ *
+ * Example:
  * ```
  * use Google\Cloud\Compute\Metadata;
  *
  * $metadata = new Metadata();
- * $project_id = $metadata->getProjectId();
+ * $projectId = $metadata->getProjectId();
+ * ```
  *
+ * ```
+ * // It is easy to get any metadata from a project.
  * $val = $metadata->getProjectMetadata($key);
  * ```
  */
@@ -59,9 +65,9 @@ class Metadata
     /**
      * Replace the default reader implementation
      *
-     * @param mixed $reader The reader implementation
+     * @param ReaderInterface $reader The reader implementation
      */
-    public function setReader($reader)
+    public function setReader(ReaderInterface $reader)
     {
         $this->reader = $reader;
     }
@@ -71,7 +77,7 @@ class Metadata
      *
      * Example:
      * ```
-     * $projectId = $reader->get('project/project-id');
+     * $projectId = $metadata->get('project/project-id');
      * ```
      *
      * @param string $path The path of the item to retrieve.
@@ -86,15 +92,15 @@ class Metadata
      *
      * Example:
      * ```
-     * $projectId = $reader->getProjectId();
+     * $projectId = $metadata->getProjectId();
      * ```
      *
      * @return string
      */
     public function getProjectId()
     {
-        if (! isset($this->projectId)) {
-            $this->projectId = $this->reader->read('project/project-id');
+        if (!isset($this->projectId)) {
+            $this->projectId = $this->get('project/project-id');
         }
 
         return $this->projectId;
@@ -105,7 +111,7 @@ class Metadata
      *
      * Example:
      * ```
-     * $foo = $reader->getProjectMetadata('foo');
+     * $foo = $metadata->getProjectMetadata('foo');
      * ```
      *
      * @param string $key The metadata key
@@ -122,7 +128,7 @@ class Metadata
      *
      * Example:
      * ```
-     * $foo = $reader->getInstanceMetadata('foo');
+     * $foo = $metadata->getInstanceMetadata('foo');
      * ```
      *
      * @param string $key The instance metadata key

--- a/src/Compute/Metadata/Readers/ReaderInterface.php
+++ b/src/Compute/Metadata/Readers/ReaderInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Compute\Metadata\Readers;
+
+/**
+ * Defines a metadata reader implementation.
+ */
+interface ReaderInterface
+{
+    /**
+     * Read metadata from a given path.
+     */
+    public function read($path);
+}

--- a/src/Compute/Metadata/Readers/StreamReader.php
+++ b/src/Compute/Metadata/Readers/StreamReader.php
@@ -22,7 +22,7 @@ namespace Google\Cloud\Compute\Metadata\Readers;
  *
  * This class makes it easy to test the MetadataStream class.
  */
-class StreamReader
+class StreamReader implements ReaderInterface
 {
     /**
      * The base PATH for the metadata.

--- a/tests/snippets/Compute/MetadataTest.php
+++ b/tests/snippets/Compute/MetadataTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Snippets\Compute;
+
+use Google\Cloud\Compute\Metadata;
+use Google\Cloud\Compute\Metadata\Readers\ReaderInterface;
+use Google\Cloud\Dev\Snippet\SnippetTestCase;
+use Prophecy\Argument;
+
+/**
+ * @group compute
+ */
+class MetadataTest extends SnippetTestCase
+{
+    const PROJECT = 'my-project';
+
+    private $metadata;
+    private $reader;
+
+    public function setUp()
+    {
+        $this->reader = $this->prophesize(ReaderInterface::class);
+        $this->metadata = new Metadata;
+        $this->metadata->setReader($this->reader->reveal());
+    }
+
+    public function testClass()
+    {
+        $this->reader->read('project/project-id')
+            ->shouldBeCalled()
+            ->willReturn(self::PROJECT);
+
+        $snippet = $this->snippetFromClass(Metadata::class);
+        $snippet->insertAfterLine(2, '$metadata->setReader($reader);');
+        $snippet->addLocal('reader', $this->reader->reveal());
+        $res = $snippet->invoke('projectId');
+
+        $this->assertEquals($res->returnVal(), self::PROJECT);
+    }
+
+    public function testClassMetadata()
+    {
+        $key = 'foo';
+        $val = 'bar';
+
+        $this->reader->read('project/attributes/'. $key)
+            ->shouldBeCalled()
+            ->willReturn($val);
+
+        $this->metadata->setReader($this->reader->reveal());
+
+        $snippet = $this->snippetFromClass(Metadata::class, 1);
+        $snippet->addLocal('metadata', $this->metadata);
+        $snippet->addLocal('key', $key);
+
+        $res = $snippet->invoke('val');
+        $this->assertEquals($res->returnVal(), $val);
+    }
+
+    public function testGet()
+    {
+        $this->reader->read('project/project-id')
+            ->shouldBeCalled()
+            ->willReturn(self::PROJECT);
+
+        $this->metadata->setReader($this->reader->reveal());
+
+        $snippet = $this->snippetFromMethod(Metadata::class, 'get');
+        $snippet->addLocal('metadata', $this->metadata);
+        $res = $snippet->invoke('projectId');
+
+        $this->assertEquals(self::PROJECT, $res->returnVal());
+    }
+
+    public function testGetProjectId()
+    {
+        $this->reader->read('project/project-id')
+            ->shouldBeCalled()
+            ->willReturn(self::PROJECT);
+
+        $this->metadata->setReader($this->reader->reveal());
+
+        $snippet = $this->snippetFromMethod(Metadata::class, 'getProjectId');
+        $snippet->addLocal('metadata', $this->metadata);
+        $res = $snippet->invoke('projectId');
+
+        $this->assertEquals(self::PROJECT, $res->returnVal());
+    }
+
+    public function testGetProjectMetadata()
+    {
+        $val = 'hello world';
+
+        $this->reader->read('project/attributes/foo')
+            ->shouldBeCalled()
+            ->willReturn($val);
+
+        $this->metadata->setReader($this->reader->reveal());
+
+        $snippet = $this->snippetFromMethod(Metadata::class, 'getProjectMetadata');
+        $snippet->addLocal('metadata', $this->metadata);
+        $res = $snippet->invoke('foo');
+
+        $this->assertEquals($val, $res->returnVal());
+    }
+
+    public function testGetInstanceMetadata()
+    {
+        $val = 'hello world';
+
+        $this->reader->read('instance/attributes/foo')
+            ->shouldBeCalled()
+            ->willReturn($val);
+
+        $this->metadata->setReader($this->reader->reveal());
+
+        $snippet = $this->snippetFromMethod(Metadata::class, 'getInstanceMetadata');
+        $snippet->addLocal('metadata', $this->metadata);
+        $res = $snippet->invoke('foo');
+
+        $this->assertEquals($val, $res->returnVal());
+    }
+}


### PR DESCRIPTION
Working on covering the remainder of snippets. This is a separate PR because there are a couple substantive changes to that API I want to highlight.

I've added a `ReaderInterface` and changed `StreamReader` to implement it. I've updated `Metadata::setReader()` to require an instance of `ReaderInterface`, rather than `mixed`.

This is technically a breaking change, but if people are using the existing StreamReader class, everything should work with no changes.