### PR TITLE
Add GAPIC docs to docs site

### DIFF
--- a/dev/src/DocGenerator/Parser/CodeParser.php
+++ b/dev/src/DocGenerator/Parser/CodeParser.php
@@ -122,8 +122,11 @@ class CodeParser implements ParserInterface
             foreach ($parsedContents as &$part) {
                 if ($part instanceof Seetag) {
                     $reference = $part->getReference();
+
                     if (substr_compare($reference, 'Google\Cloud', 0, 12) === 0) {
                         $part = $this->buildLink($reference);
+                    } elseif ($this->hasExternalType(trim(str_replace('@see', '', $part)))) {
+                        $part = $this->buildExternalType(trim(str_replace('@see', '', $part)));
                     }
                 }
             }

--- a/dev/src/DocGenerator/Parser/CodeParser.php
+++ b/dev/src/DocGenerator/Parser/CodeParser.php
@@ -31,6 +31,7 @@ class CodeParser implements ParserInterface
     private $outputName;
     private $reflector;
     private $markdown;
+    private $externalTypes;
 
     public function __construct($path, $outputName, FileReflector $reflector)
     {
@@ -38,6 +39,7 @@ class CodeParser implements ParserInterface
         $this->outputName = $outputName;
         $this->reflector = $reflector;
         $this->markdown = \Parsedown::instance();
+        $this->externalTypes = json_decode(file_get_contents(__DIR__ .'/../../../../docs/external-classes.json'), true);
     }
 
     public function parse()
