### PR TITLE
Update headers

### DIFF
--- a/src/GrpcTrait.php
+++ b/src/GrpcTrait.php
@@ -75,8 +75,8 @@ trait GrpcTrait
         return [
             'credentialsLoader' => $this->requestWrapper->getCredentialsFetcher(),
             'enableCaching' => false,
-            'appName' => 'gcloud-php',
-            'appVersion' => ServiceBuilder::VERSION
+            'libName' => 'gccl',
+            'libVersion' => ServiceBuilder::VERSION
         ];
     }
 

--- a/src/RequestWrapper.php
+++ b/src/RequestWrapper.php
@@ -139,6 +139,7 @@ class RequestWrapper
     {
         $headers = [
             'User-Agent' => 'gcloud-php/' . ServiceBuilder::VERSION,
+            'x-goog-api-client' => 'gl-php/' . phpversion() . ' gccl/' . ServiceBuilder::VERSION,
             'Authorization' => 'Bearer ' . $this->getToken()
         ];
 

--- a/tests/unit/GrpcTraitTest.php
+++ b/tests/unit/GrpcTraitTest.php
@@ -71,8 +71,8 @@ class GrpcTraitTest extends \PHPUnit_Framework_TestCase
         $expected = [
             'credentialsLoader' => $fetcher,
             'enableCaching' => false,
-            'appName' => 'gcloud-php',
-            'appVersion' => ServiceBuilder::VERSION
+            'libName' => 'gccl',
+            'libVersion' => ServiceBuilder::VERSION
         ];
 
         $this->assertEquals($expected, $this->implementation->call('getGaxConfig'));

--- a/tests/unit/RequestWrapperTest.php
+++ b/tests/unit/RequestWrapperTest.php
@@ -159,12 +159,14 @@ class RequestWrapperTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function testAddsUserAgentToRequest()
+    public function testAddsUserAgentAndXGoogApiClientToRequest()
     {
         $requestWrapper = new RequestWrapper([
             'httpHandler' => function ($request, $options = []) {
                 $userAgent = $request->getHeaderLine('User-Agent');
                 $this->assertEquals('gcloud-php/' . ServiceBuilder::VERSION, $userAgent);
+                $xGoogApiClient = $request->getHeaderLine('x-goog-api-client');
+                $this->assertEquals('gl-php/' . phpversion() . ' gccl/' . ServiceBuilder::VERSION, $xGoogApiClient);
                 return new Response(200);
             },
             'accessToken' => 'abc'


### PR DESCRIPTION
Adds the x-goog-api-client header, and adds support for the latest GAX changes. Note that we should wait until GAX is released before incorporating this into a release.