### PR TITLE
Regenerate gapic code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,8 +55,8 @@
         "james-heinrich/getid3": "^1.9",
         "erusev/parsedown": "^1.6",
         "vierbergenlars/php-semver": "^3.0",
-        "google/proto-client-php": "^0.7",
-        "google/gax": "^0.6"
+        "google/proto-client-php": "^0.9",
+        "google/gax": "^0.8"
     },
     "suggest": {
         "google/gax": "Required to support gRPC",

--- a/src/ErrorReporting/V1beta1/ErrorGroupServiceClient.php
+++ b/src/ErrorReporting/V1beta1/ErrorGroupServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ class ErrorGroupServiceClient
     /**
      * The code generator version, to be included in the agent header.
      */
-    const CODEGEN_VERSION = '0.1.0';
+    const CODEGEN_VERSION = '0.0.5';
 
     private static $groupNameTemplate;
 
@@ -138,6 +138,17 @@ class ErrorGroupServiceClient
         return self::$groupNameTemplate;
     }
 
+    private static function getGapicVersion()
+    {
+        if (file_exists(__DIR__.'../VERSION')) {
+            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+        } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
+            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+        } else {
+            $gapicVersion = null;
+        }
+    }
+
     // TODO(garrettjones): add channel (when supported in gRPC)
     /**
      * Constructor.
@@ -163,9 +174,6 @@ class ErrorGroupServiceClient
      *                              that don't use retries. For calls that use retries,
      *                              set the timeout in RetryOptions.
      *                              Default: 30000 (30 seconds)
-     *     @type string $appName The codename of the calling service. Default 'gax'.
-     *     @type string $appVersion The version of the calling service.
-     *                              Default: the current version of GAX.
      *     @type \Google\Auth\CredentialsLoader $credentialsLoader
      *                              A CredentialsLoader object created using the
      *                              Google\Auth library.
@@ -181,18 +189,21 @@ class ErrorGroupServiceClient
             ],
             'retryingOverride' => null,
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
-            'appName' => 'gax',
-            'appVersion' => AgentHeaderDescriptor::getGaxVersion(),
+            'libName' => null,
+            'libVersion' => null,
         ];
         $options = array_merge($defaultOptions, $options);
 
+        if (isset($options['libVersion'])) {
+            $gapicVersion = $options['libVersion'];
+        } else {
+            $gapicVersion = self::getGapicVersion();
+        }
+
         $headerDescriptor = new AgentHeaderDescriptor([
-            'clientName' => $options['appName'],
-            'clientVersion' => $options['appVersion'],
-            'codeGenName' => self::CODEGEN_NAME,
-            'codeGenVersion' => self::CODEGEN_VERSION,
-            'gaxVersion' => AgentHeaderDescriptor::getGaxVersion(),
-            'phpVersion' => phpversion(),
+            'libName' => $options['libName'],
+            'libVersion' => $options['libVersion'],
+            'gapicVersion' => $gapicVersion,
         ]);
 
         $defaultDescriptors = ['headerDescriptor' => $headerDescriptor];

--- a/src/ErrorReporting/V1beta1/ErrorGroupServiceClient.php
+++ b/src/ErrorReporting/V1beta1/ErrorGroupServiceClient.php
@@ -141,11 +141,11 @@ class ErrorGroupServiceClient
     private static function getGapicVersion()
     {
         if (file_exists(__DIR__.'../VERSION')) {
-            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+            return file_get_contents(__DIR__.'../VERSION');
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
-            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+            return \Google\Cloud\ServiceBuilder::VERSION;
         } else {
-            $gapicVersion = null;
+            return;
         }
     }
 
@@ -194,11 +194,7 @@ class ErrorGroupServiceClient
         ];
         $options = array_merge($defaultOptions, $options);
 
-        if (isset($options['libVersion'])) {
-            $gapicVersion = $options['libVersion'];
-        } else {
-            $gapicVersion = self::getGapicVersion();
-        }
+        $gapicVersion = $options['libVersion'] ?: self::getGapicVersion();
 
         $headerDescriptor = new AgentHeaderDescriptor([
             'libName' => $options['libName'],

--- a/src/ErrorReporting/V1beta1/ErrorGroupServiceClient.php
+++ b/src/ErrorReporting/V1beta1/ErrorGroupServiceClient.php
@@ -140,8 +140,8 @@ class ErrorGroupServiceClient
 
     private static function getGapicVersion()
     {
-        if (file_exists(__DIR__.'../VERSION')) {
-            return file_get_contents(__DIR__.'../VERSION');
+        if (file_exists(__DIR__.'/../VERSION')) {
+            return trim(file_get_contents(__DIR__.'/../VERSION'));
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
             return \Google\Cloud\ServiceBuilder::VERSION;
         } else {

--- a/src/ErrorReporting/V1beta1/ErrorStatsServiceClient.php
+++ b/src/ErrorReporting/V1beta1/ErrorStatsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ class ErrorStatsServiceClient
     /**
      * The code generator version, to be included in the agent header.
      */
-    const CODEGEN_VERSION = '0.1.0';
+    const CODEGEN_VERSION = '0.0.5';
 
     private static $projectNameTemplate;
 
@@ -174,6 +174,17 @@ class ErrorStatsServiceClient
         return $pageStreamingDescriptors;
     }
 
