### PR TITLE
Spanner fixes

### DIFF
--- a/docs/contents/cloud-spanner.json
+++ b/docs/contents/cloud-spanner.json
@@ -1,0 +1,8 @@
+{
+    "title": "Spanner",
+    "pattern": "spanner\/\\w{1,}",
+    "nav": [{
+      "title": "SpannerClient",
+      "type": "spanner/spannerclient"
+    }]
+}

--- a/src/Core/Exception/AbortedException.php
+++ b/src/Core/Exception/AbortedException.php
@@ -22,6 +22,11 @@ namespace Google\Cloud\Core\Exception;
  */
 class AbortedException extends ServiceException
 {
+    /**
+     * Return the delay in seconds and nanos before retrying the failed request.
+     *
+     * @return array
+     */
     public function getRetryDelay()
     {
         $metadata = array_filter($this->options, function ($metadataItem) {

--- a/src/Core/PhpArray.php
+++ b/src/Core/PhpArray.php
@@ -18,8 +18,9 @@
 namespace Google\Cloud\Core;
 
 use DrSlump\Protobuf;
-use google\protobuf\Struct;
 use google\protobuf\ListValue;
+use google\protobuf\NullValue;
+use google\protobuf\Struct;
 
 /**
  * Extend the Protobuf-PHP array codec to allow messages to match the format
@@ -164,6 +165,10 @@ class PhpArray extends Protobuf\Codec\PhpArray
 
     protected function filterValue($value, Protobuf\Field $field)
     {
+        if (trim($field->getReference(), '\\') === NullValue::class) {
+            return null;
+        }
+
         if ($value instanceof Protobuf\Message) {
             if ($this->isKeyValueMessage($value)) {
                 $v = $value->getValue();

--- a/src/Spanner/Admin/Database/V1/DatabaseAdminClient.php
+++ b/src/Spanner/Admin/Database/V1/DatabaseAdminClient.php
@@ -235,7 +235,7 @@ class DatabaseAdminClient
         return $pageStreamingDescriptors;
     }
 
-    public static function getLongRunningDescriptors()
+    private static function getLongRunningDescriptors()
     {
         return [
             'createDatabase' => [

--- a/src/Spanner/Admin/Instance/V1/InstanceAdminClient.php
+++ b/src/Spanner/Admin/Instance/V1/InstanceAdminClient.php
@@ -281,7 +281,7 @@ class InstanceAdminClient
         return $pageStreamingDescriptors;
     }
 
-    public static function getLongRunningDescriptors()
+    private static function getLongRunningDescriptors()
     {
         return [
             'createInstance' => [

--- a/src/Spanner/Connection/ConnectionInterface.php
+++ b/src/Spanner/Connection/ConnectionInterface.php
@@ -17,6 +17,9 @@
 
 namespace Google\Cloud\Spanner\Connection;
 
+/**
+ * Describes a connection to the Cloud Spanner API
+ */
 interface ConnectionInterface
 {
     /**

--- a/src/Spanner/Connection/Grpc.php
+++ b/src/Spanner/Connection/Grpc.php
@@ -38,6 +38,9 @@ use google\spanner\v1\TransactionOptions;
 use google\spanner\v1\TransactionSelector;
 use google\spanner\v1\Type;
 
+/**
+ * Connection to Cloud Spanner over gRPC
+ */
 class Grpc implements ConnectionInterface
 {
     use GrpcTrait;

--- a/src/Spanner/Database.php
+++ b/src/Spanner/Database.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Spanner;
 use Google\Cloud\Core\Exception\AbortedException;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Iam\Iam;
+use Google\Cloud\Core\LongRunning\LongRunningOperation;
 use Google\Cloud\Core\LongRunning\LROTrait;
 use Google\Cloud\Core\LongRunning\LongRunningConnectionInterface;
 use Google\Cloud\Core\Retry;
@@ -111,8 +112,8 @@ class Database
      * @param string $projectId The project ID.
      * @param string $name The database name.
      * @param bool $returnInt64AsObject If true, 64 bit integers will be
-     *        returned as a {@see Google\Cloud\Int64} object for 32 bit platform
-     *        compatibility. **Defaults to** false.
+     *        returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
+     *        platform compatibility. **Defaults to** false.
      */
     public function __construct(
         ConnectionInterface $connection,
@@ -397,7 +398,7 @@ class Database
      * new transaction.
      *
      * If a transaction exceeds the maximum number of retries,
-     * {@see Google\Cloud\Exception\AbortedException} will be thrown. Any other
+     * {@see Google\Cloud\Core\Exception\AbortedException} will be thrown. Any other
      * exception types will immediately bubble up and will interrupt the retry
      * operation.
      *
@@ -507,7 +508,7 @@ class Database
      *
      * When manually using a Transaction, it is advised that retry logic be
      * implemented to reapply all operations when an instance of
-     * {@see Google\Cloud\Exception\AbortedException} is thrown.
+     * {@see Google\Cloud\Core\Exception\AbortedException} is thrown.
      *
      * If you wish Google Cloud PHP to handle retry logic for you (recommended
      * for most cases), use {@see Google\Cloud\Spanner\Database::runTransaction()}.

--- a/src/Spanner/Database.php
+++ b/src/Spanner/Database.php
@@ -467,7 +467,7 @@ class Database
         $session = $this->selectSession(SessionPoolInterface::CONTEXT_READWRITE);
 
         $attempt = 0;
-        $startTransactionFn = function ($session, $options) use ($options, &$attempt) {
+        $startTransactionFn = function ($session, $options) use (&$attempt) {
             if ($attempt === 0 && $options['transaction'] instanceof Transaction) {
                 $transaction = $options['transaction'];
             } elseif ($attempt === 0 && $options['transaction']) {

--- a/src/Spanner/Instance.php
+++ b/src/Spanner/Instance.php
@@ -22,6 +22,7 @@ use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Iam\Iam;
 use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Core\Iterator\PageIterator;
+use Google\Cloud\Core\LongRunning\LongRunningOperation;
 use Google\Cloud\Core\LongRunning\LROTrait;
 use Google\Cloud\Core\LongRunning\LongRunningConnectionInterface;
 use Google\Cloud\Spanner\Admin\Database\V1\DatabaseAdminClient;
@@ -109,7 +110,7 @@ class Instance
      * @param string $projectId The project ID.
      * @param string $name The instance name.
      * @param bool $returnInt64AsObject If true, 64 bit integers will be
-     *        returned as a {@see Google\Cloud\Int64} object for 32 bit platform
+     *        returned as a {@see Google\Cloud\Core\Int64} object for 32 bit platform
      *        compatibility. **Defaults to** false.
      * @param array $info [optional] A representation of the instance object.
      */

--- a/src/Spanner/Operation.php
+++ b/src/Spanner/Operation.php
@@ -58,8 +58,8 @@ class Operation
      * @param ConnectionInterface $connection A connection to Google Cloud
      *        Spanner.
      * @param bool $returnInt64AsObject If true, 64 bit integers will be
-     *        returned as a {@see Google\Cloud\Int64} object for 32 bit platform
-     *        compatibility.
+     *        returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
+     *        platform compatibility.
      */
     public function __construct(ConnectionInterface $connection, $returnInt64AsObject)
     {
@@ -115,7 +115,7 @@ class Operation
      * @param array $options [optional] {
      *     Configuration options.
      *
-     *     @type string $transactionId
+     *     @type string $transactionId The ID of the transaction.
      * }
      * @return Timestamp The commit Timestamp.
      */

--- a/src/Spanner/Session/Session.php
+++ b/src/Spanner/Session/Session.php
@@ -129,6 +129,9 @@ class Session
         );
     }
 
+    /**
+     * @access private
+     */
     public function __debugInfo()
     {
         return [

--- a/src/Spanner/Session/SessionClient.php
+++ b/src/Spanner/Session/SessionClient.php
@@ -74,6 +74,12 @@ class SessionClient
         return $session;
     }
 
+    /**
+     * Get a Session
+     *
+     * @param string $sessionName The Session name.
+     * @return Session
+     */
     public function session($sessionName)
     {
         return new Session(
@@ -85,6 +91,9 @@ class SessionClient
         );
     }
 
+    /**
+     * @access private
+     */
     public function __debugInfo()
     {
         return [

--- a/src/Spanner/Session/SessionPool.php
+++ b/src/Spanner/Session/SessionPool.php
@@ -17,6 +17,9 @@
 
 namespace Google\Cloud\Spanner\Session;
 
+/**
+ * Manages a pool of sessions
+ */
 class SessionPool implements SessionPoolInterface
 {
     private $sessionClient;
@@ -26,21 +29,33 @@ class SessionPool implements SessionPoolInterface
      */
     private $sessions = [];
 
+    /**
+     * @access private
+     */
     public function __construct(SessionClient $sessionClient)
     {
         $this->sessionClient = $sessionClient;
     }
 
+    /**
+     * @access private
+     */
     public function addSession(Session $session)
     {
         $this->sessions[] = $sessions;
     }
 
+    /**
+     * @access private
+     */
     public function session($instance, $database, $context, array $options = [])
     {
         return array_rand($this->sessions);
     }
 
+    /**
+     * @access private
+     */
     public function refreshSessions()
     {
         // send a request from each session to keep it alive.

--- a/src/Spanner/Session/SessionPoolInterface.php
+++ b/src/Spanner/Session/SessionPoolInterface.php
@@ -17,10 +17,16 @@
 
 namespace Google\Cloud\Spanner\Session;
 
+/**
+ * Describes a session pool.
+ */
 interface SessionPoolInterface
 {
     const CONTEXT_READ = 'r';
     const CONTEXT_READWRITE = 'rw';
 
+    /**
+     * Get a session from the pool
+     */
     public function session($instance, $database, $context, array $options = []);
 }

--- a/src/Spanner/Session/SimpleSessionPool.php
+++ b/src/Spanner/Session/SimpleSessionPool.php
@@ -17,6 +17,9 @@
 
 namespace Google\Cloud\Spanner\Session;
 
+/**
+ * A simple session pool.
+ */
 class SimpleSessionPool implements SessionPoolInterface
 {
     /**
@@ -29,11 +32,17 @@ class SimpleSessionPool implements SessionPoolInterface
      */
     private $sessions = [];
 
+    /**
+     * @access private
+     */
     public function __construct(SessionClient $sessionClient)
     {
         $this->sessionClient = $sessionClient;
     }
 
+    /**
+     * @access private
+     */
     public function session($instance, $database, $mode, array $options = [])
     {
         if (!isset($this->sessions[$instance.$database.$mode])) {

--- a/src/Spanner/SpannerClient.php
+++ b/src/Spanner/SpannerClient.php
@@ -23,6 +23,7 @@ use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Int64;
 use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Core\Iterator\PageIterator;
+use Google\Cloud\Core\LongRunning\LongRunningOperation;
 use Google\Cloud\Core\LongRunning\LROTrait;
 use Google\Cloud\Core\ValidateTrait;
 use Google\Cloud\Spanner\Admin\Database\V1\DatabaseAdminClient;
@@ -32,6 +33,7 @@ use Google\Cloud\Spanner\Connection\LongRunningConnection;
 use Google\Cloud\Spanner\Session\SessionClient;
 use Google\Cloud\Spanner\Session\SimpleSessionPool;
 use google\spanner\admin\instance\v1\Instance\State;
+use Psr\Http\StreamInterface;
 
 /**
  * Google Cloud Spanner is a highly scalable, transactional, managed, NewSQL
@@ -104,7 +106,7 @@ class SpannerClient
      *           **Defaults to** `3`.
      *     @type array $scopes Scopes to be used for the request.
      *     @type bool $returnInt64AsObject If true, 64 bit integers will be
-     *           returned as a {@see Google\Cloud\Int64} object for 32 bit
+     *           returned as a {@see Google\Cloud\Core\Int64} object for 32 bit
      *           platform compatibility. **Defaults to** false.
      * }
      * @throws Google\Cloud\Exception\GoogleException

--- a/src/Spanner/Transaction.php
+++ b/src/Spanner/Transaction.php
@@ -35,7 +35,7 @@ use RuntimeException;
  * {@see Google\Cloud\Spanner\Snapshot} is a better solution which does not
  * require a commit or rollback and does not lock any data.
  *
- * Transactions may raise {@see Google\Cloud\Exception\AbortedException} errors
+ * Transactions may raise {@see Google\Cloud\Core\Exception\AbortedException} errors
  * when the transaction cannot complete for any reason. In this case, the entire
  * operation (all reads and writes) should be reapplied atomically. Google Cloud
  * PHP handles this transparently when using

--- a/src/Spanner/TransactionConfigurationTrait.php
+++ b/src/Spanner/TransactionConfigurationTrait.php
@@ -20,6 +20,9 @@ namespace Google\Cloud\Spanner;
 use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
 
+/**
+ * Manage shared transaction configuration.
+ */
 trait TransactionConfigurationTrait
 {
     use ArrayTrait;

--- a/src/Spanner/ValueMapper.php
+++ b/src/Spanner/ValueMapper.php
@@ -21,6 +21,9 @@ use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\Int64;
 use google\spanner\v1\TypeCode;
 
+/**
+ * Manage value mappings between Google Cloud PHP and Cloud Spanner
+ */
 class ValueMapper
 {
     use ArrayTrait;
@@ -43,6 +46,9 @@ class ValueMapper
      */
     private $returnInt64AsObject;
 
+    /**
+     * @param bool $returnInt64AsObject
+     */
     public function __construct($returnInt64AsObject)
     {
         $this->returnInt64AsObject = $returnInt64AsObject;

--- a/tests/unit/Spanner/SpannerClientTest.php
+++ b/tests/unit/Spanner/SpannerClientTest.php
@@ -48,6 +48,10 @@ class SpannerClientTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (!extension_loaded('grpc')) {
+            $this->markTestSkipped('Must have the grpc extension installed to run this test.');
+        }
+
         $this->connection = $this->prophesize(ConnectionInterface::class);
         $this->client = \Google\Cloud\Dev\stub(SpannerClient::class, [
             ['projectId' => self::PROJECT]


### PR DESCRIPTION
The big change here is an addition to `Google\Cloud\Core\PhpArray::filterValue()` to short-circuit any decoding logic if the value given matches a null field type reference. This change passes the various test suites, but potential side effects should be investigated further.

Additionally, since SpannerClient relies indirectly on grpc constants which do not exist if gRPC is not installed, the entire SpannerClient file is skipped in the absence of the grpc extension.