### PR TITLE
Prevent errors on method calls that may be null

### DIFF
--- a/src/CallTrait.php
+++ b/src/CallTrait.php
@@ -27,7 +27,11 @@ trait CallTrait
      */
     public function __call($name, array $args)
     {
-        if (!isset($this->info()[$name])) {
+        $methods = (isset($this->magicMethods) && is_array($this->magicMethods))
+            ? $this->magicMethods
+            : [];
+
+        if (!isset($this->info()[$name]) && !in_array($name, $methods)) {
             trigger_error(sprintf(
                 'Call to undefined method %s::%s',
                 __CLASS__,
@@ -35,6 +39,8 @@ trait CallTrait
             ), E_USER_ERROR);
         }
 
-        return $this->info()[$name];
+        return (isset($this->info()[$name]))
+            ? $this->info()[$name]
+            : null;
     }
 }

--- a/src/NaturalLanguage/Annotation.php
+++ b/src/NaturalLanguage/Annotation.php
@@ -106,6 +106,16 @@ class Annotation
     use CallTrait;
 
     /**
+     * @var array
+     */
+    private $magicMethods = [
+        'sentences',
+        'tokens',
+        'entities',
+        'language',
+    ];
+
+    /**
      * @var array The annotation's metadata.
      */
     private $info;

--- a/src/Vision/Annotation/CropHint.php
+++ b/src/Vision/Annotation/CropHint.php
@@ -74,6 +74,15 @@ class CropHint extends AbstractFeature
     use CallTrait;
 
     /**
+     * @var array
+     */
+    private $magicMethods = [
+        'boundingPoly',
+        'confidence',
+        'importanceFraction',
+    ];
+
+    /**
      * @param array $info Crop Hint result
      */
     public function __construct(array $info)

--- a/src/Vision/Annotation/Document.php
+++ b/src/Vision/Annotation/Document.php
@@ -72,6 +72,14 @@ class Document extends AbstractFeature
     use CallTrait;
 
     /**
+     * @var array
+     */
+    private $magicMethods = [
+        'pages',
+        'text',
+    ];
+
+    /**
      * @param array $info Document Text Annotation response.
      */
     public function __construct(array $info)

--- a/src/Vision/Annotation/Entity.php
+++ b/src/Vision/Annotation/Entity.php
@@ -178,6 +178,21 @@ class Entity extends AbstractFeature
     use CallTrait;
 
     /**
+     * @var array
+     */
+    private $magicMethods = [
+        'mid',
+        'locale',
+        'description',
+        'score',
+        'confidence',
+        'topicality',
+        'boundingPoly',
+        'locations',
+        'properties',
+    ];
+
+    /**
      * Create an entity annotation result.
      *
      * This class is created internally by {@see Google\Cloud\Vision\Annotation} and is used to represent various

--- a/src/Vision/Annotation/Face.php
+++ b/src/Vision/Annotation/Face.php
@@ -43,7 +43,7 @@ use Google\Cloud\Vision\Annotation\Face\Landmarks;
  *
  *     Example:
  *     ```
- *     print_R($face->boundingPoly());
+ *     print_r($face->boundingPoly());
  *     ```
  *
  *     @return array
@@ -55,7 +55,7 @@ use Google\Cloud\Vision\Annotation\Face\Landmarks;
  *
  *     Example:
  *     ```
- *     print_R($face->fdBoundingPoly());
+ *     print_r($face->fdBoundingPoly());
  *     ```
  *
  *     @return array
@@ -68,7 +68,7 @@ use Google\Cloud\Vision\Annotation\Face\Landmarks;
  *
  *     Example:
  *     ```
- *     print_R($face->rollAngle());
+ *     print_r($face->rollAngle());
  *     ```
  *
  *     @return float
@@ -81,7 +81,7 @@ use Google\Cloud\Vision\Annotation\Face\Landmarks;
  *
  *     Example:
  *     ```
- *     print_R($face->panAngle());
+ *     print_r($face->panAngle());
  *     ```
  *
  *     @return float
@@ -94,7 +94,7 @@ use Google\Cloud\Vision\Annotation\Face\Landmarks;
  *
  *     Example:
  *     ```
- *     print_R($face->tiltAngle());
+ *     print_r($face->tiltAngle());
  *     ```
  *
  *     @return float
@@ -106,7 +106,7 @@ use Google\Cloud\Vision\Annotation\Face\Landmarks;
  *
  *     Example:
  *     ```
- *     print_R($face->detectionConfidence());
+ *     print_r($face->detectionConfidence());
  *     ```
  *
  *     @return float
@@ -118,7 +118,7 @@ use Google\Cloud\Vision\Annotation\Face\Landmarks;
  *
  *     Example:
  *     ```
- *     print_R($face->landmarkingConfidence());
+ *     print_r($face->landmarkingConfidence());
  *     ```
  *
  *     @return float
@@ -212,6 +212,26 @@ class Face extends AbstractFeature
 {
     use CallTrait;
     use LikelihoodTrait;
+
+    /**
+     * @var array
+     */
+    private $magicMethods = [
+        'boundingPoly',
+        'fdBoundingPoly',
+        'rollAngle',
+        'panAngle',
+        'tiltAngle',
+        'detectionConfidence',
+        'landmarkingConfidence',
+        'joyLikelihood',
+        'sorrowLikelihood',
+        'angerLikelihood',
+        'surpriseLikelihood',
+        'underExposedLikelihood',
+        'blurredLikelihood',
+        'headwearLikelihood',
+    ];
 
     /**
      * @var Landmarks

--- a/src/Vision/Annotation/SafeSearch.php
+++ b/src/Vision/Annotation/SafeSearch.php
@@ -94,6 +94,16 @@ class SafeSearch extends AbstractFeature
     use LikelihoodTrait;
 
     /**
+     * @var array
+     */
+    private $magicMethods = [
+        'adult',
+        'spoof',
+        'medical',
+        'violence',
+    ];
+
+    /**
      * Create a SafeSearch annotation result
      *
      * This class is instantiated internally and is used to represent the result of Cloud Vision's SafeSearch annotation

--- a/src/Vision/Annotation/Web/WebEntity.php
+++ b/src/Vision/Annotation/Web/WebEntity.php
@@ -76,6 +76,15 @@ class WebEntity extends AbstractFeature
     use CallTrait;
 
     /**
+     * @var array
+     */
+    private $magicMethods = [
+        'entityId',
+        'score',
+        'description'
+    ];
+
+    /**
      * @param array $info WebEntity info
      */
     public function __construct(array $info)