+    private static function getGapicVersion()
+    {
+        if (file_exists(__DIR__.'../VERSION')) {
+            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+        } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
+            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+        } else {
+            $gapicVersion = null;
+        }
+    }
+
     // TODO(garrettjones): add channel (when supported in gRPC)
     /**
      * Constructor.
@@ -199,9 +210,6 @@ class ErrorStatsServiceClient
      *                              that don't use retries. For calls that use retries,
      *                              set the timeout in RetryOptions.
      *                              Default: 30000 (30 seconds)
-     *     @type string $appName The codename of the calling service. Default 'gax'.
-     *     @type string $appVersion The version of the calling service.
-     *                              Default: the current version of GAX.
      *     @type \Google\Auth\CredentialsLoader $credentialsLoader
      *                              A CredentialsLoader object created using the
      *                              Google\Auth library.
@@ -217,18 +225,21 @@ class ErrorStatsServiceClient
             ],
             'retryingOverride' => null,
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
-            'appName' => 'gax',
-            'appVersion' => AgentHeaderDescriptor::getGaxVersion(),
+            'libName' => null,
+            'libVersion' => null,
         ];
         $options = array_merge($defaultOptions, $options);
 
+        if (isset($options['libVersion'])) {
+            $gapicVersion = $options['libVersion'];
+        } else {
+            $gapicVersion = self::getGapicVersion();
+        }
+
         $headerDescriptor = new AgentHeaderDescriptor([
-            'clientName' => $options['appName'],
-            'clientVersion' => $options['appVersion'],
-            'codeGenName' => self::CODEGEN_NAME,
-            'codeGenVersion' => self::CODEGEN_VERSION,
-            'gaxVersion' => AgentHeaderDescriptor::getGaxVersion(),
-            'phpVersion' => phpversion(),
+            'libName' => $options['libName'],
+            'libVersion' => $options['libVersion'],
+            'gapicVersion' => $gapicVersion,
         ]);
 
         $defaultDescriptors = ['headerDescriptor' => $headerDescriptor];

--- a/src/ErrorReporting/V1beta1/ErrorStatsServiceClient.php
+++ b/src/ErrorReporting/V1beta1/ErrorStatsServiceClient.php
@@ -177,11 +177,11 @@ class ErrorStatsServiceClient
     private static function getGapicVersion()
     {
         if (file_exists(__DIR__.'../VERSION')) {
-            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+            return file_get_contents(__DIR__.'../VERSION');
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
-            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+            return \Google\Cloud\ServiceBuilder::VERSION;
         } else {
-            $gapicVersion = null;
+            return;
         }
     }
 
@@ -230,11 +230,7 @@ class ErrorStatsServiceClient
         ];
         $options = array_merge($defaultOptions, $options);
 
-        if (isset($options['libVersion'])) {
-            $gapicVersion = $options['libVersion'];
-        } else {
-            $gapicVersion = self::getGapicVersion();
-        }
+        $gapicVersion = $options['libVersion'] ?: self::getGapicVersion();
 
         $headerDescriptor = new AgentHeaderDescriptor([
             'libName' => $options['libName'],

--- a/src/ErrorReporting/V1beta1/ErrorStatsServiceClient.php
+++ b/src/ErrorReporting/V1beta1/ErrorStatsServiceClient.php
@@ -176,8 +176,8 @@ class ErrorStatsServiceClient
 
     private static function getGapicVersion()
     {
-        if (file_exists(__DIR__.'../VERSION')) {
-            return file_get_contents(__DIR__.'../VERSION');
+        if (file_exists(__DIR__.'/../VERSION')) {
+            return trim(file_get_contents(__DIR__.'/../VERSION'));
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
             return \Google\Cloud\ServiceBuilder::VERSION;
         } else {

--- a/src/ErrorReporting/V1beta1/ReportErrorsServiceClient.php
+++ b/src/ErrorReporting/V1beta1/ReportErrorsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ class ReportErrorsServiceClient
     /**
      * The code generator version, to be included in the agent header.
      */
-    const CODEGEN_VERSION = '0.1.0';
+    const CODEGEN_VERSION = '0.0.5';
 
     private static $projectNameTemplate;
 
@@ -128,6 +128,17 @@ class ReportErrorsServiceClient
         return self::$projectNameTemplate;
     }
 
+    private static function getGapicVersion()
+    {
+        if (file_exists(__DIR__.'../VERSION')) {
+            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+        } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
+            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+        } else {
+            $gapicVersion = null;
+        }
+    }
+
     // TODO(garrettjones): add channel (when supported in gRPC)
     /**
      * Constructor.
@@ -153,9 +164,6 @@ class ReportErrorsServiceClient
      *                              that don't use retries. For calls that use retries,
      *                              set the timeout in RetryOptions.
      *                              Default: 30000 (30 seconds)
-     *     @type string $appName The codename of the calling service. Default 'gax'.
-     *     @type string $appVersion The version of the calling service.
-     *                              Default: the current version of GAX.
      *     @type \Google\Auth\CredentialsLoader $credentialsLoader
      *                              A CredentialsLoader object created using the
      *                              Google\Auth library.
@@ -171,18 +179,21 @@ class ReportErrorsServiceClient
             ],
             'retryingOverride' => null,
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
-            'appName' => 'gax',
-            'appVersion' => AgentHeaderDescriptor::getGaxVersion(),
+            'libName' => null,
+            'libVersion' => null,
         ];
         $options = array_merge($defaultOptions, $options);
 
+        if (isset($options['libVersion'])) {
+            $gapicVersion = $options['libVersion'];
+        } else {
+            $gapicVersion = self::getGapicVersion();
+        }
+
         $headerDescriptor = new AgentHeaderDescriptor([
-            'clientName' => $options['appName'],
-            'clientVersion' => $options['appVersion'],
-            'codeGenName' => self::CODEGEN_NAME,
-            'codeGenVersion' => self::CODEGEN_VERSION,
-            'gaxVersion' => AgentHeaderDescriptor::getGaxVersion(),
-            'phpVersion' => phpversion(),
+            'libName' => $options['libName'],
+            'libVersion' => $options['libVersion'],
+            'gapicVersion' => $gapicVersion,
         ]);
 
         $defaultDescriptors = ['headerDescriptor' => $headerDescriptor];

--- a/src/ErrorReporting/V1beta1/ReportErrorsServiceClient.php
+++ b/src/ErrorReporting/V1beta1/ReportErrorsServiceClient.php
@@ -131,11 +131,11 @@ class ReportErrorsServiceClient
     private static function getGapicVersion()
     {
         if (file_exists(__DIR__.'../VERSION')) {
-            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+            return file_get_contents(__DIR__.'../VERSION');
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
-            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+            return \Google\Cloud\ServiceBuilder::VERSION;
         } else {
-            $gapicVersion = null;
+            return;
         }
     }
 
@@ -184,11 +184,7 @@ class ReportErrorsServiceClient
         ];
         $options = array_merge($defaultOptions, $options);
 
-        if (isset($options['libVersion'])) {
-            $gapicVersion = $options['libVersion'];
-        } else {
-            $gapicVersion = self::getGapicVersion();
-        }
+        $gapicVersion = $options['libVersion'] ?: self::getGapicVersion();
 
         $headerDescriptor = new AgentHeaderDescriptor([
             'libName' => $options['libName'],

--- a/src/ErrorReporting/V1beta1/ReportErrorsServiceClient.php
+++ b/src/ErrorReporting/V1beta1/ReportErrorsServiceClient.php
@@ -130,8 +130,8 @@ class ReportErrorsServiceClient
 
     private static function getGapicVersion()
     {
-        if (file_exists(__DIR__.'../VERSION')) {
-            return file_get_contents(__DIR__.'../VERSION');
+        if (file_exists(__DIR__.'/../VERSION')) {
+            return trim(file_get_contents(__DIR__.'/../VERSION'));
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
             return \Google\Cloud\ServiceBuilder::VERSION;
         } else {

--- a/src/ErrorReporting/V1beta1/resources/error_group_service_client_config.json
+++ b/src/ErrorReporting/V1beta1/resources/error_group_service_client_config.json
@@ -2,13 +2,13 @@
   "interfaces": {
     "google.devtools.clouderrorreporting.v1beta1.ErrorGroupService": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": [
+          "UNAVAILABLE"
+        ]
       },
       "retry_params": {
         "default": {

--- a/src/ErrorReporting/V1beta1/resources/error_stats_service_client_config.json
+++ b/src/ErrorReporting/V1beta1/resources/error_stats_service_client_config.json
@@ -2,13 +2,13 @@
   "interfaces": {
     "google.devtools.clouderrorreporting.v1beta1.ErrorStatsService": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": [
+          "UNAVAILABLE"
+        ]
       },
       "retry_params": {
         "default": {

--- a/src/ErrorReporting/V1beta1/resources/report_errors_service_client_config.json
+++ b/src/ErrorReporting/V1beta1/resources/report_errors_service_client_config.json
@@ -2,13 +2,13 @@
   "interfaces": {
     "google.devtools.clouderrorreporting.v1beta1.ReportErrorsService": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": [
+          "UNAVAILABLE"
+        ]
       },
       "retry_params": {
         "default": {

--- a/src/Logging/V2/ConfigServiceV2Client.php
+++ b/src/Logging/V2/ConfigServiceV2Client.php
@@ -204,8 +204,8 @@ class ConfigServiceV2Client
 
     private static function getGapicVersion()
     {
-        if (file_exists(__DIR__.'../VERSION')) {
-            return file_get_contents(__DIR__.'../VERSION');
+        if (file_exists(__DIR__.'/../VERSION')) {
+            return trim(file_get_contents(__DIR__.'/../VERSION'));
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
             return \Google\Cloud\ServiceBuilder::VERSION;
         } else {

--- a/src/Logging/V2/ConfigServiceV2Client.php
+++ b/src/Logging/V2/ConfigServiceV2Client.php
@@ -205,11 +205,11 @@ class ConfigServiceV2Client
     private static function getGapicVersion()
     {
         if (file_exists(__DIR__.'../VERSION')) {
-            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+            return file_get_contents(__DIR__.'../VERSION');
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
-            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+            return \Google\Cloud\ServiceBuilder::VERSION;
         } else {
-            $gapicVersion = null;
+            return;
         }
     }
 
@@ -262,11 +262,7 @@ class ConfigServiceV2Client
         ];
         $options = array_merge($defaultOptions, $options);
 
-        if (isset($options['libVersion'])) {
-            $gapicVersion = $options['libVersion'];
-        } else {
-            $gapicVersion = self::getGapicVersion();
-        }
+        $gapicVersion = $options['libVersion'] ?: self::getGapicVersion();
 
         $headerDescriptor = new AgentHeaderDescriptor([
             'libName' => $options['libName'],

--- a/src/Logging/V2/ConfigServiceV2Client.php
+++ b/src/Logging/V2/ConfigServiceV2Client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ class ConfigServiceV2Client
     /**
      * The code generator version, to be included in the agent header.
      */
