### PR TITLE
Update application headers

### DIFF
--- a/src/GrpcTrait.php
+++ b/src/GrpcTrait.php
@@ -75,8 +75,8 @@ trait GrpcTrait
         return [
             'credentialsLoader' => $this->requestWrapper->getCredentialsFetcher(),
             'enableCaching' => false,
-            'appName' => 'gcloud-php',
-            'appVersion' => ServiceBuilder::VERSION
+            'libName' => 'gccl',
+            'libVersion' => ServiceBuilder::VERSION
         ];
     }
 

--- a/src/RequestWrapper.php
+++ b/src/RequestWrapper.php
@@ -137,8 +137,12 @@ class RequestWrapper
      */
     private function signRequest(RequestInterface $request)
     {
+        $template = 'gl-php/%s gccl/%s';
+        $phpVersion = phpversion();
+        $libVersion = ServiceBuilder::VERSION;
+
         $headers = [
-            'User-Agent' => 'gcloud-php/' . ServiceBuilder::VERSION,
+            'x-goog-api-client' => sprintf($template, $phpVersion, $libVersion),
             'Authorization' => 'Bearer ' . $this->getToken()
         ];
 

--- a/tests/unit/GrpcTraitTest.php
+++ b/tests/unit/GrpcTraitTest.php
@@ -71,8 +71,8 @@ class GrpcTraitTest extends \PHPUnit_Framework_TestCase
         $expected = [
             'credentialsLoader' => $fetcher,
             'enableCaching' => false,
-            'appName' => 'gcloud-php',
-            'appVersion' => ServiceBuilder::VERSION
+            'libName' => 'gccl',
+            'libVersion' => ServiceBuilder::VERSION
         ];
 
         $this->assertEquals($expected, $this->implementation->call('getGaxConfig'));

--- a/tests/unit/RequestWrapperTest.php
+++ b/tests/unit/RequestWrapperTest.php
@@ -163,8 +163,12 @@ class RequestWrapperTest extends \PHPUnit_Framework_TestCase
     {
         $requestWrapper = new RequestWrapper([
             'httpHandler' => function ($request, $options = []) {
-                $userAgent = $request->getHeaderLine('User-Agent');
-                $this->assertEquals('gcloud-php/' . ServiceBuilder::VERSION, $userAgent);
+                $template = 'gl-php/%s gccl/%s';
+                $phpVersion = phpversion();
+                $libVersion = ServiceBuilder::VERSION;
+
+                $userAgent = $request->getHeaderLine('x-goog-api-client');
+                $this->assertEquals(sprintf($template, $phpVersion, $libVersion), $userAgent);
                 return new Response(200);
             },
             'accessToken' => 'abc'


### PR DESCRIPTION
The applicable request header in REST:

```
    [headers:GuzzleHttp\Psr7\Request:private] => Array
        (
            [x-goog-api-client] => Array
                (
                    [0] => gl-php/7.0.11 gccl/0.21.1
                )
```

/cc @michaelbausor 

NOTE: I'll be duplicating this change in #360 according to the requirements we discussed. Just wanted to get it in here early.