### PR TITLE
Don't set ACL when predefinedAcl is defined

### DIFF
--- a/src/Storage/StorageObject.php
+++ b/src/Storage/StorageObject.php
@@ -219,6 +219,12 @@ class StorageObject
     public function update(array $metadata, array $options = [])
     {
         $options += $metadata;
+
+        // can only set predefinedAcl or acl
+        if (isset($options['predefinedAcl'])) {
+            $options['acl'] = null;
+        }
+
         return $this->info = $this->connection->patchObject($options + $this->identity);
     }
 

--- a/tests/unit/Storage/StorageObjectTest.php
+++ b/tests/unit/Storage/StorageObjectTest.php
@@ -71,13 +71,42 @@ class StorageObjectTest extends \PHPUnit_Framework_TestCase
 
     public function testUpdatesData()
     {
+        $object = 'object.txt';
         $data = ['contentType' => 'image/jpg'];
-        $this->connection->patchObject(Argument::any())->willReturn(['name' => 'object.txt'] + $data);
-        $object = new StorageObject($this->connection->reveal(), 'object.txt', 'bucket', null, ['contentType' => 'image/png']);
+        $this->connection->patchObject(Argument::any())->willReturn(['name' => $object] + $data);
+        $object = new StorageObject(
+            $this->connection->reveal(),
+            $object,
+            'bucket',
+            null,
+            ['contentType' => 'image/png']
+        );
 
         $object->update($data);
 
         $this->assertEquals($data['contentType'], $object->info()['contentType']);
+    }
+
+    public function testUpdatesDataAndUnsetsAclWithPredefinedAclApplied()
+    {
+        $object = 'object.txt';
+        $bucket = 'bucket';
+        $predefinedAcl = ['predefinedAcl' => 'private'];
+        $this->connection->patchObject($predefinedAcl + [
+            'bucket' => $bucket,
+            'object' => $object,
+            'generation' => null,
+            'acl' => null
+        ])->willReturn([]);
+        $object = new StorageObject(
+            $this->connection->reveal(),
+            $object,
+            $bucket,
+            null,
+            ['acl' => 'test']
+        );
+
+        $object->update([], $predefinedAcl);
     }
 
     public function testCopyObjectWithDefaultName()


### PR DESCRIPTION
Closes: https://github.com/GoogleCloudPlatform/google-cloud-php/issues/392