### PR TITLE
Replace generators with an iterator class

### DIFF
--- a/src/BigQuery/Job.php
+++ b/src/BigQuery/Job.php
@@ -134,7 +134,7 @@ class Job
      * @param array $options [optional] {
      *     Configuration options.
      *
-     *     @type int $maxResults Maximum number of results to read.
+     *     @type int $maxResults Maximum number of results to read per page.
      *     @type int $startIndex Zero-based index of the starting row.
      *     @type int $timeoutMs How long to wait for the query to complete, in
      *           milliseconds. **Defaults to** `10000` milliseconds (10 seconds).

--- a/src/Core/Iterator/ItemIterator.php
+++ b/src/Core/Iterator/ItemIterator.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Iterator;
+
+/**
+ * Iterates over a set of items.
+ */
+class ItemIterator implements \Iterator
+{
+    use ItemIteratorTrait;
+}

--- a/src/Core/Iterator/ItemIteratorTrait.php
+++ b/src/Core/Iterator/ItemIteratorTrait.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Iterator;
+
+/**
+ * This trait fulfills the
+ * [\Iterator](http://php.net/manual/en/class.iterator.php) interface and
+ * returns results from a paged set one at a time.
+ */
+trait ItemIteratorTrait
+{
+    /**
+     * @var \Iterator
+     */
+    private $pageIterator;
+
+    /**
+     * @var int
+     */
+    private $pageIndex = 0;
+
+    /**
+     * @var int
+     */
+    private $position = 0;
+
+    /**
+     * @param \Iterator $pageIterator
+     */
+    public function __construct(\Iterator $pageIterator)
+    {
+        $this->pageIterator = $pageIterator;
+    }
+
+    /**
+     * Fetch the token used to get the next set of results.
+     *
+     * @return string|null
+     */
+    public function nextResultToken()
+    {
+        return $this->pageIterator->nextResultToken();
+    }
+
+    /**
+     * Iterate over the results on a per page basis.
+     *
+     * @return \Iterator
+     */
+    public function iterateByPage()
+    {
+        return $this->pageIterator;
+    }
+
+    /**
+     * Rewind the iterator.
+     *
+     * @return null
+     */
+    public function rewind()
+    {
+        $this->pageIndex = 0;
+        $this->position = 0;
+        $this->pageIterator->rewind();
+    }
+
+    /**
+     * Get the current item.
+     *
+     * @return array|null
+     */
+    public function current()
+    {
+        $page = $this->pageIterator->current();
+
+        return isset($page[$this->pageIndex])
+            ? $page[$this->pageIndex]
+            : null;
+    }
+
+    /**
+     * Get the key current item's key.
+     *
+     * @return int
+     */
+    public function key()
+    {
+        return $this->position;
+    }
+
+    /**
+     * Advances to the next item.
+     *
+     * @return null
+     */
+    public function next()
+    {
+        $this->pageIndex++;
+        $this->position++;
+
+        if (count($this->pageIterator->current()) <= $this->pageIndex && $this->pageIterator->nextResultToken()) {
+            $this->pageIterator->next();
+            $this->pageIndex = 0;
+        }
+    }
+
+    /**
+     * Determines if the current position is valid.
+     *
+     * @return bool
+     */
+    public function valid()
+    {
+        if (isset($this->pageIterator->current()[$this->pageIndex])) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Core/Iterator/PageIterator.php
+++ b/src/Core/Iterator/PageIterator.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Iterator;
+
+/**
+ * Iterates over a set of pages.
+ */
+class PageIterator implements \Iterator
+{
+    use PageIteratorTrait;
+}

--- a/src/Core/Iterator/PageIteratorTrait.php
+++ b/src/Core/Iterator/PageIteratorTrait.php
@@ -1,0 +1,314 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Iterator;
+
+use Google\Cloud\Core\ArrayTrait;
+
+/**
+ * This trait fulfills the
+ * [\Iterator](http://php.net/manual/en/class.iterator.php) interface and
+ * returns results as a page of items.
+ */
+trait PageIteratorTrait
+{
+    use ArrayTrait;
+
+    /**
+     * @var array|null
+     */
+    private $page;
+
+    /**
+     * @var callable
+     */
+    private $resultMapper;
+
+    /**
+     * @var callable
+     */
+    private $call;
+
+    /**
+     * @var array
+     */
+    private $callOptions;
+
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * @var int
+     */
+    private $position = 0;
+
+    /**
+     * @var int
+     */
+    private $itemCount = 0;
+
+    /**
+     * @var array
+     */
+    private $resultTokenPath;
+
+    /**
+     * @var array
+     */
+    private $nextResultTokenPath;
+
+    /**
+     * @var array
+     */
+    private $itemsPath;
+
+    /**
+     * @var string|null
+     */
+    private $initialResultToken;
+
+    /**
+     * @param callable $resultMapper Maps a result.
+     * @param callable $call The call to execute.
+     * @param array $callOptions Options to use with the call.
+     * @param array $config [optional] {
+     *     Configuration options.
+     *
+     *     @type string $itemsKey The key for the items to iterate over from the
+     *           response. **Defaults to** `"items"`.
+     *     @type string $nextResultTokenKey The key for the next result token in
+     *           the response. **Defaults to** `"nextPageToken"`.
+     *     @type string $resultTokenKey The key for the results token set in the
+     *           request. **Defaults too** `"pageToken"`.
+     *     @type array $firstPage The first page of results. If set, this data
+     *           will be used for the first page of results instead of making
+     *           a network request.
+     *     @type callable $setNextResultTokenCondition If this condition passes
+     *           then it should be considered safe to set the token to get the
+     *           next set of results.
+     *     @type int $resultLimit Limit the number of results returned in total.
+     *           **Defaults to** `0` (return all results).
+     * }
+     */
+    public function __construct(
+        callable $resultMapper,
+        callable $call,
+        array $callOptions,
+        array $config = []
+    ) {
+        $this->resultMapper = $resultMapper;
+        $this->call = $call;
+        $this->config = $config + [
+            'itemsKey' => 'items',
+            'nextResultTokenKey' => 'nextPageToken',
+            'resultTokenKey' => 'pageToken',
+            'firstPage' => null,
+            'resultLimit' => 0,
+            'setNextResultTokenCondition' => function () {
+                return true;
+            }
+        ];
+        $this->callOptions = $callOptions;
+        $this->resultTokenPath = explode('.', $this->config['resultTokenKey']);
+        $this->nextResultTokenPath = explode('.', $this->config['nextResultTokenKey']);
+        $this->itemsPath = explode('.', $this->config['itemsKey']);
+        $this->initialResultToken = $this->nextResultToken();
+    }
+
+    /**
+     * Fetch the token used to get the next set of results.
+     *
+     * @return string|null
+     */
+    public function nextResultToken()
+    {
+        return $this->get($this->resultTokenPath, $this->callOptions);
+    }
+
+    /**
+     * Rewind the iterator.
+     *
+     * @return null
+     */
+    public function rewind()
+    {
+        $this->itemCount = 0;
+        $this->position = 0;
+
+        if ($this->config['firstPage']) {
+            list($this->page, $shouldContinue) = $this->mapResults($this->config['firstPage']);
+            $nextResultToken = $this->determineNextResultToken($this->page, $shouldContinue);
+        } else {
+            $this->page = null;
+            $nextResultToken = $this->initialResultToken;
+        }
+
+        if ($nextResultToken) {
+            $this->set($this->resultTokenPath, $this->callOptions, $nextResultToken);
+        }
+    }
+
+    /**
+     * Get the current page.
+     *
+     * @return array|null
+     */
+    public function current()
+    {
+        if (!$this->page) {
+            $this->page = $this->executeCall();
+        }
+
+        return $this->get($this->itemsPath, $this->page);
+    }
+
+    /**
+     * Get the key current page's key.
+     *
+     * @return int
+     */
+    public function key()
+    {
+        return $this->position;
+    }
+
+    /**
+     * Advances to the next page.
+     *
+     * @return null
+     */
+    public function next()
+    {
+        $this->position++;
+
+        if ($this->nextResultToken()) {
+            $this->page = $this->executeCall();
+        } else {
+            $this->page = null;
+        }
+    }
+
+    /**
+     * Determines if the current position is valid.
+     *
+     * @return bool
+     */
+    public function valid()
+    {
+        if (!$this->page && $this->position) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Executes the provided call to get a set of results.
+     *
+     * @return array
+     */
+    private function executeCall()
+    {
+        $call = $this->call;
+        list($results, $shouldContinue) = $this->mapResults(
+            $call($this->callOptions)
+        );
+
+        $this->set(
+            $this->resultTokenPath,
+            $this->callOptions,
+            $this->determineNextResultToken($results, $shouldContinue)
+        );
+
+        return $results;
+    }
+
+    /**
+     * @param array $results
+     * @return array
+     */
+    private function mapResults(array $results)
+    {
+        $items = $this->get($this->itemsPath, $results);
+        $resultMapper = $this->resultMapper;
+        $shouldContinue = true;
+
+        if ($items) {
+            foreach ($items as $key => $item) {
+                $items[$key] = $resultMapper($item);
+                $this->itemCount++;
+
+                if ($this->config['resultLimit'] && $this->config['resultLimit'] <= $this->itemCount) {
+                    $items = array_slice($items, 0, $key + 1);
+                    $shouldContinue = false;
+                    break;
+                }
+            }
+
+            $this->set($this->itemsPath, $results, $items);
+        }
+
+        return [$results, $shouldContinue];
+    }
+
+    /**
+     * @param array $results
+     * @param bool $shouldContinue
+     * @return null
+     */
+    private function determineNextResultToken(array $results, $shouldContinue = true)
+    {
+        return $shouldContinue && $this->config['setNextResultTokenCondition']($results)
+            ? $this->get($this->nextResultTokenPath, $results)
+            : null;
+    }
+
+    /**
+     * @param array $path
+     * @param array $array
+     * @return mixed
+     */
+    private function get(array $path, array $array)
+    {
+        $temp = &$array;
+
+        foreach ($path as $key) {
+            $temp = &$temp[$key];
+        }
+
+        return $temp;
+    }
+
+    /**
+     * @param array $path
+     * @param array $array
+     * @param mixed $value
+     * @return null
+     */
+    private function set(array $path, array &$array, $value)
+    {
+        $temp = &$array;
+
+        foreach ($path as $key) {
+            $temp = &$temp[$key];
+        }
+
+        $temp = $value;
+    }
+}

--- a/src/Datastore/DatastoreClient.php
+++ b/src/Datastore/DatastoreClient.php
@@ -952,7 +952,7 @@ class DatastoreClient
      *     @type string $readConsistency See
      *           [ReadConsistency](https://cloud.google.com/datastore/reference/rest/v1/ReadOptions#ReadConsistency).
      * }
-     * @return \Generator<Google\Cloud\Datastore\Entity>
+     * @return EntityIterator<Google\Cloud\Datastore\Entity>
      */
     public function runQuery(QueryInterface $query, array $options = [])
     {

--- a/src/Datastore/EntityIterator.php
+++ b/src/Datastore/EntityIterator.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Datastore;
+
+use Google\Cloud\Core\Iterator\ItemIteratorTrait;
+
+/**
+ * Iterates over a set of {@see Google\Cloud\Datastore\Entity} items.
+ */
+class EntityIterator implements \Iterator
+{
+    use ItemIteratorTrait;
+
+    /**
+     * The state of the query after the current batch.
+     *
+     * @codingStandardsIgnoreStart
+     * @see https://cloud.google.com/datastore/docs/reference/rest/v1/projects/runQuery#MoreResultsType MoreResultsType Documentation
+     * @codingStandardsIgnoreEnd
+     *
+     * @return string|null
+     */
+    public function moreResultsType()
+    {
+        return $this->pageIterator->moreResultsType();
+    }
+}

--- a/src/Datastore/EntityPageIterator.php
+++ b/src/Datastore/EntityPageIterator.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Datastore;
+
+use Google\Cloud\Core\Iterator\PageIteratorTrait;
+
+/**
+ * Iterates over a set of pages containing {@see Google\Cloud\Datastore\Entity}
+ * items.
+ */
+class EntityPageIterator implements \Iterator
+{
+    use PageIteratorTrait;
+
+    /**
+     * @var string|null
+     */
+    private $moreResultsType;
+
+    /**
+     * The state of the query after the current batch.
+     *
+     * @codingStandardsIgnoreStart
+     * @see https://cloud.google.com/datastore/docs/reference/rest/v1/projects/runQuery#MoreResultsType MoreResultsType Documentation
+     * @codingStandardsIgnoreEnd
+     *
+     * @return string|null
+     */
+    public function moreResultsType()
+    {
+        return $this->moreResultsType;
+    }
+
+    /**
+     * Get the current page.
+     *
+     * @return array|null
+     */
+    public function current()
+    {
+        if (!$this->page) {
+            $this->page = $this->executeCall();
+        }
+
+        $this->moreResultsType = isset($this->page['batch']['moreResults'])
+            ? $this->page['batch']['moreResults']
+            : null;
+
+        return $this->get($this->itemsPath, $this->page);
+    }
+}

--- a/src/Datastore/Transaction.php
+++ b/src/Datastore/Transaction.php
@@ -437,7 +437,7 @@ class Transaction
      *           Must be a subclass of {@see Google\Cloud\Datastore\Entity}.
      *           If not set, {@see Google\Cloud\Datastore\Entity} will be used.
      * }
-     * @return \Generator<Google\Cloud\Datastore\Entity>
+     * @return EntityIterator<Google\Cloud\Datastore\Entity>
      */
     public function runQuery(QueryInterface $query, array $options = [])
     {

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -123,7 +123,7 @@ class ServiceBuilder
     /**
      * Google Cloud Datastore is a highly-scalable NoSQL database for your
      * applications. Find more information at the
-     * Google Cloud Datastore docs](https://cloud.google.com/datastore/docs/).
+     * [Google Cloud Datastore docs](https://cloud.google.com/datastore/docs/).
      *
      * Example:
      * ```

--- a/src/Storage/Bucket.php
+++ b/src/Storage/Bucket.php
@@ -458,7 +458,7 @@ class Bucket
      *     @type string $fields Selector which will cause the response to only
      *           return the specified fields.
      * }
-     * @return ObjectsIterator<Google\Cloud\Storage\StorageObject>
+     * @return ObjectIterator<Google\Cloud\Storage\StorageObject>
      */
     public function objects(array $options = [])
     {

--- a/src/Storage/ObjectIterator.php
+++ b/src/Storage/ObjectIterator.php
@@ -20,7 +20,7 @@ namespace Google\Cloud\Storage;
 use Google\Cloud\Core\Iterator\ItemIteratorTrait;
 
 /**
- * Iterates over a set of {@see Google\Cloud\Storage\Object} items.
+ * Iterates over a set of {@see Google\Cloud\Storage\StorageObject} items.
  */
 class ObjectIterator implements \Iterator
 {

--- a/src/Storage/ObjectIterator.php
+++ b/src/Storage/ObjectIterator.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage;
+
+use Google\Cloud\Core\Iterator\ItemIteratorTrait;
+
+/**
+ * Iterates over a set of {@see Google\Cloud\Storage\Object} items.
+ */
+class ObjectIterator implements \Iterator
+{
+    use ItemIteratorTrait;
+
+    /**
+     * Gets a list of prefixes of objects matching-but-not-listed up to and
+     * including the requested delimiter.
+     *
+     * @return array
+     */
+    public function prefixes()
+    {
+        return $this->pageIterator->prefixes();
+    }
+}

--- a/src/Storage/ObjectPageIterator.php
+++ b/src/Storage/ObjectPageIterator.php
@@ -20,8 +20,8 @@ namespace Google\Cloud\Storage;
 use Google\Cloud\Core\Iterator\PageIteratorTrait;
 
 /**
- * Iterates over a set of pages containing {@see Google\Cloud\Storage\Object}
- * items.
+ * Iterates over a set of pages containing
+ * {@see Google\Cloud\Storage\StorageObject} items.
  */
 class ObjectPageIterator implements \Iterator
 {

--- a/src/Storage/ObjectPageIterator.php
+++ b/src/Storage/ObjectPageIterator.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage;
+
+use Google\Cloud\Core\Iterator\PageIteratorTrait;
+
+/**
+ * Iterates over a set of pages containing {@see Google\Cloud\Storage\Object}
+ * items.
+ */
+class ObjectPageIterator implements \Iterator
+{
+    use PageIteratorTrait;
+
+    /**
+     * @var array
+     */
+    private $prefixes = [];
+
+    /**
+     * Gets a list of prefixes of objects matching-but-not-listed up to and
+     * including the requested delimiter.
+     *
+     * @return array
+     */
+    public function prefixes()
+    {
+        return $this->prefixes;
+    }
+
+    /**
+     * Get the current page.
+     *
+     * @return array|null
+     */
+    public function current()
+    {
+        if (!$this->page) {
+            $this->page = $this->executeCall();
+        }
+
+        if (isset($this->page['prefixes'])) {
+            $this->updatePrefixes();
+        }
+
+        return $this->get($this->itemsPath, $this->page);
+    }
+
+    /**
+     * Get the current page.
+     *
+     * @return array
+     */
+    private function updatePrefixes()
+    {
+        foreach ($this->page['prefixes'] as $prefix) {
+            if (!in_array($prefix, $this->prefixes)) {
+                $this->prefixes[] = $prefix;
+            }
+        }
+    }
+}

--- a/src/Storage/StreamWrapper.php
+++ b/src/Storage/StreamWrapper.php
@@ -71,9 +71,9 @@ class StreamWrapper
     private static $clients = [];
 
     /**
-     * @var \Generator Used for iterating through a directory
+     * @var ObjectsItemIterator Used for iterating through a directory
      */
-    private $directoryGenerator;
+    private $directoryIterator;
 
     /**
      * Ensure we close the stream when this StreamWrapper is destroyed.
@@ -305,9 +305,9 @@ class StreamWrapper
      */
     public function dir_readdir()
     {
-        $object = $this->directoryGenerator->current();
+        $object = $this->directoryIterator->current();
         if ($object) {
-            $this->directoryGenerator->next();
+            $this->directoryIterator->next();
             return $object->name();
         } else {
             return false;
@@ -322,7 +322,7 @@ class StreamWrapper
     public function dir_rewinddir()
     {
         try {
-            $this->directoryGenerator = $this->bucket->objects([
+            $this->directoryIterator = $this->bucket->objects([
                 'prefix' => $this->file,
                 'fields' => 'items/name,nextPageToken'
             ]);
@@ -390,7 +390,7 @@ class StreamWrapper
         $destinationPath = substr($url['path'], 1);
 
         $this->dir_opendir($from, []);
-        foreach ($this->directoryGenerator as $file) {
+        foreach ($this->directoryIterator as $file) {
             $name = $file->name();
             $newPath = str_replace($this->file, $destinationPath, $name);
 

--- a/tests/snippets/BigQuery/BigQueryClientTest.php
+++ b/tests/snippets/BigQuery/BigQueryClientTest.php
@@ -26,8 +26,9 @@ use Google\Cloud\BigQuery\Connection\ConnectionInterface;
 use Google\Cloud\BigQuery\Dataset;
 use Google\Cloud\BigQuery\Job;
 use Google\Cloud\BigQuery\QueryResults;
-use Google\Cloud\Dev\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Int64;
+use Google\Cloud\Core\Iterator\ItemIterator;
+use Google\Cloud\Dev\Snippet\SnippetTestCase;
 use Prophecy\Argument;
 
 /**
@@ -232,7 +233,7 @@ class BigQueryClientTest extends SnippetTestCase
         $this->client->setConnection($this->connection->reveal());
         $res = $snippet->invoke('jobs');
 
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
         $this->assertEquals('job', trim($res->output()));
     }
 
@@ -264,7 +265,7 @@ class BigQueryClientTest extends SnippetTestCase
         $this->client->setConnection($this->connection->reveal());
         $res = $snippet->invoke('datasets');
 
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
         $this->assertEquals('dataset', trim($res->output()));
     }
 

--- a/tests/snippets/BigQuery/DatasetTest.php
+++ b/tests/snippets/BigQuery/DatasetTest.php
@@ -21,6 +21,7 @@ use Google\Cloud\BigQuery\Connection\ConnectionInterface;
 use Google\Cloud\BigQuery\Dataset;
 use Google\Cloud\BigQuery\Table;
 use Google\Cloud\BigQuery\ValueMapper;
+use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Dev\Snippet\SnippetTestCase;
 use Prophecy\Argument;
 
@@ -116,7 +117,7 @@ class DatasetTest extends SnippetTestCase
         $snippet->addLocal('dataset', $dataset);
         $res = $snippet->invoke('tables');
 
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
         $this->assertEquals('table', trim($res->output()));
     }
 

--- a/tests/snippets/BigQuery/TableTest.php
+++ b/tests/snippets/BigQuery/TableTest.php
@@ -23,9 +23,10 @@ use Google\Cloud\BigQuery\InsertResponse;
 use Google\Cloud\BigQuery\Job;
 use Google\Cloud\BigQuery\Table;
 use Google\Cloud\BigQuery\ValueMapper;
+use Google\Cloud\Core\Iterator\ItemIterator;
+use Google\Cloud\Core\Upload\MultipartUploader;
 use Google\Cloud\Dev\Snippet\SnippetTestCase;
 use Google\Cloud\Storage\Connection\ConnectionInterface as StorageConnectionInterface;
-use Google\Cloud\Core\Upload\MultipartUploader;
 use Prophecy\Argument;
 
 /**
@@ -130,7 +131,7 @@ class TableTest extends SnippetTestCase
         $this->table->setConnection($this->connection->reveal());
 
         $res = $snippet->invoke('rows');
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
         $this->assertEquals('abcd' . PHP_EOL, $res->output());
     }
 

--- a/tests/snippets/Datastore/Query/GqlQueryTest.php
+++ b/tests/snippets/Datastore/Query/GqlQueryTest.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Tests\Snippets\Datastore\Query;
 use Google\Cloud\Datastore\Connection\ConnectionInterface;
 use Google\Cloud\Datastore\DatastoreClient;
 use Google\Cloud\Datastore\EntityMapper;
+use Google\Cloud\Datastore\EntityIterator;
 use Google\Cloud\Datastore\Query\GqlQuery;
 use Google\Cloud\Dev\Snippet\SnippetTestCase;
 use Prophecy\Argument;
@@ -81,7 +82,7 @@ class GqlQueryTest extends SnippetTestCase
 
         $res = $snippet->invoke(['query', 'res']);
         $this->assertEquals('Google', $res->output());
-        $this->assertInstanceOf(\Generator::class, $res->returnVal()[1]);
+        $this->assertInstanceOf(EntityIterator::class, $res->returnVal()[1]);
         $this->assertTrue(array_key_exists('namedBindings', $res->returnVal()[0]->queryObject()));
     }
 

--- a/tests/snippets/Datastore/Query/QueryTest.php
+++ b/tests/snippets/Datastore/Query/QueryTest.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Tests\Snippets\Datastore\Query;
 
 use Google\Cloud\Datastore\Connection\ConnectionInterface;
 use Google\Cloud\Datastore\DatastoreClient;
+use Google\Cloud\Datastore\EntityIterator;
 use Google\Cloud\Datastore\EntityMapper;
 use Google\Cloud\Datastore\Key;
 use Google\Cloud\Datastore\Query\Query;
@@ -88,7 +89,7 @@ class QueryTest extends SnippetTestCase
 
         $res = $snippet->invoke('res');
         $this->assertEquals('Google', $res->output());
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(EntityIterator::class, $res->returnVal());
     }
 
     public function testClassQueryObject()

--- a/tests/snippets/Logging/LoggerTest.php
+++ b/tests/snippets/Logging/LoggerTest.php
@@ -21,6 +21,7 @@ use Google\Cloud\Dev\Snippet\SnippetTestCase;
 use Google\Cloud\Logging\Connection\ConnectionInterface;
 use Google\Cloud\Logging\Entry;
 use Google\Cloud\Logging\Logger;
+use Google\Cloud\Core\Iterator\ItemIterator;
 use Prophecy\Argument;
 
 /**
@@ -82,7 +83,7 @@ class LoggerTest extends SnippetTestCase
         $this->logger->setConnection($this->connection->reveal());
 
         $res = $snippet->invoke('entries');
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
         $this->assertEquals('foo', explode(PHP_EOL, $res->output())[0]);
         $this->assertEquals('bar', explode(PHP_EOL, $res->output())[1]);
     }
@@ -108,7 +109,7 @@ class LoggerTest extends SnippetTestCase
         $this->logger->setConnection($this->connection->reveal());
 
         $res = $snippet->invoke('entries');
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
         $this->assertEquals('foo', explode(PHP_EOL, $res->output())[0]);
         $this->assertEquals('bar', explode(PHP_EOL, $res->output())[1]);
     }

--- a/tests/snippets/Logging/LoggingClientTest.php
+++ b/tests/snippets/Logging/LoggingClientTest.php
@@ -24,6 +24,7 @@ use Google\Cloud\Logging\LoggingClient;
 use Google\Cloud\Logging\Metric;
 use Google\Cloud\Logging\PsrLogger;
 use Google\Cloud\Logging\Sink;
+use Google\Cloud\Core\Iterator\ItemIterator;
 use Prophecy\Argument;
 
 /**
@@ -88,7 +89,7 @@ class LoggingClientTest extends SnippetTestCase
         $this->client->setConnection($this->connection->reveal());
 
         $res = $snippet->invoke('sinks');
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
         $this->assertEquals('Sink 1', explode(PHP_EOL, $res->output())[0]);
         $this->assertEquals('Sink 2', explode(PHP_EOL, $res->output())[1]);
     }
@@ -134,7 +135,7 @@ class LoggingClientTest extends SnippetTestCase
         $this->client->setConnection($this->connection->reveal());
 
         $res = $snippet->invoke('metrics');
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
         $this->assertEquals('Metric 1', explode(PHP_EOL, $res->output())[0]);
         $this->assertEquals('Metric 2', explode(PHP_EOL, $res->output())[1]);
     }
@@ -156,7 +157,7 @@ class LoggingClientTest extends SnippetTestCase
         $this->client->setConnection($this->connection->reveal());
 
         $res = $snippet->invoke('entries');
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
         $this->assertEquals('Entry 1', explode(PHP_EOL, $res->output())[0]);
         $this->assertEquals('Entry 2', explode(PHP_EOL, $res->output())[1]);
     }
@@ -181,7 +182,7 @@ class LoggingClientTest extends SnippetTestCase
         $this->client->setConnection($this->connection->reveal());
 
         $res = $snippet->invoke('entries');
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
         $this->assertEquals('Entry 1', explode(PHP_EOL, $res->output())[0]);
         $this->assertEquals('Entry 2', explode(PHP_EOL, $res->output())[1]);
     }

--- a/tests/snippets/PubSub/PubSubClientTest.php
+++ b/tests/snippets/PubSub/PubSubClientTest.php
@@ -24,6 +24,7 @@ use Google\Cloud\PubSub\Message;
 use Google\Cloud\PubSub\PubSubClient;
 use Google\Cloud\PubSub\Subscription;
 use Google\Cloud\PubSub\Topic;
+use Google\Cloud\Core\Iterator\ItemIterator;
 use Prophecy\Argument;
 
 /**
@@ -117,7 +118,7 @@ class PubSubClientTest extends SnippetTestCase
 
         $res = $snippet->invoke('topics');
 
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
         $this->assertEquals(self::TOPIC, $res->output());
     }
 
@@ -181,7 +182,7 @@ class PubSubClientTest extends SnippetTestCase
         $this->client->setConnection($this->connection->reveal());
 
         $res = $snippet->invoke('subscriptions');
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
         $this->assertEquals(self::SUBSCRIPTION, $res->output());
     }
 

--- a/tests/snippets/PubSub/TopicTest.php
+++ b/tests/snippets/PubSub/TopicTest.php
@@ -22,6 +22,7 @@ use Google\Cloud\Core\Iam\Iam;
 use Google\Cloud\PubSub\Connection\ConnectionInterface;
 use Google\Cloud\PubSub\Subscription;
 use Google\Cloud\PubSub\Topic;
+use Google\Cloud\Core\Iterator\ItemIterator;
 use Prophecy\Argument;
 
 /**
@@ -220,7 +221,7 @@ class TopicTest extends SnippetTestCase
         $this->topic->setConnection($this->connection->reveal());
 
         $res = $snippet->invoke('subscriptions');
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
         $this->assertEquals(self::SUBSCRIPTION, $res->output());
     }
 

--- a/tests/snippets/Storage/BucketTest.php
+++ b/tests/snippets/Storage/BucketTest.php
@@ -22,6 +22,7 @@ use Google\Cloud\Core\Exception\GoogleException;
 use Google\Cloud\Storage\Acl;
 use Google\Cloud\Storage\Bucket;
 use Google\Cloud\Storage\Connection\ConnectionInterface;
+use Google\Cloud\Storage\ObjectIterator;
 use Google\Cloud\Storage\StorageObject;
 use Google\Cloud\Core\Upload\MultipartUploader;
 use Google\Cloud\Core\Upload\ResumableUploader;
@@ -235,15 +236,21 @@ class BucketTest extends SnippetTestCase
             ->shouldBeCalled()
             ->willReturn([
                 'items' => [
-                    ['name' => 'object 1'],
-                    ['name' => 'object 2']
+                    [
+                        'name' => 'object 1',
+                        'generation' => 'abc'
+                    ],
+                    [
+                        'name' => 'object 2',
+                        'generation' => 'def'
+                    ]
                 ]
             ]);
 
         $this->bucket->setConnection($this->connection->reveal());
 
         $res = $snippet->invoke('objects');
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(ObjectIterator::class, $res->returnVal());
         $this->assertEquals('object 1', explode("\n", $res->output())[0]);
         $this->assertEquals('object 2', explode("\n", $res->output())[1]);
     }

--- a/tests/snippets/Storage/StorageClientTest.php
+++ b/tests/snippets/Storage/StorageClientTest.php
@@ -21,6 +21,7 @@ use Google\Cloud\Dev\Snippet\SnippetTestCase;
 use Google\Cloud\Storage\Bucket;
 use Google\Cloud\Storage\Connection\ConnectionInterface;
 use Google\Cloud\Storage\StorageClient;
+use Google\Cloud\Core\Iterator\ItemIterator;
 use Prophecy\Argument;
 
 /**
@@ -73,7 +74,7 @@ class StorageClientTest extends SnippetTestCase
         $this->client->setConnection($this->connection->reveal());
 
         $res = $snippet->invoke('buckets');
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
 
         $buckets = iterator_to_array($res->returnVal());
         $this->assertEquals('album 1', $buckets[0]->name());
@@ -97,7 +98,7 @@ class StorageClientTest extends SnippetTestCase
         $this->client->setConnection($this->connection->reveal());
 
         $res = $snippet->invoke('buckets');
-        $this->assertInstanceOf(\Generator::class, $res->returnVal());
+        $this->assertInstanceOf(ItemIterator::class, $res->returnVal());
         $this->assertEquals('album 1', explode("\n", $res->output())[0]);
         $this->assertEquals('album 2', explode("\n", $res->output())[1]);
     }

--- a/tests/unit/Core/Iterator/ItemIteratorTest.php
+++ b/tests/unit/Core/Iterator/ItemIteratorTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Core\Iterator;
+
+use Google\Cloud\Core\Iterator\ItemIterator;
+use Google\Cloud\Core\Iterator\PageIterator;
+
+/**
+ * @group core
+ */
+class ItemIteratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIteratesData()
+    {
+        $page1 = ['a', 'b', 'c'];
+        $page2 = ['d', 'e', 'f'];
+        $pageIterator = $this->prophesize(PageIterator::class);
+        $pageIterator->rewind()
+            ->willReturn(null)
+            ->shouldBeCalledTimes(1);
+        $pageIterator->nextResultToken()
+            ->willReturn('abc', null)
+            ->shouldBeCalledTimes(2);
+        $pageIterator->current()
+            ->willReturn($page1)
+            ->shouldBeCalledTimes(19);
+        $pageIterator->next()
+            ->will(function () use ($page2) {
+                $this->current()->willReturn($page2);
+            })
+            ->shouldBeCalledTimes(1);
+
+        $items = new ItemIterator($pageIterator->reveal());
+
+        $actualItems = [];
+        foreach ($items as $key => $item) {
+            $actualItems[] = $item;
+        }
+
+        $this->assertEquals(array_merge($page1, $page2), $actualItems);
+    }
+
+    public function testGetsNextResultToken()
+    {
+        $nextResultToken = 'abc';
+        $pageIterator = $this->prophesize(PageIterator::class);
+        $pageIterator->nextResultToken()
+            ->willReturn($nextResultToken)
+            ->shouldBeCalledTimes(1);
+
+        $items = new ItemIterator($pageIterator->reveal());
+
+        $this->assertEquals($nextResultToken, $items->nextResultToken());
+    }
+
+    public function testGetsPageIterator()
+    {
+        $pageIterator = $this->prophesize(PageIterator::class);
+
+        $items = new ItemIterator($pageIterator->reveal());
+
+        $this->assertInstanceOf(PageIterator::class, $items->iterateByPage());
+    }
+}

--- a/tests/unit/Core/Iterator/PageIteratorTest.php
+++ b/tests/unit/Core/Iterator/PageIteratorTest.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Core\Iterator;
+
+use Google\Cloud\Core\Iterator\ItemIterator;
+use Google\Cloud\Core\Iterator\PageIterator;
+
+/**
+ * @group core
+ */
+class PageIteratorTest extends \PHPUnit_Framework_TestCase
+{
+    private static $page1 = ['a', 'b', 'c'];
+    private static $page2 = ['d', 'e', 'f'];
+
+    public function testRewindsIterator()
+    {
+        $pages = new PageIterator(
+            function ($result) {
+                return $result;
+            },
+            [$this, 'theCall'],
+            ['itemsKey' => 'items', 'multiPage' => true]
+        );
+
+        $page1BeforeRewind = iterator_to_array($pages)[0];
+        $pages->rewind();
+        $page1AfterRewind = iterator_to_array($pages)[0];
+
+        $this->assertEquals($page1BeforeRewind, $page1AfterRewind);
+    }
+
+    /**
+     * @dataProvider iteratorDataProvider
+     */
+    public function testIteratesData(array $options, array $iteratorOptions, $expected)
+    {
+        $pages = new PageIterator(
+            function ($result) {
+                return strtoupper($result);
+            },
+            [$this, 'theCall'],
+            $options,
+            $iteratorOptions
+        );
+
+        $pagesArray = iterator_to_array($pages);
+
+        $this->assertEquals($expected, $pagesArray);
+    }
+
+    public function iteratorDataProvider()
+    {
+        return [
+            [
+                ['itemsKey' => 'items'],
+                [],
+                [array_map('strtoupper', self::$page1)]
+            ],
+            [
+                ['itemsKey' => 'tests'],
+                ['itemsKey' => 'tests'],
+                [array_map('strtoupper', self::$page1)]
+            ],
+            [
+                [
+                    'itemsKey' => 'items',
+                    'nextResultTokenKey' => 'nr',
+                    'resultTokenKey' => 'r'
+                ],
+                [
+                    'nextResultTokenKey' => 'nr',
+                    'resultTokenKey' => 'r',
+                    'firstPage' => [
+                        'nr' => 'abc',
+                        'items' => self::$page1
+                    ]
+                ],
+                [
+                    array_map('strtoupper', self::$page1),
+                    array_map('strtoupper', self::$page2)
+                ]
+            ],
+            [
+                [
+                    'itemsKey' => 'items',
+                    'multiPage' => true
+                ],
+                [],
+                [
+                    array_map('strtoupper', self::$page1),
+                    array_map('strtoupper', self::$page2)
+                ]
+            ],
+            [
+                [
+                    'itemsKey' => 'items',
+                    'multiPage' => true
+                ],
+                [
+                    'setNextResultTokenCondition' => function () {
+                        return false;
+                    }
+                ],
+                [
+                    array_map('strtoupper', self::$page1)
+                ]
+            ],
+            [
+                [
+                    'itemsKey' => 'items',
+                    'multiPage' => true
+                ],
+                ['resultLimit' => 4],
+                [
+                    array_map('strtoupper', self::$page1),
+                    array_slice(array_map('strtoupper', self::$page2), 0, 1)
+                ]
+            ]
+        ];
+    }
+
+    public function theCall(array $options)
+    {
+        $options += [
+            'itemsKey' => 'items',
+            'nextResultTokenKey' => 'nextPageToken',
+            'resultTokenKey' => 'pageToken'
+        ];
+
+        if (isset($options[$options['resultTokenKey']])) {
+            return [
+                $options['itemsKey'] => self::$page2
+            ];
+        }
+
+        if (isset($options['firstPage'])) {
+
+        }
+
+        if (isset($options['multiPage'])) {
+            return [
+                $options['itemsKey'] => self::$page1,
+                $options['nextResultTokenKey'] => 'abc'
+            ];
+        }
+
+        return [
+            $options['itemsKey'] => self::$page1
+        ];
+    }
+}

--- a/tests/unit/Datastore/EntityIteratorTest.php
+++ b/tests/unit/Datastore/EntityIteratorTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Datastore;
+
+use Google\Cloud\Datastore\EntityIterator;
+use Google\Cloud\Datastore\EntityPageIterator;
+
+/**
+ * @group datastore
+ */
+class EntityIteratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetsMoreResultsType()
+    {
+        $moreResultsType = 'NOT_FINISHED';
+        $pageIterator = $this->prophesize(EntityPageIterator::class);
+        $pageIterator->moreResultsType()
+            ->willReturn($moreResultsType)
+            ->shouldBeCalledTimes(1);
+
+        $items = new EntityIterator($pageIterator->reveal());
+
+        $this->assertEquals($moreResultsType, $items->moreResultsType());
+    }
+}

--- a/tests/unit/Datastore/EntityPageIteratorTest.php
+++ b/tests/unit/Datastore/EntityPageIteratorTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Datastore;
+
+use Google\Cloud\Datastore\EntityPageIterator;
+
+/**
+ * @group datastore
+ */
+class EntityPageIteratorTest extends \PHPUnit_Framework_TestCase
+{
+    private static $moreResultsType = 'NOT_FINISHED';
+    private static $items = ['a', 'b', 'c'];
+
+    public function testGetsMoreResultsType()
+    {
+        $pages = new EntityPageIterator(
+            function ($item) {
+                return $item;
+            },
+            [$this, 'theCall'],
+            ['test' => 'call']
+        );
+
+        $pagesArray = iterator_to_array($pages);
+
+        $this->assertEquals(self::$moreResultsType, $pages->moreResultsType());
+        $this->assertEquals(self::$items, $pagesArray[0]);
+    }
+
+    public function theCall(array $options)
+    {
+        return [
+            'batch' => [
+                'moreResults' => self::$moreResultsType
+            ],
+            'items' => self::$items
+        ];
+    }
+}

--- a/tests/unit/Datastore/OperationTest.php
+++ b/tests/unit/Datastore/OperationTest.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Tests\Unit\Datastore;
 
 use Google\Cloud\Datastore\Connection\ConnectionInterface;
 use Google\Cloud\Datastore\Entity;
+use Google\Cloud\Datastore\EntityIterator;
 use Google\Cloud\Datastore\EntityMapper;
 use Google\Cloud\Datastore\Key;
 use Google\Cloud\Datastore\Operation;
@@ -443,7 +444,7 @@ class OperationTest extends \PHPUnit_Framework_TestCase
 
         $res = $this->operation->runQuery($q->reveal());
 
-        $this->assertInstanceOf(\Generator::class, $res);
+        $this->assertInstanceOf(EntityIterator::class, $res);
 
         $arr = iterator_to_array($res);
         $this->assertEquals(count($arr), 2);
@@ -471,7 +472,7 @@ class OperationTest extends \PHPUnit_Framework_TestCase
 
         $res = $this->operation->runQuery($q->reveal());
 
-        $this->assertInstanceOf(\Generator::class, $res);
+        $this->assertInstanceOf(EntityIterator::class, $res);
 
         $arr = iterator_to_array($res);
         $this->assertEquals(count($arr), 3);
@@ -489,10 +490,11 @@ class OperationTest extends \PHPUnit_Framework_TestCase
         $q = $this->prophesize(QueryInterface::class);
         $q->queryKey()->shouldBeCalled()->willReturn('query');
         $q->queryObject()->shouldBeCalled()->willReturn([]);
+        $q->canPaginate()->shouldBeCalled()->willReturn(false);
 
         $res = $this->operation->runQuery($q->reveal());
 
-        $this->assertInstanceOf(\Generator::class, $res);
+        $this->assertInstanceOf(EntityIterator::class, $res);
 
         $arr = iterator_to_array($res);
         $this->assertEquals(count($arr), 0);

--- a/tests/unit/Logging/LoggerTest.php
+++ b/tests/unit/Logging/LoggerTest.php
@@ -64,7 +64,6 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
             'pageSize' => 50
         ];
         $this->connection->listEntries($options + [
-            'pageToken' => null,
             'resourceNames' => ["projects/$this->projectId"],
             'filter' => "logName = $this->formattedName"
         ])
@@ -121,7 +120,6 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     {
         $filter = 'textPayload = "hello world"';
         $this->connection->listEntries([
-            'pageToken' => null,
             'resourceNames' => ["projects/$this->projectId"],
             'filter' => $filter . " AND logName = $this->formattedName"
         ])

--- a/tests/unit/Logging/LoggingClientTest.php
+++ b/tests/unit/Logging/LoggingClientTest.php
@@ -208,7 +208,6 @@ class LoggingClientTest extends \PHPUnit_Framework_TestCase
     {
         $secondProjectId = 'secondProjectId';
         $this->connection->listEntries([
-            'pageToken' => null,
             'resourceNames' => [
                 'projects/' . $this->projectId,
                 'projects/' . $secondProjectId

--- a/tests/unit/PubSub/PubSubClientTest.php
+++ b/tests/unit/PubSub/PubSubClientTest.php
@@ -17,7 +17,7 @@
 
 namespace Google\Cloud\Tests\Unit\PubSub;
 
-use Generator;
+use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\PubSub\Connection\ConnectionInterface;
 use Google\Cloud\PubSub\Connection\Grpc;
 use Google\Cloud\PubSub\Connection\Rest;
@@ -121,7 +121,7 @@ class PubSubClientTest extends \PHPUnit_Framework_TestCase
             'foo' => 'bar'
         ]);
 
-        $this->assertInstanceOf(Generator::class, $topics);
+        $this->assertInstanceOf(ItemIterator::class, $topics);
 
         $arr = iterator_to_array($topics);
         $this->assertInstanceOf(Topic::class, $arr[0]);
@@ -144,7 +144,9 @@ class PubSubClientTest extends \PHPUnit_Framework_TestCase
 
         $this->connection->listTopics(Argument::that(function ($options) {
             if ($options['foo'] !== 'bar') return false;
-            if ($options['pageToken'] !== 'foo' && !is_null($options['pageToken'])) return false;
+            if (isset($options['pageToken']) && $options['pageToken'] !== 'foo') {
+                return false;
+            }
 
             return true;
         }))->willReturn([
@@ -230,7 +232,7 @@ class PubSubClientTest extends \PHPUnit_Framework_TestCase
             'foo' => 'bar'
         ]);
 
-        $this->assertInstanceOf(Generator::class, $subscriptions);
+        $this->assertInstanceOf(ItemIterator::class, $subscriptions);
 
         $arr = iterator_to_array($subscriptions);
         $this->assertInstanceOf(Subscription::class, $arr[0]);
@@ -256,7 +258,9 @@ class PubSubClientTest extends \PHPUnit_Framework_TestCase
 
         $this->connection->listSubscriptions(Argument::that(function ($options) {
             if ($options['foo'] !== 'bar') return false;
-            if ($options['pageToken'] !== 'foo' && !is_null($options['pageToken'])) return false;
+            if (isset($options['pageToken']) && $options['pageToken'] !== 'foo') {
+                return false;
+            }
 
             return true;
         }))->willReturn([

--- a/tests/unit/PubSub/SubscriptionTest.php
+++ b/tests/unit/PubSub/SubscriptionTest.php
@@ -17,9 +17,9 @@
 
 namespace Google\Cloud\Tests\Unit\PubSub;
 
-use Generator;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Iam\Iam;
+use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\PubSub\Connection\ConnectionInterface;
 use Google\Cloud\PubSub\Message;
 use Google\Cloud\PubSub\Subscription;

--- a/tests/unit/PubSub/TopicTest.php
+++ b/tests/unit/PubSub/TopicTest.php
@@ -17,9 +17,9 @@
 
 namespace Google\Cloud\Tests\Unit\PubSub;
 
-use Generator;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Iam\Iam;
+use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\PubSub\Connection\ConnectionInterface;
 use Google\Cloud\PubSub\Subscription;
 use Google\Cloud\PubSub\Topic;
@@ -282,7 +282,7 @@ class TopicTest extends \PHPUnit_Framework_TestCase
             'foo' => 'bar'
         ]);
 
-        $this->assertInstanceOf(Generator::class, $subscriptions);
+        $this->assertInstanceOf(ItemIterator::class, $subscriptions);
 
         $arr = iterator_to_array($subscriptions);
         $this->assertInstanceOf(Subscription::class, $arr[0]);
@@ -301,7 +301,9 @@ class TopicTest extends \PHPUnit_Framework_TestCase
 
         $this->connection->listSubscriptionsByTopic(Argument::that(function ($options) {
             if ($options['foo'] !== 'bar') return false;
-            if ($options['pageToken'] !== 'foo' && !is_null($options['pageToken'])) return false;
+            if (isset($options['pageToken']) && $options['pageToken'] !== 'foo') {
+                return false;
+            }
 
             return true;
         }))->willReturn([

--- a/tests/unit/Storage/BucketTest.php
+++ b/tests/unit/Storage/BucketTest.php
@@ -141,7 +141,10 @@ class BucketTest extends \PHPUnit_Framework_TestCase
     {
         $this->connection->listObjects(Argument::any())->willReturn([
             'items' => [
-                ['name' => 'file.txt']
+                [
+                    'name' => 'file.txt',
+                    'generation' => 'abc'
+                ]
             ]
         ]);
 
@@ -157,12 +160,18 @@ class BucketTest extends \PHPUnit_Framework_TestCase
             [
                 'nextPageToken' => 'token',
                 'items' => [
-                    ['name' => 'file.txt']
+                    [
+                        'name' => 'file.txt',
+                        'generation' => 'abc'
+                    ]
                 ]
             ],
                 [
                 'items' => [
-                    ['name' => 'file2.txt']
+                    [
+                        'name' => 'file2.txt',
+                        'generation' => 'def'
+                    ]
                 ]
             ]
         );

--- a/tests/unit/Storage/ObjectIteratorTest.php
+++ b/tests/unit/Storage/ObjectIteratorTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Storage;
+
+use Google\Cloud\Storage\ObjectIterator;
+use Google\Cloud\Storage\ObjectPageIterator;
+
+/**
+ * @group storage
+ */
+class ObjectIteratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetsPrefixes()
+    {
+        $prefixes = ['test/', 'test1/'];
+        $pageIterator = $this->prophesize(ObjectPageIterator::class);
+        $pageIterator->prefixes()
+            ->willReturn($prefixes)
+            ->shouldBeCalledTimes(1);
+
+        $items = new ObjectIterator($pageIterator->reveal());
+
+        $this->assertEquals($prefixes, $items->prefixes());
+    }
+}

--- a/tests/unit/Storage/ObjectPageIteratorTest.php
+++ b/tests/unit/Storage/ObjectPageIteratorTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Storage;
+
+use Google\Cloud\Storage\ObjectPageIterator;
+
+/**
+ * @group storage
+ */
+class ObjectPageIteratorTest extends \PHPUnit_Framework_TestCase
+{
+    private static $prefixes = ['test/', 'test1/'];
+    private static $items = ['a', 'b', 'c'];
+
+    public function testGetsPrefixes()
+    {
+        $pages = new ObjectPageIterator(
+            function ($item) {
+                return $item;
+            },
+            [$this, 'theCall'],
+            ['test' => 'call']
+        );
+
+        $pagesArray = iterator_to_array($pages);
+
+        $this->assertEquals(self::$prefixes, $pages->prefixes());
+        $this->assertEquals(self::$items, $pagesArray[0]);
+    }
+
+    public function theCall(array $options)
+    {
+        return [
+            'prefixes' => self::$prefixes,
+            'items' => self::$items
+        ];
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/GoogleCloudPlatform/google-cloud-php/issues/342

Example:
```php
use Google\Cloud\Storage\StorageClient;

$storage = new StorageClient();
$bucketsIterator = $storage->buckets(
    'maxResults' => 5 // The number of results per page
    'resultLimit' => 10 // The number of results returned in total **new**
    'pageToken' => null // Set this to the value of a previously retrieved token to resume iterating from a specific point **new**
);

// Iterate by each item (bucket) in the project
foreach ($bucketsIterator as $bucket) {
    var_dump($bucket->name());
}

// Or iterate by page
$bucketsPageIterator = $bucketsIterator->iterateByPage();

foreach ($bucketsPageIterator as $page) {
    foreach ($page as $bucket) {
        var_dump($bucket->name());
    }
}

// Get the next result token
$nextToken = $bucketsIterator->nextResultToken();
```