-    const CODEGEN_VERSION = '0.1.0';
+    const CODEGEN_VERSION = '0.0.5';
 
     private static $projectNameTemplate;
     private static $sinkNameTemplate;
@@ -202,6 +202,17 @@ class ConfigServiceV2Client
         return $pageStreamingDescriptors;
     }
 
+    private static function getGapicVersion()
+    {
+        if (file_exists(__DIR__.'../VERSION')) {
+            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+        } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
+            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+        } else {
+            $gapicVersion = null;
+        }
+    }
+
     // TODO(garrettjones): add channel (when supported in gRPC)
     /**
      * Constructor.
@@ -227,9 +238,6 @@ class ConfigServiceV2Client
      *                              that don't use retries. For calls that use retries,
      *                              set the timeout in RetryOptions.
      *                              Default: 30000 (30 seconds)
-     *     @type string $appName The codename of the calling service. Default 'gax'.
-     *     @type string $appVersion The version of the calling service.
-     *                              Default: the current version of GAX.
      *     @type \Google\Auth\CredentialsLoader $credentialsLoader
      *                              A CredentialsLoader object created using the
      *                              Google\Auth library.
@@ -249,18 +257,21 @@ class ConfigServiceV2Client
             ],
             'retryingOverride' => null,
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
-            'appName' => 'gax',
-            'appVersion' => AgentHeaderDescriptor::getGaxVersion(),
+            'libName' => null,
+            'libVersion' => null,
         ];
         $options = array_merge($defaultOptions, $options);
 
+        if (isset($options['libVersion'])) {
+            $gapicVersion = $options['libVersion'];
+        } else {
+            $gapicVersion = self::getGapicVersion();
+        }
+
         $headerDescriptor = new AgentHeaderDescriptor([
-            'clientName' => $options['appName'],
-            'clientVersion' => $options['appVersion'],
-            'codeGenName' => self::CODEGEN_NAME,
-            'codeGenVersion' => self::CODEGEN_VERSION,
-            'gaxVersion' => AgentHeaderDescriptor::getGaxVersion(),
-            'phpVersion' => phpversion(),
+            'libName' => $options['libName'],
+            'libVersion' => $options['libVersion'],
+            'gapicVersion' => $gapicVersion,
         ]);
 
         $defaultDescriptors = ['headerDescriptor' => $headerDescriptor];

--- a/src/Logging/V2/LoggingServiceV2Client.php
+++ b/src/Logging/V2/LoggingServiceV2Client.php
@@ -209,8 +209,8 @@ class LoggingServiceV2Client
 
     private static function getGapicVersion()
     {
-        if (file_exists(__DIR__.'../VERSION')) {
-            return file_get_contents(__DIR__.'../VERSION');
+        if (file_exists(__DIR__.'/../VERSION')) {
+            return trim(file_get_contents(__DIR__.'/../VERSION'));
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
             return \Google\Cloud\ServiceBuilder::VERSION;
         } else {

--- a/src/Logging/V2/LoggingServiceV2Client.php
+++ b/src/Logging/V2/LoggingServiceV2Client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ class LoggingServiceV2Client
     /**
      * The code generator version, to be included in the agent header.
      */
-    const CODEGEN_VERSION = '0.1.0';
+    const CODEGEN_VERSION = '0.0.5';
 
     private static $projectNameTemplate;
     private static $logNameTemplate;
@@ -207,6 +207,17 @@ class LoggingServiceV2Client
         return $pageStreamingDescriptors;
     }
 