@@ -427,14 +429,10 @@ class CodeParser implements ParserInterface
     private function handleTypes($types)
     {
         foreach ($types as &$type) {
-            // object is a PHPDoc keyword so it is not capable of detecting the context
-            // https://github.com/phpDocumentor/ReflectionDocBlock/blob/2.0.4/src/phpDocumentor/Reflection/DocBlock/Type/Collection.php#L37
-            if ($type === 'Object') {
-                $type = '\Google\Cloud\Storage\Object';
-            }
-
             if (substr_compare($type, '\Google\Cloud', 0, 13) === 0) {
                 $type = $this->buildLink($type);
+            } elseif ($this->hasExternalType($type)) {
+                $type = $this->buildExternalType($type);
             }
 
             $matches = [];
@@ -449,6 +447,37 @@ class CodeParser implements ParserInterface
         }
 
         return $types;
+    }
+
+    private function hasExternalType($type)
+    {
+        $type = trim($type, '\\');
+        $types = array_filter($this->externalTypes, function ($external) use ($type) {
+            return (strpos($type, $external['name']) !== false);
+        });
+
+        if (count($types) === 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function buildExternalType($type)
+    {
+        $type = trim($type, '\\');
+        $types = array_values(array_filter($this->externalTypes, function ($external) use ($type) {
+            return (strpos($type, $external['name']) !== false);
+        }));
+
+        $external = $types[0];
+
+        $href = sprintf($external['uri'], str_replace($external['name'], '', $type));
+        return sprintf(
+            '<a href="%s" target="_blank">%s</a>',
+            $href,
+            $type
+        );
     }
 
     private function buildLink($content)

--- a/docs/external-classes.json
+++ b/docs/external-classes.json
@@ -1,0 +1,44 @@
+[{
+  "name": "Google\\Auth\\",
+  "uri": "https://github.com/google/google-auth-library-php/blob/master/src/%s.php"
+}, {
+  "name": "Google\\GAX\\",
+  "uri": "https://github.com/googleapis/gax-php/tree/master/src/%s.php"
+}, {
+  "name": "google\\iam\\v1\\",
+  "uri": "https://github.com/googleapis/proto-client-php/blob/master/src/iam/v1"
+}, {
+  "name": "google\\devtools\\clouderrorreporting\\v1beta1\\",
+  "uri": "https://github.com/googleapis/proto-client-php/tree/master/src/errorreporting/v1beta1"
+}, {
+  "name": "google\\cloud\\language\\v1\\",
+  "uri": "https://github.com/googleapis/proto-client-php/tree/master/src/language/v1"
+}, {
+  "name": "google\\logging\\v2\\",
+  "uri": "https://github.com/googleapis/proto-client-php/tree/master/src/logging/v2"
+}, {
+  "name": "google\\monitoring\\v3\\",
+  "uri": "https://github.com/googleapis/proto-client-php/tree/master/src/monitoring/v3"
+}, {
+  "name": "google\\pubsub\\v1\\",
+  "uri": "https://github.com/googleapis/proto-client-php/blob/master/src/pubsub/v1/pubsub.php"
+}, {
+  "name": "google\\spanner\\admin\\database\\v1\\",
+  "name": "https://github.com/googleapis/proto-client-php/blob/master/src/spanner/admin/database/v1/spanner_database_admin.php"
+}, {
+  "name": "google\\spanner\\admin\\instance\\v1\\",
+  "uri": "https://github.com/googleapis/proto-client-php/blob/master/src/spanner/admin/instance/v1/spanner_instance_admin.php"
+}, {
+  "name": "google\\spanner\\v1\\",
+  "uri": "https://github.com/googleapis/proto-client-php/blob/master/src/spanner/v1"
+}, {
+  "name": "google\\cloud\\s[eech\\v1beta1\\",
+  "uri": "https://github.com/googleapis/proto-client-php/blob/master/src/speech/v1beta1/cloud_speech.php"
+}, {
+  "name": "google\\devtools\\cloudtrace\\v1\\",
+  "uri": "https://github.com/googleapis/proto-client-php/blob/master/src/trace/v1/trace.php"
+}, {
+  "name": "google\\cloud\\vision\\v1\\",
+  "uri": "https://github.com/googleapis/proto-client-php/tree/master/src/vision/v1"
+}]
+

--- a/docs/external-classes.json
+++ b/docs/external-classes.json
@@ -32,7 +32,7 @@
   "name": "google\\spanner\\v1\\",
   "uri": "https://github.com/googleapis/proto-client-php/blob/master/src/spanner/v1"
 }, {
-  "name": "google\\cloud\\s[eech\\v1beta1\\",
+  "name": "google\\cloud\\speech\\v1beta1\\",
   "uri": "https://github.com/googleapis/proto-client-php/blob/master/src/speech/v1beta1/cloud_speech.php"
 }, {
   "name": "google\\devtools\\cloudtrace\\v1\\",
@@ -41,7 +41,43 @@
   "name": "google\\cloud\\vision\\v1\\",
   "uri": "https://github.com/googleapis/proto-client-php/tree/master/src/vision/v1"
 }, {
+  "name": "google\\longrunning\\",
+  "uri": "https://github.com/googleapis/gax-php/blob/master/src/generated/operations.php"
+}, {
   "name": "MonitoredResource",
   "uri": "https://github.com/googleapis/gax-php/blob/master/src/generated/monitored_resource.php"
+}, {
+  "name": "ServiceContextFilter",
+  "uri": "https://github.com/googleapis/proto-client-php/blob/master/src/errorreporting/v1beta1/error_stats_service.php#L1985"
+}, {
+  "name": "QueryTimeRange",
+  "uri": "https://github.com/googleapis/proto-client-php/blob/master/src/errorreporting/v1beta1/error_stats_service.php#L1915"
+}, {
+  "name": "Duration",
+  "uri": "https://github.com/googleapis/gax-php/blob/master/src/generated/well-known-types/duration.php"
+}, {
+  "name": "TimedCountAlignment",
+  "uri": "https://github.com/googleapis/proto-client-php/blob/master/src/errorreporting/v1beta1/error_stats_service.php#L8"
+}, {
+  "name": "Timestamp",
+  "uri": "https://github.com/googleapis/gax-php/blob/master/src/generated/well-known-types/timestamp.php"
+}, {
+  "name": "ErrorGroupOrder",
+  "uri": "https://github.com/googleapis/proto-client-php/blob/master/src/errorreporting/v1beta1/error_stats_service.php#L16"
+}, {
+  "name": "TimeInterval",
+  "uri": "https://github.com/googleapis/proto-client-php/blob/master/src/monitoring/v3/common.php#L270"
+}, {
+  "name": "google\\api\\MetricDescriptor",
+  "uri": "https://github.com/googleapis/gax-php/blob/master/src/generated/metric.php#L29"
+}, {
+  "name": "google\\api\\MonitoredResourceDescriptor",
+  "uri": "https://github.com/googleapis/gax-php/blob/master/src/generated/monitored_resource.php#L8"
+}, {
+  "name": "Aggregation",
+  "uri": "https://github.com/googleapis/proto-client-php/blob/master/src/monitoring/v3/common.php#L429"
+}, {
+  "name": "PushConfig",
+  "uri": "https://github.com/googleapis/proto-client-php/blob/master/src/pubsub/v1/pubsub.php#L1827"
 }]
 

