### PR TITLE
Add system test of string normalization in GCS

### DIFF
--- a/tests/system/Storage/ManageObjectsTest.php
+++ b/tests/system/Storage/ManageObjectsTest.php
@@ -164,4 +164,21 @@ class ManageObjectsTest extends StorageTestCase
     {
         $this->assertEquals('storage#object', self::$object->reload()['kind']);
     }
+
+    public function testStringNormalization()
+    {
+        $bucket = self::$client->bucket('storage-library-test-bucket');
+
+        $cases = [
+            ["Caf\xC3\xA9", "Normalization Form C"],
+            ["Cafe\xCC\x81", "Normalization Form D"],
+        ];
+
+        foreach ($cases as list($name, $expectedContent)) {
+            $object = $bucket->object($name);
+            $actualContent = $object->downloadAsString();
+
+            $this->assertSame($expectedContent, $actualContent);
+        }
+    }
 }

--- a/tests/system/Storage/ManageObjectsTest.php
+++ b/tests/system/Storage/ManageObjectsTest.php
@@ -167,7 +167,7 @@ class ManageObjectsTest extends StorageTestCase
 
     public function testStringNormalization()
     {
-        $bucket = self::$client->bucket('storage-library-test-bucket');
+        $bucket = self::$client->bucket(self::NORMALIZATION_TEST_BUCKET);
 
         $cases = [
             ["Caf\xC3\xA9", "Normalization Form C"],

--- a/tests/system/Storage/StorageTestCase.php
+++ b/tests/system/Storage/StorageTestCase.php
@@ -23,6 +23,7 @@ use Google\Cloud\Storage\StorageClient;
 class StorageTestCase extends \PHPUnit_Framework_TestCase
 {
     const TESTING_PREFIX = 'gcloud_testing_';
+    const NORMALIZATION_TEST_BUCKET = 'storage-library-test-bucket';
 
     protected static $bucket;
     protected static $client;


### PR DESCRIPTION
This tests that the client library does not normalize the string encoding, which would affect access to buckets with similar but differently-encoded names.

The test has a hard-coded bucket name - should this be a constant in `StorageTestCase`?