### PR TITLE
Snippet finish line

### DIFF
--- a/dev/src/Snippet/SnippetTestCase.php
+++ b/dev/src/Snippet/SnippetTestCase.php
@@ -26,18 +26,13 @@ use Google\Cloud\Dev\Snippet\Container;
  */
 class SnippetTestCase extends \PHPUnit_Framework_TestCase
 {
-    const HOOK_BEFORE = 1000;
-    const HOOK_AFTER = 1001;
+    private static $coverage;
+    private static $parser;
 
-    private $coverage;
-    private $parser;
-
-    public function __construct()
+    public static function setUpBeforeClass()
     {
-        parent::__construct();
-
-        $this->coverage = Container::$coverage;
-        $this->parser = Container::$parser;
+        self::$coverage = Container::$coverage;
+        self::$parser = Container::$parser;
     }
 
     /**
@@ -49,14 +44,14 @@ class SnippetTestCase extends \PHPUnit_Framework_TestCase
      */
     public function snippetFromClass($class, $indexOrName = 0)
     {
-        $identifier = $this->parser->createIdentifier($class, $indexOrName);
+        $identifier = self::$parser->createIdentifier($class, $indexOrName);
 
-        $snippet = $this->coverage->cache($identifier);
+        $snippet = self::$coverage->cache($identifier);
         if (!$snippet) {
-            $snippet = $this->parser->classExample($class, $indexOrName);
+            $snippet = self::$parser->classExample($class, $indexOrName);
         }
 
-        $this->coverage->cover($snippet->identifier());
+        self::$coverage->cover($snippet->identifier());
 
         return $snippet;
     }
@@ -73,14 +68,14 @@ class SnippetTestCase extends \PHPUnit_Framework_TestCase
     public function snippetFromMagicMethod($class, $method, $indexOrName = 0)
     {
         $name = $class .'::'. $method;
-        $identifier = $this->parser->createIdentifier($name, $indexOrName);
+        $identifier = self::$parser->createIdentifier($name, $indexOrName);
 
-        $snippet = $this->coverage->cache($identifier);
+        $snippet = self::$coverage->cache($identifier);
         if (!$snippet) {
             throw new \Exception('Magic Method '. $name .' was not found');
         }
 
-        $this->coverage->cover($identifier);
+        self::$coverage->cover($identifier);
 
         return $snippet;
     }
@@ -96,14 +91,14 @@ class SnippetTestCase extends \PHPUnit_Framework_TestCase
     public function snippetFromMethod($class, $method, $indexOrName = 0)
     {
         $name = $class .'::'. $method;
-        $identifier = $this->parser->createIdentifier($name, $indexOrName);
+        $identifier = self::$parser->createIdentifier($name, $indexOrName);
 
-        $snippet = $this->coverage->cache($identifier);
+        $snippet = self::$coverage->cache($identifier);
         if (!$snippet) {
-            $snippet = $this->parser->methodExample($class, $method, $indexOrName);
+            $snippet = self::$parser->methodExample($class, $method, $indexOrName);
         }
 
-        $this->coverage->cover($identifier);
+        self::$coverage->cover($identifier);
 
         return $snippet;
     }

--- a/src/Iam/PolicyBuilder.php
+++ b/src/Iam/PolicyBuilder.php
@@ -80,7 +80,7 @@ class PolicyBuilder
      * ```
      * $builder->setBindings([
      *     [
-     *         'role' => roles/admin',
+     *         'role' => 'roles/admin',
      *         'members' => [
      *             'user:admin@domain.com'
      *         ]

--- a/src/NaturalLanguage/Annotation.php
+++ b/src/NaturalLanguage/Annotation.php
@@ -34,6 +34,16 @@ use Google\Cloud\CallTrait;
  * {@see Google\Cloud\NaturalLanguage\NaturalLanguageClient::analyzeSyntax()} and
  * {@see Google\Cloud\NaturalLanguage\NaturalLanguageClient::annotateText()}.
  *
+ * Example:
+ * ```
+ * use Google\Cloud\ServiceBuilder;
+ *
+ * $cloud = new ServiceBuilder();
+ * $language = $cloud->naturalLanguage();
+ *
+ * $annotation = $language->annotateText('Google Cloud Platform is a powerful tool.');
+ * ```
+ *
  * @method sentences() {
  *     Returns an array of sentences found in the document.
  *

--- a/src/PubSub/Subscription.php
+++ b/src/PubSub/Subscription.php
@@ -479,14 +479,14 @@ class Subscription
      * $messages = $subscription->pull();
      * $messagesArray = iterator_to_array($messages);
      *
-     * // Set the ack deadline to a minute and a half from now for every message
+     * // Set the ack deadline to three seconds from now for every message
      * $subscription->modifyAckDeadlineBatch($messagesArray, 3);
      *
      * // Delay execution, or make a sandwich or something.
      * sleep(2);
      *
      * // Now we'll acknowledge
-     * $subscription->acknowledge($messagesArray);
+     * $subscription->acknowledgeBatch($messagesArray);
      * ```
      *
      * @codingStandardsIgnoreStart

--- a/tests/snippets/BigQuery/JobTest.php
+++ b/tests/snippets/BigQuery/JobTest.php
@@ -150,4 +150,22 @@ class JobTest extends SnippetTestCase
         $snippet->replace('sleep(1);', '');
         $snippet->invoke();
     }