+    private static function getGapicVersion()
+    {
+        if (file_exists(__DIR__.'../VERSION')) {
+            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+        } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
+            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+        } else {
+            $gapicVersion = null;
+        }
+    }
+
     // TODO(garrettjones): add channel (when supported in gRPC)
     /**
      * Constructor.
@@ -232,9 +243,6 @@ class LoggingServiceV2Client
      *                              that don't use retries. For calls that use retries,
      *                              set the timeout in RetryOptions.
      *                              Default: 30000 (30 seconds)
-     *     @type string $appName The codename of the calling service. Default 'gax'.
-     *     @type string $appVersion The version of the calling service.
-     *                              Default: the current version of GAX.
      *     @type \Google\Auth\CredentialsLoader $credentialsLoader
      *                              A CredentialsLoader object created using the
      *                              Google\Auth library.
@@ -254,18 +262,21 @@ class LoggingServiceV2Client
             ],
             'retryingOverride' => null,
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
-            'appName' => 'gax',
-            'appVersion' => AgentHeaderDescriptor::getGaxVersion(),
+            'libName' => null,
+            'libVersion' => null,
         ];
         $options = array_merge($defaultOptions, $options);
 
+        if (isset($options['libVersion'])) {
+            $gapicVersion = $options['libVersion'];
+        } else {
+            $gapicVersion = self::getGapicVersion();
+        }
+
         $headerDescriptor = new AgentHeaderDescriptor([
-            'clientName' => $options['appName'],
-            'clientVersion' => $options['appVersion'],
-            'codeGenName' => self::CODEGEN_NAME,
-            'codeGenVersion' => self::CODEGEN_VERSION,
-            'gaxVersion' => AgentHeaderDescriptor::getGaxVersion(),
-            'phpVersion' => phpversion(),
+            'libName' => $options['libName'],
+            'libVersion' => $options['libVersion'],
+            'gapicVersion' => $gapicVersion,
         ]);
 
         $defaultDescriptors = ['headerDescriptor' => $headerDescriptor];

--- a/src/Logging/V2/LoggingServiceV2Client.php
+++ b/src/Logging/V2/LoggingServiceV2Client.php
@@ -210,11 +210,11 @@ class LoggingServiceV2Client
     private static function getGapicVersion()
     {
         if (file_exists(__DIR__.'../VERSION')) {
-            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+            return file_get_contents(__DIR__.'../VERSION');
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
-            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+            return \Google\Cloud\ServiceBuilder::VERSION;
         } else {
-            $gapicVersion = null;
+            return;
         }
     }
 
@@ -267,11 +267,7 @@ class LoggingServiceV2Client
         ];
         $options = array_merge($defaultOptions, $options);
 
-        if (isset($options['libVersion'])) {
-            $gapicVersion = $options['libVersion'];
-        } else {
-            $gapicVersion = self::getGapicVersion();
-        }
+        $gapicVersion = $options['libVersion'] ?: self::getGapicVersion();
 
         $headerDescriptor = new AgentHeaderDescriptor([
             'libName' => $options['libName'],

--- a/src/Logging/V2/MetricsServiceV2Client.php
+++ b/src/Logging/V2/MetricsServiceV2Client.php
@@ -203,8 +203,8 @@ class MetricsServiceV2Client
 
     private static function getGapicVersion()
     {
-        if (file_exists(__DIR__.'../VERSION')) {
-            return file_get_contents(__DIR__.'../VERSION');
+        if (file_exists(__DIR__.'/../VERSION')) {
+            return trim(file_get_contents(__DIR__.'/../VERSION'));
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
             return \Google\Cloud\ServiceBuilder::VERSION;
         } else {

--- a/src/Logging/V2/MetricsServiceV2Client.php
+++ b/src/Logging/V2/MetricsServiceV2Client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@ class MetricsServiceV2Client
     /**
      * The code generator version, to be included in the agent header.
      */
-    const CODEGEN_VERSION = '0.1.0';
+    const CODEGEN_VERSION = '0.0.5';
 
     private static $projectNameTemplate;
     private static $metricNameTemplate;
@@ -201,6 +201,17 @@ class MetricsServiceV2Client
         return $pageStreamingDescriptors;
     }
 
+    private static function getGapicVersion()
+    {
+        if (file_exists(__DIR__.'../VERSION')) {
+            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+        } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
+            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+        } else {
+            $gapicVersion = null;
+        }
+    }
+
     // TODO(garrettjones): add channel (when supported in gRPC)
     /**
      * Constructor.
@@ -226,9 +237,6 @@ class MetricsServiceV2Client
      *                              that don't use retries. For calls that use retries,
      *                              set the timeout in RetryOptions.
      *                              Default: 30000 (30 seconds)
-     *     @type string $appName The codename of the calling service. Default 'gax'.
-     *     @type string $appVersion The version of the calling service.
-     *                              Default: the current version of GAX.
      *     @type \Google\Auth\CredentialsLoader $credentialsLoader
      *                              A CredentialsLoader object created using the
      *                              Google\Auth library.
@@ -248,18 +256,21 @@ class MetricsServiceV2Client
             ],
             'retryingOverride' => null,
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
-            'appName' => 'gax',
-            'appVersion' => AgentHeaderDescriptor::getGaxVersion(),
+            'libName' => null,
+            'libVersion' => null,
         ];
         $options = array_merge($defaultOptions, $options);
 
+        if (isset($options['libVersion'])) {
+            $gapicVersion = $options['libVersion'];
+        } else {
+            $gapicVersion = self::getGapicVersion();
+        }
+
         $headerDescriptor = new AgentHeaderDescriptor([
-            'clientName' => $options['appName'],
-            'clientVersion' => $options['appVersion'],
-            'codeGenName' => self::CODEGEN_NAME,
-            'codeGenVersion' => self::CODEGEN_VERSION,
-            'gaxVersion' => AgentHeaderDescriptor::getGaxVersion(),
-            'phpVersion' => phpversion(),
+            'libName' => $options['libName'],
+            'libVersion' => $options['libVersion'],
+            'gapicVersion' => $gapicVersion,
         ]);
 
         $defaultDescriptors = ['headerDescriptor' => $headerDescriptor];

--- a/src/Logging/V2/MetricsServiceV2Client.php
+++ b/src/Logging/V2/MetricsServiceV2Client.php
@@ -204,11 +204,11 @@ class MetricsServiceV2Client
     private static function getGapicVersion()
     {
         if (file_exists(__DIR__.'../VERSION')) {
-            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+            return file_get_contents(__DIR__.'../VERSION');
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
-            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+            return \Google\Cloud\ServiceBuilder::VERSION;
         } else {
-            $gapicVersion = null;
+            return;
         }
     }
 
@@ -261,11 +261,7 @@ class MetricsServiceV2Client
         ];
         $options = array_merge($defaultOptions, $options);
 
-        if (isset($options['libVersion'])) {
-            $gapicVersion = $options['libVersion'];
-        } else {
-            $gapicVersion = self::getGapicVersion();
-        }
+        $gapicVersion = $options['libVersion'] ?: self::getGapicVersion();
 
         $headerDescriptor = new AgentHeaderDescriptor([
             'libName' => $options['libName'],

--- a/src/Logging/V2/resources/config_service_v2_client_config.json
+++ b/src/Logging/V2/resources/config_service_v2_client_config.json
@@ -2,13 +2,13 @@
   "interfaces": {
     "google.logging.v2.ConfigServiceV2": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": [
+          "UNAVAILABLE"
+        ]
       },
       "retry_params": {
         "default": {

--- a/src/Logging/V2/resources/logging_service_v2_client_config.json
+++ b/src/Logging/V2/resources/logging_service_v2_client_config.json
@@ -2,13 +2,13 @@
   "interfaces": {
     "google.logging.v2.LoggingServiceV2": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": [
+          "UNAVAILABLE"
+        ]
       },
       "retry_params": {
         "default": {
@@ -39,7 +39,12 @@
         "WriteLogEntries": {
           "timeout_millis": 30000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "default",
+          "bundling": {
+            "element_count_threshold": 100,
+            "request_byte_threshold": 1024,
+            "delay_threshold_millis": 10
+          }
         },
         "ListLogEntries": {
           "timeout_millis": 30000,

--- a/src/Logging/V2/resources/metrics_service_v2_client_config.json
+++ b/src/Logging/V2/resources/metrics_service_v2_client_config.json
@@ -2,13 +2,13 @@
   "interfaces": {
     "google.logging.v2.MetricsServiceV2": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": [
+          "UNAVAILABLE"
+        ]
       },
       "retry_params": {
         "default": {

--- a/src/Monitoring/V3/GroupServiceClient.php
+++ b/src/Monitoring/V3/GroupServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,7 +118,7 @@ class GroupServiceClient
     /**
      * The code generator version, to be included in the agent header.
      */
-    const CODEGEN_VERSION = '0.1.0';
+    const CODEGEN_VERSION = '0.0.5';
 
     private static $projectNameTemplate;
     private static $groupNameTemplate;
