### PR TITLE
Prepare v0.23.0

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -7,6 +7,7 @@
     "matchPartialServiceId": true,
     "markdown": "php",
     "versions": [
+        "v0.23.0",
         "v0.22.0",
         "v0.21.1",
         "v0.21.0",

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -48,7 +48,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class ServiceBuilder
 {
-    const VERSION = '0.22.0';
+    const VERSION = '0.23.0';
 
     /**
      * @var array Configuration options to be used between clients.


### PR DESCRIPTION
Wait for #382 before merging.

----

## Google Cloud PHP v0.23.0

### Cloud Pub/Sub

* :heavy_exclamation_mark: **BREAKING CHANGE** The return type of
  `Google\Cloud\PubSub\Subscription::pull()` has changed from
  `Generator<Google\Cloud\PubSub\Message>` to `Google\Cloud\PubSub\Message[]`.
  (#375)

### Cloud Vision

* Cloud Vision in Google Cloud PHP is now considered beta! That means that while
  we're not quite ready to call it done, we're getting a lot closer. You should
  expect more stability and fewer breaking changes between now and our 1.0
  release. (#387)

### Various and Sundry

* Fixed a bug where application identifying headers were not sent when using an
  API key rather than a service account over the REST transport. (#378)