--- a/src/Vision/Annotation/Web/WebImage.php
+++ b/src/Vision/Annotation/Web/WebImage.php
@@ -66,6 +66,14 @@ class WebImage extends AbstractFeature
     use CallTrait;
 
     /**
+     * @var array
+     */
+    private $magicMethods = [
+        'url',
+        'score'
+    ];
+
+    /**
      * @param array $info The WebImage result
      */
     public function __construct(array $info)

--- a/src/Vision/Annotation/Web/WebPage.php
+++ b/src/Vision/Annotation/Web/WebPage.php
@@ -66,6 +66,14 @@ class WebPage extends AbstractFeature
     use CallTrait;
 
     /**
+     * @var array
+     */
+    private $magicMethods = [
+        'url',
+        'score'
+    ];
+
+    /**
      * @param array $info The WebPage result
      */
     public function __construct(array $info)

--- a/tests/unit/CallTraitTest.php
+++ b/tests/unit/CallTraitTest.php
@@ -40,11 +40,24 @@ class CallTraitTest extends \PHPUnit_Framework_TestCase
 
         $t->bar();
     }
+
+    public function testDefinedMagicMethods()
+    {
+        $t = new CallTraitStub(['method1' => 'bar', 'test' => 'foo']);
+
+        $this->assertEquals('bar', $t->method1());
+        $this->assertEquals('foo', $t->test());
+        $this->assertNull($t->method2());
+    }
 }
 
 class CallTraitStub
 {
     use CallTrait;
+
+    private $magicMethods = [
+        'method1', 'method2'
+    ];
 
     public function __construct(array $data)
     {


### PR DESCRIPTION
On classes that use `Google\Cloud\CallTrait` to provide magic methods, there is an implicit assumption that none of the expected members of `$info` are missing. If one is missing or malformed, a call to that member, which should succeed, will result in an error which in PHP versions prior to 7.0, cannot be caught.

I ran into this myself in testing, so this change scratches my own itch..

A class using CallTrait can optionally specify a private property called `$magicMethods`, which is an array of method names. Any call to these methods will NOT raise an error, regardless of whether the property exists in the `$info` array. CallTrait will return either the value, or `null` if the property doesn't exist.