@@ -222,6 +222,17 @@ class GroupServiceClient
         return $pageStreamingDescriptors;
     }
 
+    private static function getGapicVersion()
+    {
+        if (file_exists(__DIR__.'../VERSION')) {
+            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+        } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
+            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+        } else {
+            $gapicVersion = null;
+        }
+    }
+
     // TODO(garrettjones): add channel (when supported in gRPC)
     /**
      * Constructor.
@@ -247,9 +258,6 @@ class GroupServiceClient
      *                              that don't use retries. For calls that use retries,
      *                              set the timeout in RetryOptions.
      *                              Default: 30000 (30 seconds)
-     *     @type string $appName The codename of the calling service. Default 'gax'.
-     *     @type string $appVersion The version of the calling service.
-     *                              Default: the current version of GAX.
      *     @type \Google\Auth\CredentialsLoader $credentialsLoader
      *                              A CredentialsLoader object created using the
      *                              Google\Auth library.
@@ -268,18 +276,21 @@ class GroupServiceClient
             ],
             'retryingOverride' => null,
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
-            'appName' => 'gax',
-            'appVersion' => AgentHeaderDescriptor::getGaxVersion(),
+            'libName' => null,
+            'libVersion' => null,
         ];
         $options = array_merge($defaultOptions, $options);
 
+        if (isset($options['libVersion'])) {
+            $gapicVersion = $options['libVersion'];
+        } else {
+            $gapicVersion = self::getGapicVersion();
+        }
+
         $headerDescriptor = new AgentHeaderDescriptor([
-            'clientName' => $options['appName'],
-            'clientVersion' => $options['appVersion'],
-            'codeGenName' => self::CODEGEN_NAME,
-            'codeGenVersion' => self::CODEGEN_VERSION,
-            'gaxVersion' => AgentHeaderDescriptor::getGaxVersion(),
-            'phpVersion' => phpversion(),
+            'libName' => $options['libName'],
+            'libVersion' => $options['libVersion'],
+            'gapicVersion' => $gapicVersion,
         ]);
 
         $defaultDescriptors = ['headerDescriptor' => $headerDescriptor];

--- a/src/Monitoring/V3/GroupServiceClient.php
+++ b/src/Monitoring/V3/GroupServiceClient.php
@@ -224,8 +224,8 @@ class GroupServiceClient
 
     private static function getGapicVersion()
     {
-        if (file_exists(__DIR__.'../VERSION')) {
-            return file_get_contents(__DIR__.'../VERSION');
+        if (file_exists(__DIR__.'/../VERSION')) {
+            return trim(file_get_contents(__DIR__.'/../VERSION'));
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
             return \Google\Cloud\ServiceBuilder::VERSION;
         } else {

--- a/src/Monitoring/V3/GroupServiceClient.php
+++ b/src/Monitoring/V3/GroupServiceClient.php
@@ -225,11 +225,11 @@ class GroupServiceClient
     private static function getGapicVersion()
     {
         if (file_exists(__DIR__.'../VERSION')) {
-            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+            return file_get_contents(__DIR__.'../VERSION');
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
-            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+            return \Google\Cloud\ServiceBuilder::VERSION;
         } else {
-            $gapicVersion = null;
+            return;
         }
     }
 
@@ -281,11 +281,7 @@ class GroupServiceClient
         ];
         $options = array_merge($defaultOptions, $options);
 
-        if (isset($options['libVersion'])) {
-            $gapicVersion = $options['libVersion'];
-        } else {
-            $gapicVersion = self::getGapicVersion();
-        }
+        $gapicVersion = $options['libVersion'] ?: self::getGapicVersion();
 
         $headerDescriptor = new AgentHeaderDescriptor([
             'libName' => $options['libName'],

--- a/src/Monitoring/V3/MetricServiceClient.php
+++ b/src/Monitoring/V3/MetricServiceClient.php
@@ -267,8 +267,8 @@ class MetricServiceClient
 
     private static function getGapicVersion()
     {
-        if (file_exists(__DIR__.'../VERSION')) {
-            return file_get_contents(__DIR__.'../VERSION');
+        if (file_exists(__DIR__.'/../VERSION')) {
+            return trim(file_get_contents(__DIR__.'/../VERSION'));
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
             return \Google\Cloud\ServiceBuilder::VERSION;
         } else {

--- a/src/Monitoring/V3/MetricServiceClient.php
+++ b/src/Monitoring/V3/MetricServiceClient.php
@@ -268,11 +268,11 @@ class MetricServiceClient
     private static function getGapicVersion()
     {
         if (file_exists(__DIR__.'../VERSION')) {
-            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+            return file_get_contents(__DIR__.'../VERSION');
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
-            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+            return \Google\Cloud\ServiceBuilder::VERSION;
         } else {
-            $gapicVersion = null;
+            return;
         }
     }
 
@@ -324,11 +324,7 @@ class MetricServiceClient
         ];
         $options = array_merge($defaultOptions, $options);
 
-        if (isset($options['libVersion'])) {
-            $gapicVersion = $options['libVersion'];
-        } else {
-            $gapicVersion = self::getGapicVersion();
-        }
+        $gapicVersion = $options['libVersion'] ?: self::getGapicVersion();
 
         $headerDescriptor = new AgentHeaderDescriptor([
             'libName' => $options['libName'],

--- a/src/Monitoring/V3/MetricServiceClient.php
+++ b/src/Monitoring/V3/MetricServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,7 +113,7 @@ class MetricServiceClient
     /**
      * The code generator version, to be included in the agent header.
      */
-    const CODEGEN_VERSION = '0.1.0';
+    const CODEGEN_VERSION = '0.0.5';
 
     private static $projectNameTemplate;
     private static $metricDescriptorNameTemplate;
@@ -265,6 +265,17 @@ class MetricServiceClient
         return $pageStreamingDescriptors;
     }
 
