### PR TITLE
Allow the retry function to be overridden in the RequestWrapper

### DIFF
--- a/src/Core/RequestWrapper.php
+++ b/src/Core/RequestWrapper.php
@@ -33,9 +33,11 @@ class RequestWrapper
 {
     use JsonTrait;
     use RequestWrapperTrait;
+    use RetryDeciderTrait;
 
     /**
-     * @var string
+     * @var string The current version of the component from which the request
+     * originated.
      */
     private $componentVersion;
 
@@ -61,26 +63,15 @@ class RequestWrapper
     private $restOptions;
 
     /**
-     * @var array
-     */
-    private $httpRetryCodes = [
-        500,
-        502,
-        503
-    ];
-
-    /**
-     * @var array
-     */
-    private $httpRetryMessages = [
-        'rateLimitExceeded',
-        'userRateLimitExceeded'
-    ];
-
-    /**
      * @var bool $shouldSignRequest Whether to enable request signing.
      */
     private $shouldSignRequest;
+
+    /**
+     * @var callable $retryFunction Sets the conditions for whether or not a
+     * request should attempt to retry.
+     */
+    private $retryFunction;
 
     /**
      * @param array $config [optional] {
@@ -88,8 +79,6 @@ class RequestWrapper
      *     {@see Google\Cloud\Core\RequestWrapperTrait::setCommonDefaults()} for
      *     the other available options.
      *
-     *     @type string $componentName The name of the component from which the request
-     *           originated.
      *     @type string $componentVersion The current version of the component from
      *           which the request originated.
      *     @type string $accessToken Access token used to sign requests.
@@ -98,6 +87,8 @@ class RequestWrapper
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
      *     @type array $restOptions HTTP client specific configuration options.
      *     @type bool $shouldSignRequest Whether to enable request signing.
+     *     @type callable $restRetryFunction Sets the conditions for whether or
+     *           not a request should attempt to retry.
      * }
      */
     public function __construct(array $config = [])
@@ -109,7 +100,8 @@ class RequestWrapper
             'httpHandler' => null,
             'restOptions' => [],
             'shouldSignRequest' => true,
-            'componentVersion' => null
+            'componentVersion' => null,
+            'restRetryFunction' => null
         ];
 
         $this->componentVersion = $config['componentVersion'];
@@ -118,6 +110,7 @@ class RequestWrapper
         $this->authHttpHandler = $config['authHttpHandler'] ?: $this->httpHandler;
         $this->restOptions = $config['restOptions'];
         $this->shouldSignRequest = $config['shouldSignRequest'];
+        $this->retryFunction = $config['restRetryFunction'] ?: $this->getRetryFunction();
     }
 
     /**
@@ -131,6 +124,8 @@ class RequestWrapper
      *           request. **Defaults to** `0`.
      *     @type int $retries Number of retries for a failed request.
      *           **Defaults to** `3`.
+     *     @type callable $restRetryFunction Sets the conditions for whether or
+     *           not a request should attempt to retry.
      *     @type array $restOptions HTTP client specific configuration options.
      * }
      * @return ResponseInterface
@@ -140,7 +135,10 @@ class RequestWrapper
         $retries = isset($options['retries']) ? $options['retries'] : $this->retries;
         $restOptions = isset($options['restOptions']) ? $options['restOptions'] : $this->restOptions;
         $timeout = isset($options['requestTimeout']) ? $options['requestTimeout'] : $this->requestTimeout;
-        $backoff = new ExponentialBackoff($retries, $this->getRetryFunction());
+        $retryFunction = isset($options['restRetryFunction'])
+            ? $options['restRetryFunction']
+            : $this->retryFunction;
+        $backoff = new ExponentialBackoff($retries, $retryFunction);
 
         if ($timeout && !array_key_exists('timeout', $restOptions)) {
             $restOptions['timeout'] = $timeout;
@@ -259,38 +257,5 @@ class RequestWrapper
         }
 
         return $ex->getMessage();
-    }
-
-    /**
-     * Determines whether or not the request should be retried.
-     *
-     * @return bool
-     */
-    private function getRetryFunction()
-    {
-        $httpRetryCodes = $this->httpRetryCodes;
-        $httpRetryMessages = $this->httpRetryMessages;
-
-        return function (\Exception $ex) use ($httpRetryCodes, $httpRetryMessages) {
-            $statusCode = $ex->getCode();
-
-            if (in_array($statusCode, $httpRetryCodes)) {
-                return true;
-            }
-
-            $message = json_decode($ex->getMessage(), true);
-
-            if (!isset($message['error']['errors'])) {
-                return false;
-            }
-
-            foreach ($message['error']['errors'] as $error) {
-                if (in_array($error['reason'], $httpRetryMessages)) {
-                    return true;
-                }
-            }
-
-            return false;
-        };
     }
 }

--- a/src/Core/RequestWrapperTrait.php
+++ b/src/Core/RequestWrapperTrait.php
@@ -114,6 +114,7 @@ trait RequestWrapperTrait
         $this->retries = $config['retries'];
         $this->scopes = $config['scopes'];
         $this->keyFile = $config['keyFile'];