--- a/docs/external-classes.json
+++ b/docs/external-classes.json
@@ -40,5 +40,8 @@
 }, {
   "name": "google\\cloud\\vision\\v1\\",
   "uri": "https://github.com/googleapis/proto-client-php/tree/master/src/vision/v1"
+}, {
+  "name": "MonitoredResource",
+  "uri": "https://github.com/googleapis/gax-php/blob/master/src/generated/monitored_resource.php"
 }]
 

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -94,6 +94,24 @@
             }]
         },
         {
+            "title": "Error Reporting",
+            "type": "errorreporting/readme",
+            "nav": [{
+                "title": "v1beta1",
+                "type": "errorreporting/v1beta1/readme",
+                "nav": [{
+                    "title": "ErrorGroupServiceClient",
+                    "type": "errorreporting/v1beta1/errorgroupserviceclient"
+                }, {
+                    "title": "ErrorStatsServiceClient",
+                    "type": "errorreporting/v1beta1/errorstatsserviceclient"
+                }, {
+                    "title": "ReportErrorsServiceClient",
+                    "type": "errorreporting/v1beta1/reporterrorsserviceclient"
+                }]
+            }]
+        },
+        {
             "title": "Logging",
             "type": "logging/loggingclient",
             "nav": [{
@@ -111,6 +129,34 @@
             },{
                 "title": "Sink",
                 "type": "logging/sink"
+            }, {
+                "title": "v2",
+                "type": "logging/v2/readme",
+                "nav": [{
+                    "title": "ConfigServiceV2Client",
+                    "type": "logging/v2/configservicev2client"
+                }, {
+                    "title": "LoggingServiceV2Client",
+                    "type": "logging/v2/loggingservicev2client"
+                }, {
+                    "title": "MetricsServiceV2Client",
+                    "type": "logging/v2/metricsservicev2client"
+                }]
+            }]
+        },
+        {
+            "title": "Monitoring",
+            "type": "monitoring/readme",
+            "nav": [{
+                "title": "v3",
+                "type": "monitoring/v3/readme",
+                "nav": [{
+                    "title": "GroupServiceClient",
+                    "type": "monitoring/v3/groupserviceclient"
+                }, {
+                    "title": "MetricServiceClient",
+                    "type": "monitoring/v3/metricserviceclient"
+                }]
             }]
         },
         {
@@ -135,6 +181,16 @@
             {
                 "title": "Topic",
                 "type": "pubsub/topic"
+            }, {
+                "title": "v1",
+                "type": "pubsub/v1/readme",
+                "nav": [{
+                    "title": "PublisherClient",
+                    "type": "pubsub/v1/publisherclient"
+                }, {
+                    "title": "SubscriberClient",
+                    "type": "pubsub/v1/subscriberclient"
+                }]
             }]
         },
         {
@@ -143,6 +199,13 @@
             "nav": [{
                 "title": "Operation",
                 "type": "speech/operation"
+            }, {
+                "title": "v1beta1",
+                "type": "speech/v1beta1/readme",
+                "nav": [{
+                    "title": "SpeechClient",
+                    "type": "speech/v1beta1/speechclient"
+                }]
             }]
         },
         {

--- a/src/ErrorReporting/README.md
+++ b/src/ErrorReporting/README.md
@@ -1,0 +1,5 @@
+# Stackdriver Error Reporting
+
+Stackdriver Error Reporting counts, analyzes and aggregates the crashes in your running cloud services.
+
+For more information, see [cloud.google.com](https://cloud.google.com/error-reporting/).

--- a/src/ErrorReporting/V1beta1/README.md
+++ b/src/ErrorReporting/V1beta1/README.md
@@ -1,0 +1,5 @@
+# Stackdriver Error Reporting
+
+Stackdriver Error Reporting counts, analyzes and aggregates the crashes in your running cloud services.
+
+For more information, see [cloud.google.com](https://cloud.google.com/error-reporting/).

--- a/src/Logging/V2/README.md
+++ b/src/Logging/V2/README.md
@@ -1,0 +1,5 @@
+# Stackdriver Logging
+
+Stackdriver Logging allows you to store, search, analyze, monitor, and alert on log data and events from Google Cloud Platform and Amazon Web Services (AWS).
+
+For more information, see [cloud.google.com](https://cloud.google.com/logging/).

--- a/src/Monitoring/README.md
+++ b/src/Monitoring/README.md
@@ -1,0 +1,5 @@
+# Stackdriver Monitoring
+
+Stackdriver Monitoring provides visibility into the performance, uptime, and overall health of cloud-powered applications.
+
+For more information, see [cloud.google.com](https://cloud.google.com/monitoring/).

--- a/src/Monitoring/V3/README.md
+++ b/src/Monitoring/V3/README.md
@@ -1,0 +1,5 @@
+# Stackdriver Monitoring
+
+Stackdriver Monitoring provides visibility into the performance, uptime, and overall health of cloud-powered applications.
+
+For more information, see [cloud.google.com](https://cloud.google.com/monitoring/).

--- a/src/PubSub/V1/README.md
+++ b/src/PubSub/V1/README.md
@@ -1,0 +1,5 @@
+# Cloud Pub\Sub
+
+Cloud Pub/Sub is a fully-managed real-time messaging service that allows you to send and receive messages between independent applications.
+
+For more information, see [cloud.google.com](https://cloud.google.com/pubsub/).

--- a/src/Speech/V1beta1/README.md
+++ b/src/Speech/V1beta1/README.md
@@ -1,0 +1,5 @@
+# Cloud Speech
+
+Google Cloud Speech API enables developers to convert audio to text by applying powerful neural network models in an easy to use API.
+
+For more information, see [cloud.google.com](https://cloud.google.com/speech/).


### PR DESCRIPTION
This change adds the generated GAPIC clients to the Google Cloud PHP docs site. It takes advantage of GoogleCloudPlatform/gcloud-common#213, so we'll need to rebuild the docs site before this is merged.

* Add all generated clients to the table of contents.
* Add simple landing pages (README.md) in empty folders.
* Modify doc generator to recognize external types specified in `docs/external-classes.json` and transform references into external links.

For an example, see https://jdpedrie.github.io/gcloud-php/#/docs/master/servicebuilder.

This closes #99.