+    private static function getGapicVersion()
+    {
+        if (file_exists(__DIR__.'../VERSION')) {
+            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+        } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
+            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+        } else {
+            $gapicVersion = null;
+        }
+    }
+
     // TODO(garrettjones): add channel (when supported in gRPC)
     /**
      * Constructor.
@@ -290,9 +301,6 @@ class MetricServiceClient
      *                              that don't use retries. For calls that use retries,
      *                              set the timeout in RetryOptions.
      *                              Default: 30000 (30 seconds)
-     *     @type string $appName The codename of the calling service. Default 'gax'.
-     *     @type string $appVersion The version of the calling service.
-     *                              Default: the current version of GAX.
      *     @type \Google\Auth\CredentialsLoader $credentialsLoader
      *                              A CredentialsLoader object created using the
      *                              Google\Auth library.
@@ -311,18 +319,21 @@ class MetricServiceClient
             ],
             'retryingOverride' => null,
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
-            'appName' => 'gax',
-            'appVersion' => AgentHeaderDescriptor::getGaxVersion(),
+            'libName' => null,
+            'libVersion' => null,
         ];
         $options = array_merge($defaultOptions, $options);
 
+        if (isset($options['libVersion'])) {
+            $gapicVersion = $options['libVersion'];
+        } else {
+            $gapicVersion = self::getGapicVersion();
+        }
+
         $headerDescriptor = new AgentHeaderDescriptor([
-            'clientName' => $options['appName'],
-            'clientVersion' => $options['appVersion'],
-            'codeGenName' => self::CODEGEN_NAME,
-            'codeGenVersion' => self::CODEGEN_VERSION,
-            'gaxVersion' => AgentHeaderDescriptor::getGaxVersion(),
-            'phpVersion' => phpversion(),
+            'libName' => $options['libName'],
+            'libVersion' => $options['libVersion'],
+            'gapicVersion' => $gapicVersion,
         ]);
 
         $defaultDescriptors = ['headerDescriptor' => $headerDescriptor];

--- a/src/Monitoring/V3/resources/group_service_client_config.json
+++ b/src/Monitoring/V3/resources/group_service_client_config.json
@@ -2,13 +2,13 @@
   "interfaces": {
     "google.monitoring.v3.GroupService": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": [
+          "UNAVAILABLE"
+        ]
       },
       "retry_params": {
         "default": {

--- a/src/Monitoring/V3/resources/metric_service_client_config.json
+++ b/src/Monitoring/V3/resources/metric_service_client_config.json
@@ -2,13 +2,13 @@
   "interfaces": {
     "google.monitoring.v3.MetricService": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": [
+          "UNAVAILABLE"
+        ]
       },
       "retry_params": {
         "default": {

--- a/src/PubSub/V1/PublisherClient.php
+++ b/src/PubSub/V1/PublisherClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ class PublisherClient
     /**
      * The code generator version, to be included in the agent header.
      */
-    const CODEGEN_VERSION = '0.1.0';
+    const CODEGEN_VERSION = '0.0.5';
 
     private static $projectNameTemplate;
     private static $topicNameTemplate;
@@ -205,6 +205,17 @@ class PublisherClient
         return $pageStreamingDescriptors;
     }
 
+    private static function getGapicVersion()
+    {
+        if (file_exists(__DIR__.'../VERSION')) {
+            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+        } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
+            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+        } else {
+            $gapicVersion = null;
+        }
+    }
+
     // TODO(garrettjones): add channel (when supported in gRPC)
     /**
      * Constructor.
@@ -230,9 +241,6 @@ class PublisherClient
      *                              that don't use retries. For calls that use retries,
      *                              set the timeout in RetryOptions.
      *                              Default: 30000 (30 seconds)
-     *     @type string $appName The codename of the calling service. Default 'gax'.
-     *     @type string $appVersion The version of the calling service.
-     *                              Default: the current version of GAX.
      *     @type \Google\Auth\CredentialsLoader $credentialsLoader
      *                              A CredentialsLoader object created using the
      *                              Google\Auth library.
@@ -249,18 +257,21 @@ class PublisherClient
             ],
             'retryingOverride' => null,
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
-            'appName' => 'gax',
-            'appVersion' => AgentHeaderDescriptor::getGaxVersion(),
+            'libName' => null,
+            'libVersion' => null,
         ];
         $options = array_merge($defaultOptions, $options);
 
+        if (isset($options['libVersion'])) {
+            $gapicVersion = $options['libVersion'];
+        } else {
+            $gapicVersion = self::getGapicVersion();
+        }
+
         $headerDescriptor = new AgentHeaderDescriptor([
-            'clientName' => $options['appName'],
-            'clientVersion' => $options['appVersion'],
-            'codeGenName' => self::CODEGEN_NAME,
-            'codeGenVersion' => self::CODEGEN_VERSION,
-            'gaxVersion' => AgentHeaderDescriptor::getGaxVersion(),
-            'phpVersion' => phpversion(),
+            'libName' => $options['libName'],
+            'libVersion' => $options['libVersion'],
+            'gapicVersion' => $gapicVersion,
         ]);
 
         $defaultDescriptors = ['headerDescriptor' => $headerDescriptor];

--- a/src/PubSub/V1/PublisherClient.php
+++ b/src/PubSub/V1/PublisherClient.php
@@ -207,8 +207,8 @@ class PublisherClient
 
     private static function getGapicVersion()
     {
-        if (file_exists(__DIR__.'../VERSION')) {
-            return file_get_contents(__DIR__.'../VERSION');
+        if (file_exists(__DIR__.'/../VERSION')) {
+            return trim(file_get_contents(__DIR__.'/../VERSION'));
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
             return \Google\Cloud\ServiceBuilder::VERSION;
         } else {

--- a/src/PubSub/V1/PublisherClient.php
+++ b/src/PubSub/V1/PublisherClient.php
@@ -208,11 +208,11 @@ class PublisherClient
     private static function getGapicVersion()
     {
         if (file_exists(__DIR__.'../VERSION')) {
-            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+            return file_get_contents(__DIR__.'../VERSION');
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
-            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+            return \Google\Cloud\ServiceBuilder::VERSION;
         } else {
-            $gapicVersion = null;
+            return;
         }
     }
 
@@ -262,11 +262,7 @@ class PublisherClient
         ];
         $options = array_merge($defaultOptions, $options);
 
-        if (isset($options['libVersion'])) {
-            $gapicVersion = $options['libVersion'];
-        } else {
-            $gapicVersion = self::getGapicVersion();
-        }
+        $gapicVersion = $options['libVersion'] ?: self::getGapicVersion();
 
         $headerDescriptor = new AgentHeaderDescriptor([
             'libName' => $options['libName'],

--- a/src/PubSub/V1/SubscriberClient.php
+++ b/src/PubSub/V1/SubscriberClient.php
@@ -310,11 +310,11 @@ class SubscriberClient
     private static function getGapicVersion()
     {
         if (file_exists(__DIR__.'../VERSION')) {
-            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+            return file_get_contents(__DIR__.'../VERSION');
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
-            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+            return \Google\Cloud\ServiceBuilder::VERSION;
         } else {
-            $gapicVersion = null;
+            return;
         }
     }
 
@@ -364,11 +364,7 @@ class SubscriberClient
         ];
         $options = array_merge($defaultOptions, $options);
 
-        if (isset($options['libVersion'])) {
-            $gapicVersion = $options['libVersion'];
-        } else {
-            $gapicVersion = self::getGapicVersion();
-        }
+        $gapicVersion = $options['libVersion'] ?: self::getGapicVersion();
 
         $headerDescriptor = new AgentHeaderDescriptor([
             'libName' => $options['libName'],

--- a/src/PubSub/V1/SubscriberClient.php
+++ b/src/PubSub/V1/SubscriberClient.php
@@ -309,8 +309,8 @@ class SubscriberClient
 
     private static function getGapicVersion()
     {
-        if (file_exists(__DIR__.'../VERSION')) {
-            return file_get_contents(__DIR__.'../VERSION');
+        if (file_exists(__DIR__.'/../VERSION')) {
+            return trim(file_get_contents(__DIR__.'/../VERSION'));
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
             return \Google\Cloud\ServiceBuilder::VERSION;
         } else {

--- a/src/PubSub/V1/resources/publisher_client_config.json
+++ b/src/PubSub/V1/resources/publisher_client_config.json
@@ -2,17 +2,17 @@
   "interfaces": {
     "google.pubsub.v1.Publisher": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "one_plus_delivery": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "one_plus_delivery": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": [
+          "UNAVAILABLE"
+        ]
       },
       "retry_params": {
         "default": {

--- a/src/PubSub/V1/resources/subscriber_client_config.json
+++ b/src/PubSub/V1/resources/subscriber_client_config.json
@@ -2,13 +2,13 @@
   "interfaces": {
     "google.pubsub.v1.Subscriber": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": [
+          "UNAVAILABLE"
+        ]
       },
       "retry_params": {
         "default": {
@@ -41,6 +41,11 @@
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
+        "UpdateSubscription": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
         "ListSubscriptions": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
@@ -66,7 +71,32 @@
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "messaging"
         },
+        "StreamingPull": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "messaging"
+        },
         "ModifyPushConfig": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ListSnapshots": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "CreateSnapshot": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "DeleteSnapshot": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "Seek": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"

--- a/src/Speech/V1beta1/SpeechClient.php
+++ b/src/Speech/V1beta1/SpeechClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,11 +34,13 @@ use Google\GAX\CallSettings;
 use Google\GAX\GrpcConstants;
 use Google\GAX\GrpcCredentialsHelper;
 use Google\GAX\LongRunning\OperationsClient;
+use Google\GAX\OperationResponse;
 use google\cloud\speech\v1beta1\AsyncRecognizeRequest;
 use google\cloud\speech\v1beta1\AsyncRecognizeResponse;
 use google\cloud\speech\v1beta1\RecognitionAudio;
 use google\cloud\speech\v1beta1\RecognitionConfig;
 use google\cloud\speech\v1beta1\SpeechGrpcClient;
+use google\cloud\speech\v1beta1\StreamingRecognizeRequest;
 use google\cloud\speech\v1beta1\SyncRecognizeRequest;
 
 /**
@@ -54,8 +56,14 @@ use google\cloud\speech\v1beta1\SyncRecognizeRequest;
  * ```
  * try {
  *     $speechClient = new SpeechClient();
+ *     $encoding = AudioEncoding::FLAC;
+ *     $sampleRate = 44100;
  *     $config = new RecognitionConfig();
+ *     $config->setEncoding($encoding);
+ *     $config->setSampleRate($sampleRate);
+ *     $uri = "gs://bucket_name/file_name.flac";
  *     $audio = new RecognitionAudio();
+ *     $audio->setUri($uri);
  *     $response = $speechClient->syncRecognize($config, $audio);
  * } finally {
  *     $speechClient->close();
@@ -92,7 +100,7 @@ class SpeechClient
     /**
      * The code generator version, to be included in the agent header.
      */