+        $this->requestTimeout = $config['requestTimeout'];
     }
 
     /**

--- a/src/Core/RetryDeciderTrait.php
+++ b/src/Core/RetryDeciderTrait.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core;
+
+/**
+ * Provides methods for deciding if a request should be retried.
+ */
+trait RetryDeciderTrait
+{
+    /**
+     * @var array
+     */
+    private $httpRetryCodes = [
+        500,
+        502,
+        503
+    ];
+
+    /**
+     * @var array
+     */
+    private $httpRetryMessages = [
+        'rateLimitExceeded',
+        'userRateLimitExceeded'
+    ];
+
+    /**
+     * Determines whether or not the request should be retried.
+     *
+     * @param bool $shouldRetryMessages Whether or not to attempt retrying based
+     *        on the failure message.
+     * @return callable
+     */
+    private function getRetryFunction($shouldRetryMessages = true)
+    {
+        $httpRetryCodes = $this->httpRetryCodes;
+        $httpRetryMessages = $this->httpRetryMessages;
+
+        return function (\Exception $ex) use ($httpRetryCodes, $httpRetryMessages, $shouldRetryMessages) {
+            $statusCode = $ex->getCode();
+
+            if (in_array($statusCode, $httpRetryCodes)) {
+                return true;
+            }
+
+            if (!$shouldRetryMessages) {
+                return false;
+            }
+
+            $message = json_decode($ex->getMessage(), true);
+
+            if (!isset($message['error']['errors'])) {
+                return false;
+            }
+
+            foreach ($message['error']['errors'] as $error) {
+                if (in_array($error['reason'], $httpRetryMessages)) {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+    }
+}

--- a/src/NaturalLanguage/NaturalLanguageClient.php
+++ b/src/NaturalLanguage/NaturalLanguageClient.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\NaturalLanguage;
 
 use Google\Cloud\Core\ClientTrait;
+use Google\Cloud\Core\RetryDeciderTrait;
 use Google\Cloud\NaturalLanguage\Connection\ConnectionInterface;
 use Google\Cloud\NaturalLanguage\Connection\Rest;
 use Google\Cloud\Storage\StorageObject;
@@ -40,6 +41,7 @@ use Psr\Cache\CacheItemPoolInterface;
 class NaturalLanguageClient
 {
     use ClientTrait;
+    use RetryDeciderTrait;
 
     const VERSION = '0.1.0';
 
@@ -88,9 +90,10 @@ class NaturalLanguageClient
      */
     public function __construct(array $config = [])
     {
-        if (!isset($config['scopes'])) {
-            $config['scopes'] = [self::FULL_CONTROL_SCOPE];
-        }
+        $config += [
+            'scopes' => [self::FULL_CONTROL_SCOPE],
+            'restRetryFunction' => $this->getRetryFunction(false)
+        ];
 
         $this->connection = new Rest($this->configureAuthentication($config));
     }

--- a/tests/unit/Core/RetryDeciderTraitTest.php
+++ b/tests/unit/Core/RetryDeciderTraitTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Core;
+
+use Google\Cloud\Core\RetryDeciderTrait;
+
+/**
+ * @group core
+ */
+class RetryDeciderTraitTest extends \PHPUnit_Framework_TestCase
+{
+    private $implementation;
+
+    public function setUp()
+    {
+        $this->implementation = new RetryDeciderTraitStub();
+    }
+
+    /**
+     * @dataProvider retryProvider
+     */
+    public function testShouldRetry($exception, $shouldRetryMessage, $expected)
+    {
+        $retryFunction = $this->implementation->call('getRetryFunction', [$shouldRetryMessage]);
+
+        $this->assertEquals($expected, $retryFunction($exception));
+    }
+
+    public function retryProvider()
+    {
+        $rateLimitExceededMessage = '{"error": {"errors": [{"reason": "rateLimitExceeded"}]}}';
+        $userRateLimitExceededMessage = '{"error": {"errors": [{"reason": "userRateLimitExceeded"}]}}';
+        $notAGoodMessage = '{"error": {"errors": [{"reason": "notAGoodReason"}]}}';
+
+        return [
+            [new \Exception('', 400), true, false],
+            [new \Exception('', 500), true, true],
+            [new \Exception('', 502), true, true],
+            [new \Exception('', 503), true, true],
+            [new \Exception($rateLimitExceededMessage), true, true],
+            [new \Exception($userRateLimitExceededMessage), true, true],
+            [new \Exception($userRateLimitExceededMessage), false, false],
+            [new \Exception($notAGoodMessage), true, false],
+        ];
+    }
+}
+
+class RetryDeciderTraitStub
+{
+    use RetryDeciderTrait;
+
+    public function call($fn, array $args = [])
+    {
+        return call_user_func_array([$this, $fn], $args);
+    }
+}


### PR DESCRIPTION
This also includes a change to prevent the natural language client from attempting to retry on rate limit related errors.

Closes: https://github.com/GoogleCloudPlatform/google-cloud-php/issues/403