### PR TITLE
Change ResourceNameTrait methods visibility

### DIFF
--- a/src/PubSub/ResourceNameTrait.php
+++ b/src/PubSub/ResourceNameTrait.php
@@ -55,7 +55,7 @@ trait ResourceNameTrait
      * @return string
      * @throws \InvalidArgumentException
      */
-    public function pluckName($type, $name)
+    private function pluckName($type, $name)
     {
         if (!isset($this->regexes[$type])) {
             throw new InvalidArgumentException(sprintf(
@@ -85,7 +85,7 @@ trait ResourceNameTrait
      * @return string
      * @throws \InvalidArgumentException
      */
-    public function formatName($type, $name, $projectId = null)
+    private function formatName($type, $name, $projectId = null)
     {
         if (!isset($this->templates[$type])) {
             throw new InvalidArgumentException(sprintf(
@@ -113,7 +113,7 @@ trait ResourceNameTrait
      * @return bool
      * @throws \InvalidArgumentException
      */
-    public function isFullyQualifiedName($type, $name)
+    private function isFullyQualifiedName($type, $name)
     {
         if (!isset($this->regexes[$type])) {
             throw new InvalidArgumentException(sprintf(

--- a/tests/unit/PubSub/ResourceNameTraitTest.php
+++ b/tests/unit/PubSub/ResourceNameTraitTest.php
@@ -28,35 +28,35 @@ class ResourceNameTraitTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->trait = $this->getObjectForTrait(ResourceNameTrait::class);
+        $this->trait = new ResourceNameTraitStub;
     }
 
     public function testPluckProjectId()
     {
-        $res = $this->trait->pluckName(
+        $res = $this->trait->call('pluckName', [
             'project',
             'projects/foo'
-        );
+        ]);
 
         $this->assertEquals('foo', $res);
     }
 
     public function testPluckTopicName()
     {
-        $res = $this->trait->pluckName(
+        $res = $this->trait->call('pluckName', [
             'topic',
             'projects/foo/topics/bar'
-        );
+        ]);
 
         $this->assertEquals('bar', $res);
     }
 
     public function testPluckSubscriptionName()
     {
-        $res = $this->trait->pluckName(
+        $res = $this->trait->call('pluckName', [
             'subscription',
             'projects/foo/subscriptions/bar'
-        );
+        ]);
 
         $this->assertEquals('bar', $res);
     }
@@ -66,26 +66,26 @@ class ResourceNameTraitTest extends \PHPUnit_Framework_TestCase
      */
     public function testPluckNameInvalidFormat()
     {
-        $this->trait->pluckName('lame', 'bar');
+        $this->trait->call('pluckName', ['lame', 'bar']);
     }
 
     public function testFormatProjectId()
     {
-        $res = $this->trait->formatName('project', 'foo');
+        $res = $this->trait->call('formatName', ['project', 'foo']);
 
         $this->assertEquals('projects/foo', $res);
     }
 
     public function testFormatTopicName()
     {
-        $res = $this->trait->formatName('topic', 'foo', 'my-project');
+        $res = $this->trait->call('formatName', ['topic', 'foo', 'my-project']);
 
         $this->assertEquals('projects/my-project/topics/foo', $res);
     }
 
     public function testFormatSubscriptionName()
     {
-        $res = $this->trait->formatName('subscription', 'foo', 'my-project');
+        $res = $this->trait->call('formatName', ['subscription', 'foo', 'my-project']);
 
         $this->assertEquals('projects/my-project/subscriptions/foo', $res);
     }
@@ -95,46 +95,46 @@ class ResourceNameTraitTest extends \PHPUnit_Framework_TestCase
      */
     public function testFormatNameInvalidType()
     {
-        $this->trait->formatName('lame', ['foo']);
+        $this->trait->call('formatName', ['lame', 'foo']);
     }
 
     public function testIsFullyQualifiedProjectId()
     {
-        $this->assertTrue($this->trait->isFullyQualifiedName(
+        $this->assertTrue($this->trait->call('isFullyQualifiedName', [
             'project',
             'projects/foo'
-        ));
+        ]));
 
-        $this->assertFalse($this->trait->isFullyQualifiedName(
+        $this->assertFalse($this->trait->call('isFullyQualifiedName', [
             'project',
             'foo'
-        ));
+        ]));
     }
 
     public function testIsFullyQualifiedTopicName()
     {
-        $this->assertTrue($this->trait->isFullyQualifiedName(
+        $this->assertTrue($this->trait->call('isFullyQualifiedName', [
             'topic',
             'projects/foo/topics/bar'
-        ));
+        ]));
 
-        $this->assertFalse($this->trait->isFullyQualifiedName(
+        $this->assertFalse($this->trait->call('isFullyQualifiedName', [
             'topic',
             'foo'
-        ));
+        ]));
     }
 
     public function testIsFullyQualifiedSubscriptionName()
     {
-        $this->assertTrue($this->trait->isFullyQualifiedName(
+        $this->assertTrue($this->trait->call('isFullyQualifiedName', [
             'subscription',
             'projects/foo/subscriptions/bar'
-        ));
+        ]));
 
-        $this->assertFalse($this->trait->isFullyQualifiedName(
+        $this->assertFalse($this->trait->call('isFullyQualifiedName', [
             'subscription',
             'foo'
-        ));
+        ]));
     }
 
     /**
@@ -142,6 +142,16 @@ class ResourceNameTraitTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsFullyQualifiedNameInvalidType()
     {
-        $this->trait->isFullyQualifiedName('lame', 'foo');
+        $this->trait->call('isFullyQualifiedName', ['lame', 'foo']);
+    }
+}
+
+class ResourceNameTraitStub
+{
+    use ResourceNameTrait;
+
+    public function call($method, array $args)
+    {
+        return call_user_func_array([$this, $method], $args);
     }
 }


### PR DESCRIPTION
This changes the visibility of the ResourceNameTrait methods to private, in line with other APIs which do not expose the means of formatting names. This is a breaking change.