-    const CODEGEN_VERSION = '0.1.0';
+    const CODEGEN_VERSION = '0.0.5';
 
     private $grpcCredentialsHelper;
     private $speechStub;
@@ -111,6 +119,26 @@ class SpeechClient
         ];
     }
 
+    private static function getGrpcStreamingDescriptors()
+    {
+        return [
+            'streamingRecognize' => [
+                'grpcStreamingType' => 'BidiStreaming',
+            ],
+        ];
+    }
+
+    private static function getGapicVersion()
+    {
+        if (file_exists(__DIR__.'../VERSION')) {
+            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+        } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
+            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+        } else {
+            $gapicVersion = null;
+        }
+    }
+
     /**
      * Return an OperationsClient object with the same endpoint as $this.
      *
@@ -119,6 +147,32 @@ class SpeechClient
     public function getOperationsClient()
     {
         return $this->operationsClient;
+    }
+
+    /**
+     * Resume an existing long running operation that was previously started
+     * by a long running API method. If $methodName is not provided, or does
+     * not match a long running API method, then the operation can still be
+     * resumed, but the OperationResponse object will not deserialize the
+     * final response.
+     *
+     * @param string $operationName The name of the long running operation
+     * @param string $methodName    The name of the method used to start the operation
+     *
+     * @return \Google\GAX\OperationResponse
+     */
+    public function resumeOperation($operationName, $methodName = null)
+    {
+        $lroDescriptors = self::getLongRunningDescriptors();
+        if (!is_null($methodName) && array_key_exists($methodName, $lroDescriptors)) {
+            $options = $lroDescriptors[$methodName];
+        } else {
+            $options = [];
+        }
+        $operation = new OperationResponse($operationName, $this->getOperationsClient(), $options);
+        $operation->reload();
+
+        return $operation;
     }
 
     // TODO(garrettjones): add channel (when supported in gRPC)
@@ -146,9 +200,6 @@ class SpeechClient
      *                              that don't use retries. For calls that use retries,
      *                              set the timeout in RetryOptions.
      *                              Default: 30000 (30 seconds)
-     *     @type string $appName The codename of the calling service. Default 'gax'.
-     *     @type string $appVersion The version of the calling service.
-     *                              Default: the current version of GAX.
      *     @type \Google\Auth\CredentialsLoader $credentialsLoader
      *                              A CredentialsLoader object created using the
      *                              Google\Auth library.
@@ -164,33 +215,47 @@ class SpeechClient
             ],
             'retryingOverride' => null,
             'timeoutMillis' => self::DEFAULT_TIMEOUT_MILLIS,
-            'appName' => 'gax',
-            'appVersion' => AgentHeaderDescriptor::getGaxVersion(),
+            'libName' => null,
+            'libVersion' => null,
         ];
         $options = array_merge($defaultOptions, $options);
 
-        $this->operationsClient = new OperationsClient([
-            'serviceAddress' => $options['serviceAddress'],
-            'scopes' => $options['scopes'],
-        ]);
+        if (array_key_exists('operationsClient', $options)) {
+            $this->operationsClient = $options['operationsClient'];
+        } else {
+            $this->operationsClient = new OperationsClient([
+                'serviceAddress' => $options['serviceAddress'],
+                'scopes' => $options['scopes'],
+                'libName' => $options['libName'],
+                'libVersion' => $options['libVersion'],
+            ]);
+        }
+
+        if (isset($options['libVersion'])) {
+            $gapicVersion = $options['libVersion'];
+        } else {
+            $gapicVersion = self::getGapicVersion();
+        }
 
         $headerDescriptor = new AgentHeaderDescriptor([
-            'clientName' => $options['appName'],
-            'clientVersion' => $options['appVersion'],
-            'codeGenName' => self::CODEGEN_NAME,
-            'codeGenVersion' => self::CODEGEN_VERSION,
-            'gaxVersion' => AgentHeaderDescriptor::getGaxVersion(),
-            'phpVersion' => phpversion(),
+            'libName' => $options['libName'],
+            'libVersion' => $options['libVersion'],
+            'gapicVersion' => $gapicVersion,
         ]);
 
         $defaultDescriptors = ['headerDescriptor' => $headerDescriptor];
         $this->descriptors = [
             'syncRecognize' => $defaultDescriptors,
             'asyncRecognize' => $defaultDescriptors,
+            'streamingRecognize' => $defaultDescriptors,
         ];
         $longRunningDescriptors = self::getLongRunningDescriptors();
         foreach ($longRunningDescriptors as $method => $longRunningDescriptor) {
             $this->descriptors[$method]['longRunningDescriptor'] = $longRunningDescriptor + ['operationsClient' => $this->operationsClient];
+        }
+        $grpcStreamingDescriptors = self::getGrpcStreamingDescriptors();
+        foreach ($grpcStreamingDescriptors as $method => $grpcStreamingDescriptor) {
+            $this->descriptors[$method]['grpcStreamingDescriptor'] = $grpcStreamingDescriptor;
         }
 
         $clientConfigJsonString = file_get_contents(__DIR__.'/resources/speech_client_config.json');
