### PR TITLE
Ignore private methods on snippet test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,6 @@ script:
 after_success:
     - bash <(curl -s https://codecov.io/bash)
     - ./dev/sh/push-docs
+
+after_failure:
+    - echo "SNIPPET COVERAGE REPORT" && cat ./build/snippets-uncovered.json

--- a/dev/src/Snippet/Parser/Parser.php
+++ b/dev/src/Snippet/Parser/Parser.php
@@ -176,6 +176,10 @@ class Parser
             $method = new ReflectionMethod($class, $method);
         }
 
+        if (!$method->isPublic()) {
+            return [];
+        }
+
         $doc = new DocBlock($method);
 
         $parent = $method->getDeclaringClass();

--- a/tests/snippets/bootstrap.php
+++ b/tests/snippets/bootstrap.php
@@ -30,6 +30,7 @@ register_shutdown_function(function () {
 
     if (!empty($uncovered)) {
         echo sprintf("\033[31mNOTICE: %s uncovered snippets! See build/snippets-uncovered.json for a report.\n", count($uncovered));
+        exit(1);
     }
 });
 


### PR DESCRIPTION
Also, if snippets are uncovered, the suite will fail.