+
+    public function testId()
+    {
+        $snippet = $this->snippetFromMethod(Job::class, 'id');
+        $snippet->addLocal('job', $this->getJob($this->connection, []));
+        $res = $snippet->invoke();
+
+        $this->assertEquals($res->output(), $this->identity['jobId']);
+    }
+
+    public function testIdentity()
+    {
+        $snippet = $this->snippetFromMethod(Job::class, 'identity');
+        $snippet->addLocal('job', $this->getJob($this->connection, []));
+        $res = $snippet->invoke();
+
+        $this->assertEquals($res->output(), $this->identity['projectId']);
+    }
 }

--- a/tests/snippets/Datastore/DatastoreClientTest.php
+++ b/tests/snippets/Datastore/DatastoreClientTest.php
@@ -30,6 +30,7 @@ use Google\Cloud\Datastore\Query\Query;
 use Google\Cloud\Datastore\Query\QueryInterface;
 use Google\Cloud\Datastore\Transaction;
 use Google\Cloud\Dev\Snippet\SnippetTestCase;
+use Google\Cloud\Int64;
 use Prophecy\Argument;
 
 /**
@@ -233,6 +234,24 @@ class DatastoreClientTest extends SnippetTestCase
     public function testBlob()
     {
         $snippet = $this->snippetFromMethod(DatastoreClient::class, 'blob');
+        $snippet->addLocal('datastore', $this->client);
+
+        $res = $snippet->invoke('blob');
+        $this->assertInstanceOf(Blob::class, $res->returnVal());
+    }
+
+    public function testInt64()
+    {
+        $snippet = $this->snippetFromMethod(DatastoreClient::class, 'int64');
+        $snippet->addLocal('datastore', $this->client);
+
+        $res = $snippet->invoke('int64');
+        $this->assertInstanceOf(Int64::class, $res->returnVal());
+    }
+
+    public function testBlobWithFile()
+    {
+        $snippet = $this->snippetFromMethod(DatastoreClient::class, 'blob', 1);
         $snippet->addLocal('datastore', $this->client);
         $snippet->replace("file_get_contents(__DIR__ .'/family-photo.jpg')", "''");
 

--- a/tests/snippets/Iam/IamTest.php
+++ b/tests/snippets/Iam/IamTest.php
@@ -43,6 +43,14 @@ class IamTest extends SnippetTestCase
         $this->iam->setConnection($this->connection->reveal());
     }
 
+    public function testClass()
+    {
+        $snippet = $this->snippetFromClass(Iam::class);
+        $res = $snippet->invoke('iam');
+
+        $this->assertInstanceOf(Iam::class, $res->returnVal());
+    }
+
     public function testPolicy()
     {
         $snippet = $this->snippetFromMethod(Iam::class, 'policy');
@@ -62,7 +70,7 @@ class IamTest extends SnippetTestCase
         $this->assertEquals('foo', $res->returnVal());
     }
 
-    public function setPolicy()
+    public function testSetPolicy()
     {
         $snippet = $this->snippetFromMethod(Iam::class, 'setPolicy');
         $snippet->addLocal('iam', $this->iam);
@@ -76,9 +84,12 @@ class IamTest extends SnippetTestCase
             ]);
 
         $this->connection->setPolicy([
-            'bindings' => [
-                ['members' => ['user:test@example.com']]
-            ]
+            'policy' => [
+                'bindings' => [
+                    ['members' => 'user:test@example.com']
+                ]
+            ],
+            'resource' => $this->resource
         ])->shouldBeCalled()->willReturn('foo');
 
         $this->iam->setConnection($this->connection->reveal());

--- a/tests/snippets/Iam/PolicyBuilderTest.php
+++ b/tests/snippets/Iam/PolicyBuilderTest.php
@@ -44,6 +44,16 @@ class PolicyBuilderTest extends SnippetTestCase
 
     public function testSetBindings()
     {
+        $snippet = $this->snippetFromMethod(PolicyBuilder::class, 'setBindings');
+        $snippet->addLocal('builder', $this->pb);
+
+        $res = $snippet->invoke();
+        $this->assertEquals('roles/admin', $this->pb->result()['bindings'][0]['role']);
+        $this->assertEquals('user:admin@domain.com', $this->pb->result()['bindings'][0]['members'][0]);
+    }
+
+    public function testAddBindings()
+    {
         $snippet = $this->snippetFromMethod(PolicyBuilder::class, 'addBinding');
         $snippet->addLocal('builder', $this->pb);
 

--- a/tests/snippets/Int64Test.php
+++ b/tests/snippets/Int64Test.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Snippets;
+
+use Google\Cloud\Dev\Snippet\SnippetTestCase;
+use Google\Cloud\Int64;
+
+/**
+ * @group root
+ */
+class Int64Test extends SnippetTestCase
+{
+    const VALUE = 1234;
+
+    private $int64;
+
+    public function setUp()
+    {
+        $this->int64 = new Int64((string)self::VALUE);
+    }
+
+    public function testClass()
+    {
+        $snippet = $this->snippetFromClass(Int64::class);
+        $snippet->addUse(Int64::class);
+        $this->assertInstanceOf(Int64::class, $snippet->invoke('int64')->returnVal());
+    }
+
+    public function testGet()
+    {
+        $snippet = $this->snippetFromMethod(Int64::class, 'get');
+        $snippet->addLocal('int64', $this->int64);
+        $res = $snippet->invoke('value');
+
+        $this->assertEquals((string)self::VALUE, $res->returnVal());
+    }
+}