@@ -235,8 +300,14 @@ class SpeechClient
      * ```
      * try {
      *     $speechClient = new SpeechClient();
+     *     $encoding = AudioEncoding::FLAC;
+     *     $sampleRate = 44100;
      *     $config = new RecognitionConfig();
+     *     $config->setEncoding($encoding);
+     *     $config->setSampleRate($sampleRate);
+     *     $uri = "gs://bucket_name/file_name.flac";
      *     $audio = new RecognitionAudio();
+     *     $audio->setUri($uri);
      *     $response = $speechClient->syncRecognize($config, $audio);
      * } finally {
      *     $speechClient->close();
@@ -293,8 +364,14 @@ class SpeechClient
      * ```
      * try {
      *     $speechClient = new SpeechClient();
+     *     $encoding = AudioEncoding::FLAC;
+     *     $sampleRate = 44100;
      *     $config = new RecognitionConfig();
+     *     $config->setEncoding($encoding);
+     *     $config->setSampleRate($sampleRate);
+     *     $uri = "gs://bucket_name/file_name.flac";
      *     $audio = new RecognitionAudio();
+     *     $audio->setUri($uri);
      *     $operationResponse = $speechClient->asyncRecognize($config, $audio);
      *     $operationResponse->pollUntilComplete();
      *     if ($operationResponse->operationSucceeded()) {
@@ -302,6 +379,23 @@ class SpeechClient
      *       // doSomethingWith($result)
      *     } else {
      *       $error = $operationResponse->getError();
+     *       // handleError($error)
+     *     }
+     *
+     *     // OR start the operation, keep the operation name, and resume later
+     *     $operationResponse = $speechClient->asyncRecognize($config, $audio);
+     *     $operationName = $operationResponse->getName();
+     *     // ... do other work
+     *     $newOperationResponse = $speechClient->resumeOperation($operationName, 'asyncRecognize');
+     *     while (!$newOperationResponse->isDone()) {
+     *         // ... do other work
+     *         $newOperationResponse->reload();
+     *     }
+     *     if ($newOperationResponse->operationSucceeded()) {
+     *       $result = $newOperationResponse->getResult();
+     *       // doSomethingWith($result)
+     *     } else {
+     *       $error = $newOperationResponse->getError();
      *       // handleError($error)
      *     }
      * } finally {
@@ -345,6 +439,75 @@ class SpeechClient
 
         return $callable(
             $request,
+            [],
+            ['call_credentials_callback' => $this->createCredentialsCallback()]);
+    }
+
+    /**
+     * Perform bidirectional streaming speech-recognition: receive results while
+     * sending audio. This method is only available via the gRPC API (not REST).
+     *
+     * Sample code:
+     * ```
+     * try {
+     *     $speechClient = new SpeechClient();
+     *     $request = new StreamingRecognizeRequest();
+     *     $requests = [$request];
+     *
+     *     // Write all requests to the server, then read all responses until the
+     *     // stream is complete
+     *     $stream = $speechClient->streamingRecognize();
+     *     $stream->writeAll($requests);
+     *     foreach ($stream->closeWriteAndReadAll() as $element) {
+     *         // doSomethingWith($element);
+     *     }
+     *
+     *     // OR write requests individually, making read() calls if
+     *     // required. Call closeWrite() once writes are complete, and read the
+     *     // remaining responses from the server.
+     *     $stream = $speechClient->streamingRecognize();
+     *     foreach ($requests as $request) {
+     *         $stream->write($request);
+     *         // if required, read a single response from the stream
+     *         $element = $stream->read();
+     *         // doSomethingWith($element)
+     *     }
+     *     $stream->closeWrite();
+     *     $element = $stream->read();
+     *     while (!is_null($element)) {
+     *         // doSomethingWith($element)
+     *         $element = $stream->read();
+     *     }
+     * } finally {
+     *     $speechClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *                            Optional.
+     *
+     *     @type int $timeoutMillis
+     *          Timeout to use for this call.
+     * }
+     *
+     * @return \Google\GAX\BidiStreamingResponse
+     *
+     * @throws \Google\GAX\ApiException if the remote call fails
+     */
+    public function streamingRecognize($optionalArgs = [])
+    {
+        $mergedSettings = $this->defaultCallSettings['streamingRecognize']->merge(
+            new CallSettings($optionalArgs)
+        );
+        $callable = ApiCallable::createApiCall(
+            $this->speechStub,
+            'StreamingRecognize',
+            $mergedSettings,
+            $this->descriptors['streamingRecognize']
+        );
+
+        return $callable(
+            null,
             [],
             ['call_credentials_callback' => $this->createCredentialsCallback()]);
     }

--- a/src/Speech/V1beta1/SpeechClient.php
+++ b/src/Speech/V1beta1/SpeechClient.php
@@ -130,8 +130,8 @@ class SpeechClient
 
     private static function getGapicVersion()
     {
-        if (file_exists(__DIR__.'../VERSION')) {
-            return file_get_contents(__DIR__.'../VERSION');
+        if (file_exists(__DIR__.'/../VERSION')) {
+            return trim(file_get_contents(__DIR__.'/../VERSION'));
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
             return \Google\Cloud\ServiceBuilder::VERSION;
         } else {

--- a/src/Speech/V1beta1/SpeechClient.php
+++ b/src/Speech/V1beta1/SpeechClient.php
@@ -131,11 +131,11 @@ class SpeechClient
     private static function getGapicVersion()
     {
         if (file_exists(__DIR__.'../VERSION')) {
-            $gapicVersion = file_get_contents(__DIR__.'../VERSION');
+            return file_get_contents(__DIR__.'../VERSION');
         } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
-            $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+            return \Google\Cloud\ServiceBuilder::VERSION;
         } else {
-            $gapicVersion = null;
+            return;
         }
     }
 
@@ -231,11 +231,7 @@ class SpeechClient
             ]);
         }
 
-        if (isset($options['libVersion'])) {
-            $gapicVersion = $options['libVersion'];
-        } else {
-            $gapicVersion = self::getGapicVersion();
-        }
+        $gapicVersion = $options['libVersion'] ?: self::getGapicVersion();
 
         $headerDescriptor = new AgentHeaderDescriptor([
             'libName' => $options['libName'],

--- a/src/Speech/V1beta1/resources/speech_client_config.json
+++ b/src/Speech/V1beta1/resources/speech_client_config.json
@@ -2,13 +2,13 @@
   "interfaces": {
     "google.cloud.speech.v1beta1.Speech": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": [
+          "UNAVAILABLE"
+        ]
       },
       "retry_params": {
         "default": {
@@ -30,6 +30,11 @@
         "AsyncRecognize": {
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamingRecognize": {
+          "timeout_millis": 190000,
+          "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         }
       }


### PR DESCRIPTION
This includes the updated headers. It also includes changes to:
- Pubsub (adding new methods)
- Speech (adding streaming support)
- Client config json files (removing retry_codes_def)