### PR TITLE
Run system tests on non-PR

### DIFF
--- a/dev/sh/tests
+++ b/dev/sh/tests
@@ -23,6 +23,6 @@ function snippets() {
 unit
 snippets
 
-if [ "${TRAVIS_EVENT_TYPE}" == "cron" ]; then
+if [[ $TRAVIS_PULL_REQUEST -eq "false" ]]; then
   system
 fi


### PR DESCRIPTION
This change adds system tests to the build on all builds which are not pull requests. A maintainer should manually run system tests on any PR which could impact the test status.