--- a/tests/snippets/Logging/PsrLoggerTest.php
+++ b/tests/snippets/Logging/PsrLoggerTest.php
@@ -64,6 +64,21 @@ class PsrLoggerTest extends SnippetTestCase
         $snippet->invoke();
     }
 
+    public function testAlert()
+    {
+        $snippet = $this->snippetFromMethod(PsrLogger::class, 'alert');
+        $snippet->addLocal('psrLogger', $this->psr);
+
+        $this->connection->writeEntries(Argument::that(function ($args) {
+            if ($args['entries'][0]['severity'] !== Logger::ALERT) return false;
+            return true;
+        }))->shouldBeCalled();
+
+        $this->psr->setConnection($this->connection->reveal());
+
+        $snippet->invoke();
+    }
+
     public function testCritical()
     {
         $snippet = $this->snippetFromMethod(PsrLogger::class, 'critical');

--- a/tests/snippets/NaturalLanguage/AnnotationTest.php
+++ b/tests/snippets/NaturalLanguage/AnnotationTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Snippets\NaturalLanguage;
+
+use Google\Cloud\Dev\Snippet\SnippetTestCase;
+use Google\Cloud\NaturalLanguage\Annotation;
+use Google\Cloud\NaturalLanguage\Connection\ConnectionInterface;
+use Prophecy\Argument;
+
+/**
+ * @group naturallanguage
+ */
+class AnnotationTest extends SnippetTestCase
+{
+    private $annotation;
+    private $info;
+
+    public function setUp()
+    {
+        $this->info = [
+            'sentences' => [
+                [
+                    'text' => [
+                        'content' => 'hello world'
+                    ]
+                ]
+            ],
+            'tokens' => [
+                [
+                    'text' => [
+                        'content' => 'hello world'
+                    ],
+                    'partOfSpeech' => [
+                        'tag' => 'NOUN'
+                    ],
+                    'dependencyEdge' => [
+                        'label' => 'P'
+                    ],
+                    'lemma' => 'foo'
+                ]
+            ],
+            'entities' => [
+                [
+                    'type' => 'PERSON',
+                    'name' => 'somebody'
+                ]
+            ],
+            'language' => 'en-us',
+            'documentSentiment' => [
+                'score' => 999
+            ]
+        ];
+        $this->annotation = new Annotation($this->info);
+    }
+
+    public function testClass()
+    {
+        $connection = $this->prophesize(ConnectionInterface::class);
+        $connection->annotateText(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([]);
+
+        $snippet = $this->snippetFromClass(Annotation::class);
+        $snippet->addLocal('connectionStub', $connection->reveal());
+        $snippet->insertAfterLine(3, '$reflection = new \ReflectionClass($language);
+            $property = $reflection->getProperty(\'connection\');
+            $property->setAccessible(true);
+            $property->setValue($language, $connectionStub);
+            $property->setAccessible(false);'
+        );
+
+        $res = $snippet->invoke('annotation');
+        $this->assertInstanceOf(Annotation::class, $res->returnVal());
+    }
+
+    public function testSentences()
+    {
+        $snippet = $this->snippetFromMagicMethod(Annotation::class, 'sentences');
+        $snippet->addLocal('annotation', $this->annotation);
+        $res = $snippet->invoke();
+        $this->assertEquals($this->info['sentences'][0]['text']['content'], $res->output());
+    }
+
+    public function testTokens()
+    {
+        $snippet = $this->snippetFromMagicMethod(Annotation::class, 'tokens');
+        $snippet->addLocal('annotation', $this->annotation);
+        $res = $snippet->invoke();
+        $this->assertEquals($this->info['tokens'][0]['text']['content'], $res->output());
+    }
+
+    public function testEntities()
+    {
+        $snippet = $this->snippetFromMagicMethod(Annotation::class, 'entities');
+        $snippet->addLocal('annotation', $this->annotation);
+        $res = $snippet->invoke();
+        $this->assertEquals($this->info['entities'][0]['type'], $res->output());
+    }
+
+    public function testLanguage()
+    {
+        $snippet = $this->snippetFromMagicMethod(Annotation::class, 'language');
+        $snippet->addLocal('annotation', $this->annotation);
+        $res = $snippet->invoke();
+        $this->assertEquals($this->info['language'], $res->output());
+    }
+
+    public function testInfo()
+    {
+        $snippet = $this->snippetFromMethod(Annotation::class, 'info');
+        $snippet->addLocal('annotation', $this->annotation);
+        $res = $snippet->invoke('info');
+
+        $this->assertEquals($this->info, $res->returnVal());
+    }
+
+    public function testSentiment()
+    {
+        $snippet = $this->snippetFromMethod(Annotation::class, 'sentiment');
+        $snippet->addLocal('annotation', $this->annotation);
+        $res = $snippet->invoke();
+        $this->assertEquals('This is a positive message.', $res->output());
+    }
+
+    public function testTokensByTag()
+    {
+        $snippet = $this->snippetFromMethod(Annotation::class, 'tokensByTag');
+        $snippet->addLocal('annotation', $this->annotation);
+        $res = $snippet->invoke();
+        $this->assertEquals($this->info['tokens'][0]['lemma'], $res->output());
+    }
+
+    public function testTokensByLabel()
+    {
+        $snippet = $this->snippetFromMethod(Annotation::class, 'tokensByLabel');
+        $snippet->addLocal('annotation', $this->annotation);
+        $res = $snippet->invoke();
+        $this->assertEquals($this->info['tokens'][0]['lemma'], $res->output());
+    }
+
+    public function testEntitiesByType()
+    {
+        $snippet = $this->snippetFromMethod(Annotation::class, 'entitiesByType');
+        $snippet->addLocal('annotation', $this->annotation);
+        $res = $snippet->invoke();
+        $this->assertEquals($this->info['entities'][0]['name'], $res->output());
+    }
+}

--- a/tests/snippets/NaturalLanguage/NaturalLanguageClientTest.php
+++ b/tests/snippets/NaturalLanguage/NaturalLanguageClientTest.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Snippets\NaturalLanguage;
+
+use Google\Cloud\Dev\Snippet\SnippetTestCase;
+use Google\Cloud\NaturalLanguage\Connection\ConnectionInterface;
+use Google\Cloud\NaturalLanguage\NaturalLanguageClient;
+use Prophecy\Argument;
+
+/**
+ * @group naturallanguage
+ */
+class NaturalLanguageClientTest extends SnippetTestCase
+{
+    private $client;
+    private $connection;
+
+    public function setUp()
+    {
+        $this->connection = $this->prophesize(ConnectionInterface::class);
+        $this->client = new \NaturalLanguageClientStub;
+        $this->client->setConnection($this->connection->reveal());
+    }
+
+    public function testClass()
+    {
+        $snippet = $this->snippetFromClass(NaturalLanguageClient::class);
+        $res = $snippet->invoke('language');
+        $this->assertInstanceOf(NaturalLanguageClient::class, $res->returnVal());
+    }
+
+    public function testClassDirect()
+    {
+        $snippet = $this->snippetFromClass(NaturalLanguageClient::class, 1);
+        $res = $snippet->invoke('language');
+        $this->assertInstanceOf(NaturalLanguageClient::class, $res->returnVal());
+    }
+
+    public function testAnalyzeEntities()
+    {
+        $this->connection->analyzeEntities(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                'entities' => [
+                    [
+                        'type' => 'PERSON'
+                    ]
+                ]
+            ]);
+
+        $this->client->setConnection($this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(NaturalLanguageClient::class, 'analyzeEntities');
+        $snippet->addLocal('language', $this->client);
+
+        $res = $snippet->invoke();
+        $this->assertEquals('PERSON', $res->output());
+    }
+
+    public function testAnalyzeSentiment()
+    {
+        $this->connection->analyzeSentiment(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                'documentSentiment' => [
+                    'score' => 1.0
+                ]
+            ]);
+
+        $this->client->setConnection($this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(NaturalLanguageClient::class, 'analyzeSentiment');
+        $snippet->addLocal('language', $this->client);
+
+        $res = $snippet->invoke();
+        $this->assertEquals("This is a positive message.", $res->output());
+    }
+
+    public function testAnalyzeSyntax()
+    {
+        $this->connection->analyzeSyntax(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                'sentences' => [
+                    [
+                        'text' => [
+                            'beginOffset' => 1.0
+                        ]
+                    ]
+                ]
+            ]);
+
+        $this->client->setConnection($this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(NaturalLanguageClient::class, 'analyzeSyntax');
+        $snippet->addLocal('language', $this->client);
+
+        $res = $snippet->invoke();
+        $this->assertEquals('1.0', $res->output());
+    }
+
+    public function testAnnotateTextAllFeatures()
+    {
+        $this->connection->annotateText(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                'documentSentiment' => [
+                    'magnitude' => 999
+                ]
+            ]);
+
+        $this->client->setConnection($this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(NaturalLanguageClient::class, 'annotateText');
+        $snippet->addLocal('language', $this->client);
+
+        $this->assertEquals('999', $snippet->invoke()->output());
+    }
+
+    public function testAnnotateTextSomeFeatures()
+    {
+        $this->connection->annotateText(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                'tokens' => [
+                    [
+                        'text' => [
+                            'beginOffset' => '2.0'
+                        ]
+                    ]
+                ]
+            ]);
+
+        $this->client->setConnection($this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(NaturalLanguageClient::class, 'annotateText', 1);
+        $snippet->addLocal('language', $this->client);
+
+        $this->assertEquals('2.0', $snippet->invoke()->output());
+    }
+}

--- a/tests/snippets/PubSub/PubSubClientTest.php
+++ b/tests/snippets/PubSub/PubSubClientTest.php
@@ -45,7 +45,24 @@ class PubSubClientTest extends SnippetTestCase
 
     public function testClassExample1()
     {
-        $snippet = $this->snippetFromClass(PubSubClient::class, '__construct');
+        $snippet = $this->snippetFromClass(PubSubClient::class);
+        $res = $snippet->invoke('pubsub');
+
+        $this->assertInstanceOf(PubSubClient::class, $res->returnVal());
+    }
+
+    public function testClassExample2()
+    {
+        $snippet = $this->snippetFromClass(PubSubClient::class, 1);
+        $res = $snippet->invoke('pubsub');
+
+        $this->assertInstanceOf(PubSubClient::class, $res->returnVal());
+    }
+
+    // phpunit doesn't get the value of $_ENV, so testing PUBSUB_EMULATOR_HOST is pretty tough.
+    public function testClassExample3()
+    {
+        $snippet = $this->snippetFromClass(PubSubClient::class, 2);
         $res = $snippet->invoke('pubsub');
 
         $this->assertInstanceOf(PubSubClient::class, $res->returnVal());

--- a/tests/snippets/PubSub/SubscriptionTest.php
+++ b/tests/snippets/PubSub/SubscriptionTest.php
@@ -241,7 +241,7 @@ class SubscriptionTest extends SnippetTestCase
 
     public function testModifyAckDeadlineBatch()
     {
-        $snippet = $this->snippetFromMethod(Subscription::class, 'modifyAckDeadline');
+        $snippet = $this->snippetFromMethod(Subscription::class, 'modifyAckDeadlineBatch');
         $snippet->addLocal('subscription', $this->subscription);
 
         $this->connection->pull(Argument::any())

--- a/tests/snippets/PubSub/TopicTest.php
+++ b/tests/snippets/PubSub/TopicTest.php
@@ -224,7 +224,7 @@ class TopicTest extends SnippetTestCase
         $this->assertEquals(self::SUBSCRIPTION, $res->output());
     }
 
-    public function iam()
+    public function testIam()
     {
         $snippet = $this->snippetFromMethod(Topic::class, 'iam');
         $snippet->addLocal('topic', $this->topic);

--- a/tests/snippets/ServiceBuilderTest.php
+++ b/tests/snippets/ServiceBuilderTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Snippets;
+
+use Google\Cloud\BigQuery\BigQueryClient;
+use Google\Cloud\Datastore\DatastoreClient;
+use Google\Cloud\Dev\Snippet\SnippetTestCase;
+use Google\Cloud\Logging\LoggingClient;
+use Google\Cloud\NaturalLanguage\NaturalLanguageClient;
+use Google\Cloud\PubSub\PubSubClient;
+use Google\Cloud\ServiceBuilder;
+use Google\Cloud\Speech\SpeechClient;
+use Google\Cloud\Storage\StorageClient;
+use Google\Cloud\Translate\TranslateClient;
+use Google\Cloud\Vision\VisionClient;
+
+/**
+ * @group root
+ */
+class ServiceBuilderTest extends SnippetTestCase
+{
+    private $cloud;
+
+    public function setUp()
+    {
+        $this->cloud = new ServiceBuilder;
+    }
+
+    public function testConstructor()
+    {
+        $snippet = $this->snippetFromMethod(ServiceBuilder::class, '__construct');
+        $this->assertInstanceOf(ServiceBuilder::class, $snippet->invoke('cloud')->returnVal());
+    }
+
+    public function serviceBuilderMethods()
+    {
+        return [
+            ['bigQuery', BigQueryClient::class, 'bigQuery'],
+            ['datastore', DatastoreClient::class, 'datastore'],
+            ['logging', LoggingClient::class, 'logging'],
+            ['naturalLanguage', NaturalLanguageClient::class, 'language'],
+            ['pubsub', PubSubClient::class, 'pubsub'],
+            ['speech', SpeechClient::class, 'speech'],
+            ['storage', StorageClient::class, 'storage'],
+            ['vision', VisionClient::class, 'vision'],
+            ['translate', TranslateClient::class, 'translate']
+        ];
+    }
+
+    /**
+     * @dataProvider serviceBuilderMethods
+     */
+    public function testServices($method, $returnType, $returnName)
+    {
+        $snippet = $this->snippetFromMethod(ServiceBuilder::class, $method);
+        $snippet->addLocal('cloud', $this->cloud);
+        $res = $snippet->invoke($returnName);
+
+        $this->assertInstanceOf($returnType, $res->returnVal());
+    }
+}

--- a/tests/snippets/Speech/OperationTest.php
+++ b/tests/snippets/Speech/OperationTest.php
@@ -50,24 +50,24 @@ class OperationTest extends SnippetTestCase
         $this->operation = new \SpeechOperationStub($this->connection->reveal(), $this->opData['name'], $this->opData);
     }
 
-    // /**
-    //  * @expectedException InvalidArgumentException
-    //  */
-    // public function testClass()
-    // {
-    //     $snippet = $this->snippetFromClass(Operation::class);
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testClass()
+    {
+        $snippet = $this->snippetFromClass(Operation::class);
 
-    //     $connectionStub = $this->prophesize(ConnectionInterface::class);
+        $connectionStub = $this->prophesize(ConnectionInterface::class);
 
-    //     $connectionStub->asyncRecognize(Argument::any())
-    //         ->willReturn(['name' => 'foo']);
+        $connectionStub->asyncRecognize(Argument::any())
+            ->willReturn(['name' => 'foo']);
 
-    //     $snippet->addLocal('connectionStub', $connectionStub->reveal());
+        $snippet->addLocal('connectionStub', $connectionStub->reveal());
 
-    //     $snippet->setLine(5, '$audioFileStream = fopen(\'php://temp\', \'r\');');
+        $snippet->replace("__DIR__  . '/audio.flac'", '"php://temp"');
 
-    //     $res = $snippet->invoke('operation');
-    // }
+        $res = $snippet->invoke('operation');
+    }
 
     public function testIsComplete()
     {

--- a/tests/snippets/Storage/BucketTest.php
+++ b/tests/snippets/Storage/BucketTest.php
@@ -25,6 +25,7 @@ use Google\Cloud\Storage\Connection\ConnectionInterface;
 use Google\Cloud\Storage\StorageObject;
 use Google\Cloud\Upload\MultipartUploader;
 use Google\Cloud\Upload\ResumableUploader;
+use Google\Cloud\Upload\StreamableUploader;
 use Prophecy\Argument;
 
 /**
@@ -194,6 +195,26 @@ class BucketTest extends SnippetTestCase
         $this->bucket->setConnection($this->connection->reveal());
 
         $res = $snippet->invoke('object');
+    }
+
+    public function testGetStreamableUploader()
+    {
+        $snippet = $this->snippetFromMethod(Bucket::class, 'getStreamableUploader');
+        $snippet->addLocal('bucket', $this->bucket);
+        $snippet->addUse(GoogleException::class);
+        $snippet->replace("data.txt", 'php://temp');
+
+        $uploader = $this->prophesize(StreamableUploader::class);
+        $uploader->upload()
+            ->shouldBeCalledTimes(1);
+
+        $this->connection->insertObject(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn($uploader->reveal());
+
+        $this->bucket->setConnection($this->connection->reveal());
+
+        $res = $snippet->invoke();
     }
 
     public function testObject()

--- a/tests/snippets/Storage/StorageClientTest.php
+++ b/tests/snippets/Storage/StorageClientTest.php
@@ -123,4 +123,19 @@ class StorageClientTest extends SnippetTestCase
         $res = $snippet->invoke('bucket');
         $this->assertInstanceOf(Bucket::class, $res->returnVal());
     }
+
+    public function testCreateBucketWithLogging()
+    {
+        $snippet = $this->snippetFromMethod(StorageClient::class, 'createBucket', 1);
+        $snippet->addLocal('storage', $this->client);
+
+        $this->connection->insertBucket(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([]);
+
+        $this->client->setConnection($this->connection->reveal());
+
+        $res = $snippet->invoke('bucket');
+        $this->assertInstanceOf(Bucket::class, $res->returnVal());
+    }
 }

--- a/tests/snippets/Translate/TranslateClientTest.php
+++ b/tests/snippets/Translate/TranslateClientTest.php
@@ -37,9 +37,17 @@ class TranslateClientTest extends SnippetTestCase
         $this->client->setConnection($this->connection->reveal());
     }
 
-    public function testTrue()
+    public function testClass()
     {
         $snippet = $this->snippetFromClass(TranslateClient::class);
+        $res = $snippet->invoke('translate');
+
+        $this->assertInstanceOf(TranslateClient::class, $res->returnVal());
+    }
+
+    public function testClassDirectInstantiation()
+    {
+        $snippet = $this->snippetFromClass(TranslateClient::class, 1);
         $res = $snippet->invoke('translate');
 
         $this->assertInstanceOf(TranslateClient::class, $res->returnVal());

--- a/tests/snippets/Vision/Annotation/EntityTest.php
+++ b/tests/snippets/Vision/Annotation/EntityTest.php
@@ -74,6 +74,13 @@ class EntityTest extends SnippetTestCase
         $this->assertInstanceOf(Entity::class, $res->returnVal());
     }
 
+    public function testInfo()
+    {
+        $snippet = $this->snippetFromMagicMethod(Entity::class, 'info');
+        $snippet->addLocal('text', $this->entity);
+        $this->assertEquals($this->entityData, $snippet->invoke('info')->returnVal());
+    }
+
     public function testMid()
     {
         $snippet = $this->snippetFromMagicMethod(Entity::class, 'mid');

--- a/tests/snippets/Vision/Annotation/Face/LandmarksTest.php
+++ b/tests/snippets/Vision/Annotation/Face/LandmarksTest.php
@@ -153,7 +153,7 @@ class LandmarksTest extends SnippetTestCase
 
     public function testLeftEyeBrow()
     {
-        $snippet = $this->snippetFromMethod(Landmarks::class, 'leftEyeBrow');
+        $snippet = $this->snippetFromMethod(Landmarks::class, 'leftEyebrow');
         $snippet->addLocal('landmarks', $this->landmarks);
 
         $res = $snippet->invoke();
@@ -198,7 +198,7 @@ class LandmarksTest extends SnippetTestCase
 
     public function testRightEyeBrow()
     {
-        $snippet = $this->snippetFromMethod(Landmarks::class, 'rightEyeBrow');
+        $snippet = $this->snippetFromMethod(Landmarks::class, 'rightEyebrow');
         $snippet->addLocal('landmarks', $this->landmarks);
 
         $res = $snippet->invoke();

--- a/tests/snippets/Vision/Annotation/FaceTest.php
+++ b/tests/snippets/Vision/Annotation/FaceTest.php
@@ -41,13 +41,13 @@ class FaceTest extends SnippetTestCase
             "tiltAngle" => 'testtiltAngle',
             "detectionConfidence" => 'testdetectionConfidence',
             "landmarkingConfidence" => 'testlandmarkingConfidence',
-            "joyLikelihood" => 'testjoyLikelihood',
-            "sorrowLikelihood" => 'testsorrowLikelihood',
-            "angerLikelihood" => 'testangerLikelihood',
-            "surpriseLikelihood" => 'testsurpriseLikelihood',
-            "underExposedLikelihood" => 'testunderExposedLikelihood',
-            "blurredLikelihood" => 'testblurredLikelihood',
-            "headwearLikelihood" => 'testheadwearLikelihood',
+            "joyLikelihood" => 'VERY_LIKELY',
+            "sorrowLikelihood" => 'VERY_LIKELY',
+            "angerLikelihood" => 'VERY_LIKELY',
+            "surpriseLikelihood" => 'VERY_LIKELY',
+            "underExposedLikelihood" => 'VERY_LIKELY',
+            "blurredLikelihood" => 'VERY_LIKELY',
+            "headwearLikelihood" => 'VERY_LIKELY',
         ];
 
         $this->face = new Face($this->faceData);
@@ -81,6 +81,13 @@ class FaceTest extends SnippetTestCase
             $property->setValue($vision, $connectionStub);
             $property->setAccessible(false);'
         );
+    }
+
+    public function testInfo()
+    {
+        $snippet = $this->snippetFromMagicMethod(Face::class, 'info');
+        $snippet->addLocal('face', $this->face);
+        $this->assertEquals($this->faceData, $snippet->invoke('info')->returnVal());
     }
 
     public function testLandmarks()
@@ -225,4 +232,28 @@ class FaceTest extends SnippetTestCase
         $this->assertEquals($this->faceData['headwearLikelihood'], $res->output());
     }
 
+    /**
+     * @dataProvider boolTests
+     */
+    public function testFaceBoolTests($method, $output)
+    {
+        $snippet = $this->snippetFromMethod(Face::class, $method);
+        $snippet->addLocal('face', $this->face);
+
+        $res = $snippet->invoke();
+        $this->assertEquals($output, $res->output());
+    }
+
+    public function boolTests()
+    {
+        return [
+            ['isJoyful', 'Face is Joyful'],
+            ['isSorrowful', 'Face is Sorrowful'],
+            ['isAngry', 'Face is Angry'],
+            ['isSurprised', 'Face is Surprised'],
+            ['isUnderExposed', 'Face is Under Exposed'],
+            ['isBlurred', 'Face is Blurred'],
+            ['hasHeadwear', 'Face has Headwear']
+        ];
+    }
 }

--- a/tests/snippets/Vision/Annotation/SafeSearchTest.php
+++ b/tests/snippets/Vision/Annotation/SafeSearchTest.php
@@ -70,6 +70,14 @@ class SafeSearchTest extends SnippetTestCase
         $this->assertInstanceOf(SafeSearch::class, $res->returnVal());
     }
 
+    public function testInfo()
+    {
+        $snippet = $this->snippetFromMagicMethod(SafeSearch::class, 'info');
+        $snippet->addLocal('safeSearch', $this->ss);
+
+        $this->assertEquals($this->ssData, $snippet->invoke('info')->returnVal());
+    }
+
     public function testAdult()
     {
         $snippet = $this->snippetFromMagicMethod(SafeSearch::class, 'adult');

--- a/tests/snippets/bootstrap.php
+++ b/tests/snippets/bootstrap.php
@@ -48,6 +48,7 @@ stub('IamStub', Google\Cloud\Iam\Iam::class);
 stub('LoggerStub', Google\Cloud\Logging\Logger::class);
 stub('LoggingClientStub', Google\Cloud\Logging\LoggingClient::class);
 stub('MetricStub', Google\Cloud\Logging\Metric::class);
+stub('NaturalLanguageClientStub', Google\Cloud\NaturalLanguage\NaturalLanguageClient::class);
 stub('OperationStub', Google\Cloud\Datastore\Operation::class);
 stub('PubSubClientStub', Google\Cloud\PubSub\PubSubClient::class);
 stub('QueryResultsStub', Google\Cloud\BigQuery\QueryResults::class);


### PR DESCRIPTION
This adds coverage for everything which wasn't covered, save for the Compute and ResourceNameTrait snippets, which are addressed elsewhere.