### PR TITLE
Fix incorrect return type in doc-comment

### DIFF
--- a/src/BigQuery/Dataset.php
+++ b/src/BigQuery/Dataset.php
@@ -153,7 +153,7 @@ class Dataset
      * ```
      *
      * @param string $id The id of the table to request.
-     * @return Dataset
+     * @return Table
      */
     public function table($id)
     {


### PR DESCRIPTION
Method returns a Table not a Dataset. This throws off IDEs and leads users to dive into the documentation to work out why they can't do:

```php
        $table = $dataset->table($tableName);

        $job = $table->load(...)
```