### PR TITLE
[core, language] Add support for Language method AnalyzeEntitySentiment

### DIFF
--- a/src/Core/RestTrait.php
+++ b/src/Core/RestTrait.php
@@ -63,7 +63,14 @@ trait RestTrait
      *
      * @param string $resource The resource type used for the request.
      * @param string $method The method used for the request.
-     * @param array $options [optional] Options used to build out the request.
+     * @param array $options [optional] {
+     *     Options used to build out the request.
+     *
+     *     @type RequestBuilder $requestBuilder An instance of RequestBuilder.
+     *           If provided, the request will be constructed using the given
+     *           instance, rather than the one found in the `$requestBuilder`
+     *           property.
+     * }
      * @return array
      */
     public function send($resource, $method, array $options = [])
@@ -74,9 +81,14 @@ trait RestTrait
             'requestTimeout'
         ], $options);
 
+        $requestBuilder = $this->pluck('requestBuilder', $options, false);
+        if (is_null($requestBuilder) || !($requestBuilder instanceof RequestBuilder)) {
+            $requestBuilder = $this->requestBuilder;
+        }
+
         return json_decode(
             $this->requestWrapper->send(
-                $this->requestBuilder->build($resource, $method, $options),
+                $requestBuilder->build($resource, $method, $options),
                 $requestOptions
             )->getBody(),
             true

--- a/src/NaturalLanguage/Annotation.php
+++ b/src/NaturalLanguage/Annotation.php
@@ -31,6 +31,7 @@ use Google\Cloud\Core\CallTrait;
  * Annotations are returned by
  * {@see Google\Cloud\NaturalLanguage\NaturalLanguageClient::analyzeEntities()},
  * {@see Google\Cloud\NaturalLanguage\NaturalLanguageClient::analyzeSentiment()},
+ * {@see Google\Cloud\NaturalLanguage\NaturalLanguageClient::analyzeEntitySentiment()},
  * {@see Google\Cloud\NaturalLanguage\NaturalLanguageClient::analyzeSyntax()} and
  * {@see Google\Cloud\NaturalLanguage\NaturalLanguageClient::annotateText()}.
  *
@@ -53,7 +54,7 @@ use Google\Cloud\Core\CallTrait;
  *     }
  *     ```
  *
- *     @see https://cloud.google.com/natural-language/docs/reference/rest/v1beta1/Sentence Sentence type documentation
+ *     @see https://cloud.google.com/natural-language/docs/reference/rest/v1/Sentence Sentence type documentation
  *
  *     @return array|null
  * }
@@ -67,7 +68,7 @@ use Google\Cloud\Core\CallTrait;
  *     }
  *     ```
  *
- *     @see https://cloud.google.com/natural-language/docs/reference/rest/v1beta1/Token Token type documentation
+ *     @see https://cloud.google.com/natural-language/docs/reference/rest/v1/Token Token type documentation
  *
  *     @return array|null
  * }
@@ -81,7 +82,7 @@ use Google\Cloud\Core\CallTrait;
  *     }
  *     ```
  *
- *     @see https://cloud.google.com/natural-language/docs/reference/rest/v1beta1/Entity Entity type documentation
+ *     @see https://cloud.google.com/natural-language/docs/reference/rest/v1/Entity Entity type documentation
  *
  *     @return array|null
  * }
@@ -124,7 +125,7 @@ class Annotation
      * ```
      *
      * @codingStandardsIgnoreStart
-     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1beta1/documents/annotateText#response-body Annotate Text documentation
+     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1/documents/annotateText#response-body Annotate Text documentation
      * @codingStandardsIgnoreEnd
      *
      * @return array
@@ -146,7 +147,7 @@ class Annotation
      * }
      * ```
      *
-     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1beta1/Sentiment Sentiment type documentation
+     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1/Sentiment Sentiment type documentation
      *
      * @return array|null
      */
@@ -168,7 +169,7 @@ class Annotation
      * ```
      *
      * @codingStandardsIgnoreStart
-     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1beta1/Token#Tag Token tags documentation
+     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1/Token#Tag Token tags documentation
      * @codingStandardsIgnoreEnd
      *
      * @return array|null
@@ -195,7 +196,7 @@ class Annotation
      * ```
      *
      * @codingStandardsIgnoreStart
-     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1beta1/Token#Label Token labels documentation
+     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1/Token#Label Token labels documentation
      * @codingStandardsIgnoreEnd
      *
      * @return array|null
@@ -222,7 +223,7 @@ class Annotation
      * ```
      *
      * @codingStandardsIgnoreStart
-     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1beta1/Entity#Type Entity types documentation
+     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1/Entity#Type Entity types documentation
      * @codingStandardsIgnoreEnd
      *
      * @return array|null

--- a/src/NaturalLanguage/Connection/ConnectionInterface.php
+++ b/src/NaturalLanguage/Connection/ConnectionInterface.php
@@ -39,6 +39,12 @@ interface ConnectionInterface
      * @param array $args
      * @return array
      */
+    public function analyzeEntitySentiment(array $args = []);
+
+    /**
+     * @param array $args
+     * @return array
+     */
     public function analyzeSyntax(array $args = []);
 
     /**

--- a/src/NaturalLanguage/Connection/Rest.php
+++ b/src/NaturalLanguage/Connection/Rest.php
@@ -35,6 +35,11 @@ class Rest implements ConnectionInterface
     const BASE_URI = 'https://language.googleapis.com/';
 
     /**
+     * @var RequestBuilder
+     */
+    private $betaRequestBuilder;
+
+    /**
      * @param array $config
      */
     public function __construct(array $config = [])
@@ -49,6 +54,11 @@ class Rest implements ConnectionInterface
             $config['serviceDefinitionPath'],
             self::BASE_URI
         ));
+
+        $this->betaRequestBuilder = new RequestBuilder(
+            __DIR__ . '/ServiceDefinition/language-v1beta2.json',
+            self::BASE_URI
+        );
     }
 
     /**
@@ -67,6 +77,17 @@ class Rest implements ConnectionInterface
     public function analyzeSentiment(array $args = [])
     {
         return $this->send('documents', 'analyzeSentiment', $args);
+    }
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    public function analyzeEntitySentiment(array $args = [])
+    {
+        return $this->send('documents', 'analyzeEntitySentiment', [
+            'requestBuilder' => $this->betaRequestBuilder
+        ] + $args);
     }
 
     /**

--- a/src/NaturalLanguage/Connection/ServiceDefinition/language-v1beta2.json
+++ b/src/NaturalLanguage/Connection/ServiceDefinition/language-v1beta2.json
@@ -1,0 +1,1160 @@
+{
+  "version": "v1beta2",
+  "baseUrl": "https://language.googleapis.com/",
+  "servicePath": "",
+  "kind": "discovery#restDescription",
+  "description": "Google Cloud Natural Language API provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.",
+  "basePath": "",
+  "id": "language:v1beta2",
+  "revision": "20170401",
+  "documentationLink": "https://cloud.google.com/natural-language/",
+  "discoveryVersion": "v1",
+  "version_module": "True",
+  "schemas": {
+    "AnalyzeEntitySentimentResponse": {
+      "properties": {
+        "language": {
+          "description": "The language of the text, which will be the same as the language specified\nin the request or, if not specified, the automatically-detected language.\nSee Document.language field for more details.",
+          "type": "string"
+        },
+        "entities": {
+          "description": "The recognized entities in the input document with associated sentiments.",
+          "type": "array",
+          "items": {
+            "$ref": "Entity"
+          }
+        }
+      },
+      "id": "AnalyzeEntitySentimentResponse",
+      "description": "The entity-level sentiment analysis response message.",
+      "type": "object"
+    },
+    "AnalyzeEntitySentimentRequest": {
+      "properties": {
+        "encodingType": {
+          "enumDescriptions": [
+            "If `EncodingType` is not specified, encoding-dependent information (such as\n`begin_offset`) will be set at `-1`.",
+            "Encoding-dependent information (such as `begin_offset`) is calculated based\non the UTF-8 encoding of the input. C++ and Go are examples of languages\nthat use this encoding natively.",
+            "Encoding-dependent information (such as `begin_offset`) is calculated based\non the UTF-16 encoding of the input. Java and Javascript are examples of\nlanguages that use this encoding natively.",
+            "Encoding-dependent information (such as `begin_offset`) is calculated based\non the UTF-32 encoding of the input. Python is an example of a language\nthat uses this encoding natively."
+          ],
+          "enum": [
+            "NONE",
+            "UTF8",
+            "UTF16",
+            "UTF32"
+          ],
+          "description": "The encoding type used by the API to calculate offsets.",
+          "type": "string"
+        },
+        "document": {
+          "description": "Input document.",
+          "$ref": "Document"
+        }
+      },
+      "id": "AnalyzeEntitySentimentRequest",
+      "description": "The entity-level sentiment analysis request message.",
+      "type": "object"
+    },
+    "PartOfSpeech": {
+      "id": "PartOfSpeech",
+      "description": "Represents part of speech information for a token.",
+      "type": "object",
+      "properties": {
+        "proper": {
+          "enumDescriptions": [
+            "Proper is not applicable in the analyzed language or is not predicted.",
+            "Proper",
+            "Not proper"
+          ],
+          "enum": [
+            "PROPER_UNKNOWN",
+            "PROPER",
+            "NOT_PROPER"
+          ],
+          "description": "The grammatical properness.",
+          "type": "string"
+        },
+        "case": {
+          "enum": [
+            "CASE_UNKNOWN",
+            "ACCUSATIVE",
+            "ADVERBIAL",
+            "COMPLEMENTIVE",
+            "DATIVE",
+            "GENITIVE",
+            "INSTRUMENTAL",
+            "LOCATIVE",
+            "NOMINATIVE",
+            "OBLIQUE",
+            "PARTITIVE",
+            "PREPOSITIONAL",
+            "REFLEXIVE_CASE",
+            "RELATIVE_CASE",
+            "VOCATIVE"
+          ],
+          "description": "The grammatical case.",
+          "type": "string",
+          "enumDescriptions": [
+            "Case is not applicable in the analyzed language or is not predicted.",
+            "Accusative",
+            "Adverbial",
+            "Complementive",
+            "Dative",
+            "Genitive",
+            "Instrumental",
+            "Locative",
+            "Nominative",
+            "Oblique",
+            "Partitive",
+            "Prepositional",
+            "Reflexive",
+            "Relative",
+            "Vocative"
+          ]
+        },
+        "tense": {
+          "enumDescriptions": [
+            "Tense is not applicable in the analyzed language or is not predicted.",
+            "Conditional",
+            "Future",
+            "Past",
+            "Present",
+            "Imperfect",
+            "Pluperfect"
+          ],
+          "enum": [
+            "TENSE_UNKNOWN",
+            "CONDITIONAL_TENSE",
+            "FUTURE",
+            "PAST",
+            "PRESENT",
+            "IMPERFECT",
+            "PLUPERFECT"
+          ],
+          "description": "The grammatical tense.",
+          "type": "string"
+        },
+        "reciprocity": {
+          "description": "The grammatical reciprocity.",
+          "type": "string",
+          "enumDescriptions": [
+            "Reciprocity is not applicable in the analyzed language or is not\npredicted.",
+            "Reciprocal",
+            "Non-reciprocal"
+          ],
+          "enum": [
+            "RECIPROCITY_UNKNOWN",
+            "RECIPROCAL",
+            "NON_RECIPROCAL"
+          ]
+        },
+        "form": {
+          "description": "The grammatical form.",
+          "type": "string",
+          "enumDescriptions": [
+            "Form is not applicable in the analyzed language or is not predicted.",
+            "Adnomial",
+            "Auxiliary",
+            "Complementizer",
+            "Final ending",
+            "Gerund",
+            "Realis",
+            "Irrealis",
+            "Short form",
+            "Long form",
+            "Order form",
+            "Specific form"
+          ],
+          "enum": [
+            "FORM_UNKNOWN",
+            "ADNOMIAL",
+            "AUXILIARY",
+            "COMPLEMENTIZER",
+            "FINAL_ENDING",
+            "GERUND",
+            "REALIS",
+            "IRREALIS",
+            "SHORT",
+            "LONG",
+            "ORDER",
+            "SPECIFIC"
+          ]
+        },
+        "number": {
+          "enumDescriptions": [
+            "Number is not applicable in the analyzed language or is not predicted.",
+            "Singular",
+            "Plural",
+            "Dual"
+          ],
+          "enum": [
+            "NUMBER_UNKNOWN",
+            "SINGULAR",
+            "PLURAL",
+            "DUAL"
+          ],
+          "description": "The grammatical number.",
+          "type": "string"
+        },
+        "voice": {
+          "enumDescriptions": [
+            "Voice is not applicable in the analyzed language or is not predicted.",
+            "Active",
+            "Causative",
+            "Passive"
+          ],
+          "enum": [
+            "VOICE_UNKNOWN",
+            "ACTIVE",
+            "CAUSATIVE",
+            "PASSIVE"
+          ],
+          "description": "The grammatical voice.",
+          "type": "string"
+        },
+        "aspect": {
+          "enumDescriptions": [
+            "Aspect is not applicable in the analyzed language or is not predicted.",
+            "Perfective",
+            "Imperfective",
+            "Progressive"
+          ],
+          "enum": [
+            "ASPECT_UNKNOWN",
+            "PERFECTIVE",
+            "IMPERFECTIVE",
+            "PROGRESSIVE"
+          ],
+          "description": "The grammatical aspect.",
+          "type": "string"
+        },
+        "mood": {
+          "enum": [
+            "MOOD_UNKNOWN",
+            "CONDITIONAL_MOOD",
+            "IMPERATIVE",
+            "INDICATIVE",
+            "INTERROGATIVE",
+            "JUSSIVE",
+            "SUBJUNCTIVE"
+          ],
+          "description": "The grammatical mood.",
+          "type": "string",
+          "enumDescriptions": [
+            "Mood is not applicable in the analyzed language or is not predicted.",
+            "Conditional",
+            "Imperative",
+            "Indicative",
+            "Interrogative",
+            "Jussive",
+            "Subjunctive"
+          ]
+        },
+        "tag": {
+          "enum": [
+            "UNKNOWN",
+            "ADJ",
+            "ADP",
+            "ADV",
+            "CONJ",
+            "DET",
+            "NOUN",
+            "NUM",
+            "PRON",
+            "PRT",
+            "PUNCT",
+            "VERB",
+            "X",
+            "AFFIX"
+          ],
+          "description": "The part of speech tag.",
+          "type": "string",
+          "enumDescriptions": [
+            "Unknown",
+            "Adjective",
+            "Adposition (preposition and postposition)",
+            "Adverb",
+            "Conjunction",
+            "Determiner",
+            "Noun (common and proper)",
+            "Cardinal number",
+            "Pronoun",
+            "Particle or other function word",
+            "Punctuation",
+            "Verb (all tenses and modes)",
+            "Other: foreign words, typos, abbreviations",
+            "Affix"
+          ]
+        },
+        "gender": {
+          "enumDescriptions": [
+            "Gender is not applicable in the analyzed language or is not predicted.",
+            "Feminine",
+            "Masculine",
+            "Neuter"
+          ],
+          "enum": [
+            "GENDER_UNKNOWN",
+            "FEMININE",
+            "MASCULINE",
+            "NEUTER"
+          ],
+          "description": "The grammatical gender.",
+          "type": "string"
+        },
+        "person": {
+          "description": "The grammatical person.",
+          "type": "string",
+          "enumDescriptions": [
+            "Person is not applicable in the analyzed language or is not predicted.",
+            "First",
+            "Second",
+            "Third",
+            "Reflexive"
+          ],
+          "enum": [
+            "PERSON_UNKNOWN",
+            "FIRST",
+            "SECOND",
+            "THIRD",
+            "REFLEXIVE_PERSON"
+          ]
+        }
+      }
+    },
+    "AnalyzeSyntaxRequest": {
+      "description": "The syntax analysis request message.",
+      "type": "object",
+      "properties": {
+        "encodingType": {
+          "description": "The encoding type used by the API to calculate offsets.",
+          "type": "string",
+          "enumDescriptions": [
+            "If `EncodingType` is not specified, encoding-dependent information (such as\n`begin_offset`) will be set at `-1`.",
+            "Encoding-dependent information (such as `begin_offset`) is calculated based\non the UTF-8 encoding of the input. C++ and Go are examples of languages\nthat use this encoding natively.",
+            "Encoding-dependent information (such as `begin_offset`) is calculated based\non the UTF-16 encoding of the input. Java and Javascript are examples of\nlanguages that use this encoding natively.",
+            "Encoding-dependent information (such as `begin_offset`) is calculated based\non the UTF-32 encoding of the input. Python is an example of a language\nthat uses this encoding natively."
+          ],
+          "enum": [
+            "NONE",
+            "UTF8",
+            "UTF16",
+            "UTF32"
+          ]
+        },
+        "document": {
+          "description": "Input document.",
+          "$ref": "Document"
+        }
+      },
+      "id": "AnalyzeSyntaxRequest"
+    },
+    "AnalyzeSentimentResponse": {
+      "description": "The sentiment analysis response message.",
+      "type": "object",
+      "properties": {
+        "documentSentiment": {
+          "$ref": "Sentiment",
+          "description": "The overall sentiment of the input document."
+        },
+        "language": {
+          "description": "The language of the text, which will be the same as the language specified\nin the request or, if not specified, the automatically-detected language.",
+          "type": "string"
+        },
+        "sentences": {
+          "description": "The sentiment for all the sentences in the document.",
+          "type": "array",
+          "items": {
+            "$ref": "Sentence"
+          }
+        }
+      },
+      "id": "AnalyzeSentimentResponse"
+    },
+    "AnalyzeEntitiesResponse": {
+      "description": "The entity analysis response message.",
+      "type": "object",
+      "properties": {
+        "entities": {
+          "type": "array",
+          "items": {
+            "$ref": "Entity"
+          },
+          "description": "The recognized entities in the input document."
+        },
+        "language": {
+          "description": "The language of the text, which will be the same as the language specified\nin the request or, if not specified, the automatically-detected language.\nSee Document.language field for more details.",
+          "type": "string"
+        }
+      },
+      "id": "AnalyzeEntitiesResponse"
+    },
+    "Entity": {
+      "properties": {
+        "name": {
+          "description": "The representative name for the entity.",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "UNKNOWN",
+            "PERSON",
+            "LOCATION",
+            "ORGANIZATION",
+            "EVENT",
+            "WORK_OF_ART",
+            "CONSUMER_GOOD",
+            "OTHER"
+          ],
+          "description": "The entity type.",
+          "type": "string",
+          "enumDescriptions": [
+            "Unknown",
+            "Person",
+            "Location",
+            "Organization",
+            "Event",
+            "Work of art",
+            "Consumer goods",
+            "Other types"
+          ]
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Metadata associated with the entity.\n\nCurrently, Wikipedia URLs and Knowledge Graph MIDs are provided, if\navailable. The associated keys are \"wikipedia_url\" and \"mid\", respectively."
+        },
+        "salience": {
+          "description": "The salience score associated with the entity in the [0, 1.0] range.\n\nThe salience score for an entity provides information about the\nimportance or centrality of that entity to the entire document text.\nScores closer to 0 are less salient, while scores closer to 1.0 are highly\nsalient.",
+          "format": "float",
+          "type": "number"
+        },
+        "sentiment": {
+          "$ref": "Sentiment",
+          "description": "For calls to AnalyzeEntitySentiment or if\nAnnotateTextRequest.Features.extract_entity_sentiment is set to\ntrue, this field will contain the aggregate sentiment expressed for this\nentity in the provided document."
+        },
+        "mentions": {
+          "description": "The mentions of this entity in the input document. The API currently\nsupports proper noun mentions.",
+          "type": "array",
+          "items": {
+            "$ref": "EntityMention"
+          }
+        }
+      },
+      "id": "Entity",
+      "description": "Represents a phrase in the text that is a known entity, such as\na person, an organization, or location. The API associates information, such\nas salience and mentions, with entities.",
+      "type": "object"
+    },
+    "AnalyzeSyntaxResponse": {
+      "type": "object",
+      "properties": {
+        "language": {
+          "description": "The language of the text, which will be the same as the language specified\nin the request or, if not specified, the automatically-detected language.\nSee Document.language field for more details.",
+          "type": "string"
+        },
+        "sentences": {
+          "description": "Sentences in the input document.",
+          "type": "array",
+          "items": {
+            "$ref": "Sentence"
+          }
+        },
+        "tokens": {
+          "description": "Tokens, along with their syntactic information, in the input document.",
+          "type": "array",
+          "items": {
+            "$ref": "Token"
+          }
+        }
+      },
+      "id": "AnalyzeSyntaxResponse",
+      "description": "The syntax analysis response message."
+    },
+    "AnnotateTextRequest": {
+      "id": "AnnotateTextRequest",
+      "description": "The request message for the text annotation API, which can perform multiple\nanalysis types (sentiment, entities, and syntax) in one call.",
+      "type": "object",
+      "properties": {
+        "encodingType": {
+          "enum": [
+            "NONE",
+            "UTF8",
+            "UTF16",
+            "UTF32"
+          ],
+          "description": "The encoding type used by the API to calculate offsets.",
+          "type": "string",
+          "enumDescriptions": [
+            "If `EncodingType` is not specified, encoding-dependent information (such as\n`begin_offset`) will be set at `-1`.",
+            "Encoding-dependent information (such as `begin_offset`) is calculated based\non the UTF-8 encoding of the input. C++ and Go are examples of languages\nthat use this encoding natively.",
+            "Encoding-dependent information (such as `begin_offset`) is calculated based\non the UTF-16 encoding of the input. Java and Javascript are examples of\nlanguages that use this encoding natively.",
+            "Encoding-dependent information (such as `begin_offset`) is calculated based\non the UTF-32 encoding of the input. Python is an example of a language\nthat uses this encoding natively."
+          ]
+        },
+        "document": {
+          "$ref": "Document",
+          "description": "Input document."
+        },
+        "features": {
+          "description": "The enabled features.",
+          "$ref": "Features"
+        }
+      }
+    },
+    "AnnotateTextResponse": {
+      "description": "The text annotations response message.",
+      "type": "object",
+      "properties": {
+        "documentSentiment": {
+          "$ref": "Sentiment",
+          "description": "The overall sentiment for the document. Populated if the user enables\nAnnotateTextRequest.Features.extract_document_sentiment."
+        },
+        "language": {
+          "description": "The language of the text, which will be the same as the language specified\nin the request or, if not specified, the automatically-detected language.\nSee Document.language field for more details.",
+          "type": "string"
+        },
+        "sentences": {
+          "description": "Sentences in the input document. Populated if the user enables\nAnnotateTextRequest.Features.extract_syntax.",
+          "type": "array",
+          "items": {
+            "$ref": "Sentence"
+          }
+        },
+        "tokens": {
+          "description": "Tokens, along with their syntactic information, in the input document.\nPopulated if the user enables\nAnnotateTextRequest.Features.extract_syntax.",
+          "type": "array",
+          "items": {
+            "$ref": "Token"
+          }
+        },
+        "entities": {
+          "description": "Entities, along with their semantic information, in the input document.\nPopulated if the user enables\nAnnotateTextRequest.Features.extract_entities.",
+          "type": "array",
+          "items": {
+            "$ref": "Entity"
+          }
+        }
+      },
+      "id": "AnnotateTextResponse"
+    },
+    "AnalyzeSentimentRequest": {
+      "description": "The sentiment analysis request message.",
+      "type": "object",
+      "properties": {
+        "encodingType": {
+          "enum": [
+            "NONE",
+            "UTF8",
+            "UTF16",
+            "UTF32"
+          ],
+          "description": "The encoding type used by the API to calculate sentence offsets for the\nsentence sentiment.",
+          "type": "string",
+          "enumDescriptions": [
+            "If `EncodingType` is not specified, encoding-dependent information (such as\n`begin_offset`) will be set at `-1`.",
+            "Encoding-dependent information (such as `begin_offset`) is calculated based\non the UTF-8 encoding of the input. C++ and Go are examples of languages\nthat use this encoding natively.",
+            "Encoding-dependent information (such as `begin_offset`) is calculated based\non the UTF-16 encoding of the input. Java and Javascript are examples of\nlanguages that use this encoding natively.",
+            "Encoding-dependent information (such as `begin_offset`) is calculated based\non the UTF-32 encoding of the input. Python is an example of a language\nthat uses this encoding natively."
+          ]
+        },
+        "document": {
+          "$ref": "Document",
+          "description": "Input document. Currently, `analyzeSentiment` only supports English text\n(Document.language=\"EN\")."
+        }
+      },
+      "id": "AnalyzeSentimentRequest"
+    },
+    "DependencyEdge": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "enum": [
+            "UNKNOWN",
+            "ABBREV",
+            "ACOMP",
+            "ADVCL",
+            "ADVMOD",
+            "AMOD",
+            "APPOS",
+            "ATTR",
+            "AUX",
+            "AUXPASS",
+            "CC",
+            "CCOMP",
+            "CONJ",
+            "CSUBJ",
+            "CSUBJPASS",
+            "DEP",
+            "DET",
+            "DISCOURSE",
+            "DOBJ",
+            "EXPL",
+            "GOESWITH",
+            "IOBJ",
+            "MARK",
+            "MWE",
+            "MWV",
+            "NEG",
+            "NN",
+            "NPADVMOD",
+            "NSUBJ",
+            "NSUBJPASS",
+            "NUM",
+            "NUMBER",
+            "P",
+            "PARATAXIS",
+            "PARTMOD",
+            "PCOMP",
+            "POBJ",
+            "POSS",
+            "POSTNEG",
+            "PRECOMP",
+            "PRECONJ",
+            "PREDET",
+            "PREF",
+            "PREP",
+            "PRONL",
+            "PRT",
+            "PS",
+            "QUANTMOD",
+            "RCMOD",
+            "RCMODREL",
+            "RDROP",
+            "REF",
+            "REMNANT",
+            "REPARANDUM",
+            "ROOT",
+            "SNUM",
+            "SUFF",
+            "TMOD",
+            "TOPIC",
+            "VMOD",
+            "VOCATIVE",
+            "XCOMP",
+            "SUFFIX",
+            "TITLE",
+            "ADVPHMOD",
+            "AUXCAUS",
+            "AUXVV",
+            "DTMOD",
+            "FOREIGN",
+            "KW",
+            "LIST",
+            "NOMC",
+            "NOMCSUBJ",
+            "NOMCSUBJPASS",
+            "NUMC",
+            "COP",
+            "DISLOCATED"
+          ],
+          "description": "The parse label for the token.",
+          "type": "string",
+          "enumDescriptions": [
+            "Unknown",
+            "Abbreviation modifier",
+            "Adjectival complement",
+            "Adverbial clause modifier",
+            "Adverbial modifier",
+            "Adjectival modifier of an NP",
+            "Appositional modifier of an NP",
+            "Attribute dependent of a copular verb",
+            "Auxiliary (non-main) verb",
+            "Passive auxiliary",
+            "Coordinating conjunction",
+            "Clausal complement of a verb or adjective",
+            "Conjunct",
+            "Clausal subject",
+            "Clausal passive subject",
+            "Dependency (unable to determine)",
+            "Determiner",
+            "Discourse",
+            "Direct object",
+            "Expletive",
+            "Goes with (part of a word in a text not well edited)",
+            "Indirect object",
+            "Marker (word introducing a subordinate clause)",
+            "Multi-word expression",
+            "Multi-word verbal expression",
+            "Negation modifier",
+            "Noun compound modifier",
+            "Noun phrase used as an adverbial modifier",
+            "Nominal subject",
+            "Passive nominal subject",
+            "Numeric modifier of a noun",
+            "Element of compound number",
+            "Punctuation mark",
+            "Parataxis relation",
+            "Participial modifier",
+            "The complement of a preposition is a clause",
+            "Object of a preposition",
+            "Possession modifier",
+            "Postverbal negative particle",
+            "Predicate complement",
+            "Preconjunt",
+            "Predeterminer",
+            "Prefix",
+            "Prepositional modifier",
+            "The relationship between a verb and verbal morpheme",
+            "Particle",
+            "Associative or possessive marker",
+            "Quantifier phrase modifier",
+            "Relative clause modifier",
+            "Complementizer in relative clause",
+            "Ellipsis without a preceding predicate",
+            "Referent",
+            "Remnant",
+            "Reparandum",
+            "Root",
+            "Suffix specifying a unit of number",
+            "Suffix",
+            "Temporal modifier",
+            "Topic marker",
+            "Clause headed by an infinite form of the verb that modifies a noun",
+            "Vocative",
+            "Open clausal complement",
+            "Name suffix",
+            "Name title",
+            "Adverbial phrase modifier",
+            "Causative auxiliary",
+            "Helper auxiliary",
+            "Rentaishi (Prenominal modifier)",
+            "Foreign words",
+            "Keyword",
+            "List for chains of comparable items",
+            "Nominalized clause",
+            "Nominalized clausal subject",
+            "Nominalized clausal passive",
+            "Compound of numeric modifier",
+            "Copula",
+            "Dislocated relation (for fronted/topicalized elements)"
+          ]
+        },
+        "headTokenIndex": {
+          "description": "Represents the head of this token in the dependency tree.\nThis is the index of the token which has an arc going to this token.\nThe index is the position of the token in the array of tokens returned\nby the API method. If this token is a root token, then the\n`head_token_index` is its own index.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "id": "DependencyEdge",
+      "description": "Represents dependency parse tree information for a token."
+    },
+    "TextSpan": {
+      "description": "Represents an output piece of text.",
+      "type": "object",
+      "properties": {
+        "beginOffset": {
+          "description": "The API calculates the beginning offset of the content in the original\ndocument according to the EncodingType specified in the API request.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "content": {
+          "description": "The content of the output text.",
+          "type": "string"
+        }
+      },
+      "id": "TextSpan"
+    },
+    "Token": {
+      "description": "Represents the smallest syntactic building block of the text.",
+      "type": "object",
+      "properties": {
+        "partOfSpeech": {
+          "$ref": "PartOfSpeech",
+          "description": "Parts of speech tag for this token."
+        },
+        "text": {
+          "$ref": "TextSpan",
+          "description": "The token text."
+        },
+        "dependencyEdge": {
+          "$ref": "DependencyEdge",
+          "description": "Dependency tree parse for this token."
+        },
+        "lemma": {
+          "description": "[Lemma](https://en.wikipedia.org/wiki/Lemma_%28morphology%29) of the token.",
+          "type": "string"
+        }
+      },
+      "id": "Token"
+    },
+    "Status": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "The status code, which should be an enum value of google.rpc.Code.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "message": {
+          "description": "A developer-facing error message, which should be in English. Any\nuser-facing error message should be localized and sent in the\ngoogle.rpc.Status.details field, or localized by the client.",
+          "type": "string"
+        },
+        "details": {
+          "description": "A list of messages that carry the error details.  There will be a\ncommon set of message types for APIs to use.",
+          "type": "array",
+          "items": {
+            "additionalProperties": {
+              "description": "Properties of the object. Contains field @type with type URL.",
+              "type": "any"
+            },
+            "type": "object"
+          }
+        }
+      },
+      "id": "Status",
+      "description": "The `Status` type defines a logical error model that is suitable for different\nprogramming environments, including REST APIs and RPC APIs. It is used by\n[gRPC](https://github.com/grpc). The error model is designed to be:\n\n- Simple to use and understand for most users\n- Flexible enough to meet unexpected needs\n\n# Overview\n\nThe `Status` message contains three pieces of data: error code, error message,\nand error details. The error code should be an enum value of\ngoogle.rpc.Code, but it may accept additional error codes if needed.  The\nerror message should be a developer-facing English message that helps\ndevelopers *understand* and *resolve* the error. If a localized user-facing\nerror message is needed, put the localized message in the error details or\nlocalize it in the client. The optional error details may contain arbitrary\ninformation about the error. There is a predefined set of error detail types\nin the package `google.rpc` which can be used for common error conditions.\n\n# Language mapping\n\nThe `Status` message is the logical representation of the error model, but it\nis not necessarily the actual wire format. When the `Status` message is\nexposed in different client libraries and different wire protocols, it can be\nmapped differently. For example, it will likely be mapped to some exceptions\nin Java, but more likely mapped to some error codes in C.\n\n# Other uses\n\nThe error model and the `Status` message can be used in a variety of\nenvironments, either with or without APIs, to provide a\nconsistent developer experience across different environments.\n\nExample uses of this error model include:\n\n- Partial errors. If a service needs to return partial errors to the client,\n    it may embed the `Status` in the normal response to indicate the partial\n    errors.\n\n- Workflow errors. A typical workflow has multiple steps. Each step may\n    have a `Status` message for error reporting purpose.\n\n- Batch operations. If a client uses batch request and batch response, the\n    `Status` message should be used directly inside batch response, one for\n    each error sub-response.\n\n- Asynchronous operations. If an API call embeds asynchronous operation\n    results in its response, the status of those operations should be\n    represented directly using the `Status` message.\n\n- Logging. If some API errors are stored in logs, the message `Status` could\n    be used directly after any stripping needed for security/privacy reasons."
+    },
+    "Features": {
+      "description": "All available features for sentiment, syntax, and semantic analysis.\nSetting each one to true will enable that specific analysis for the input.",
+      "type": "object",
+      "properties": {
+        "extractSyntax": {
+          "description": "Extract syntax information.",
+          "type": "boolean"
+        },
+        "extractDocumentSentiment": {
+          "description": "Extract document-level sentiment.",
+          "type": "boolean"
+        },
+        "extractEntitySentiment": {
+          "description": "Extract entities and their associated sentiment.",
+          "type": "boolean"
+        },
+        "extractEntities": {
+          "description": "Extract entities.",
+          "type": "boolean"
+        }
+      },
+      "id": "Features"
+    },
+    "EntityMention": {
+      "description": "Represents a mention for an entity in the text. Currently, proper noun\nmentions are supported.",
+      "type": "object",
+      "properties": {
+        "text": {
+          "description": "The mention text.",
+          "$ref": "TextSpan"
+        },
+        "type": {
+          "description": "The type of the entity mention.",
+          "type": "string",
+          "enumDescriptions": [
+            "Unknown",
+            "Proper name",
+            "Common noun (or noun compound)"
+          ],
+          "enum": [
+            "TYPE_UNKNOWN",
+            "PROPER",
+            "COMMON"
+          ]
+        },
+        "sentiment": {
+          "$ref": "Sentiment",
+          "description": "For calls to AnalyzeEntitySentiment or if\nAnnotateTextRequest.Features.extract_entity_sentiment is set to\ntrue, this field will contain the sentiment expressed for this mention of\nthe entity in the provided document."
+        }
+      },
+      "id": "EntityMention"
+    },
+    "Document": {
+      "id": "Document",
+      "description": "################################################################ #\n\nRepresents the input to API methods.",
+      "type": "object",
+      "properties": {
+        "gcsContentUri": {
+          "description": "The Google Cloud Storage URI where the file content is located.\nThis URI must be of the form: gs://bucket_name/object_name. For more\ndetails, see https://cloud.google.com/storage/docs/reference-uris.\nNOTE: Cloud Storage object versioning is not supported.",
+          "type": "string"
+        },
+        "language": {
+          "description": "The language of the document (if not specified, the language is\nautomatically detected). Both ISO and BCP-47 language codes are\naccepted.\u003cbr\u003e\n**Current Language Restrictions:**\n\n * Only English, Spanish, and Japanese textual content are supported.\nIf the language (either specified by the caller or automatically detected)\nis not supported by the called API method, an `INVALID_ARGUMENT` error\nis returned.",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enumDescriptions": [
+            "The content type is not specified.",
+            "Plain text",
+            "HTML"
+          ],
+          "enum": [
+            "TYPE_UNSPECIFIED",
+            "PLAIN_TEXT",
+            "HTML"
+          ],
+          "description": "Required. If the type is not set or is `TYPE_UNSPECIFIED`,\nreturns an `INVALID_ARGUMENT` error."
+        },
+        "content": {
+          "description": "The content of the input in string format.",
+          "type": "string"
+        }
+      }
+    },
+    "Sentence": {
+      "properties": {
+        "text": {
+          "description": "The sentence text.",
+          "$ref": "TextSpan"
+        },
+        "sentiment": {
+          "$ref": "Sentiment",
+          "description": "For calls to AnalyzeSentiment or if\nAnnotateTextRequest.Features.extract_document_sentiment is set to\ntrue, this field will contain the sentiment for the sentence."
+        }
+      },
+      "id": "Sentence",
+      "description": "Represents a sentence in the input document.",
+      "type": "object"
+    },
+    "Sentiment": {
+      "id": "Sentiment",
+      "description": "Represents the feeling associated with the entire text or entities in\nthe text.",
+      "type": "object",
+      "properties": {
+        "score": {
+          "description": "Sentiment score between -1.0 (negative sentiment) and 1.0\n(positive sentiment).",
+          "format": "float",
+          "type": "number"
+        },
+        "magnitude": {
+          "type": "number",
+          "description": "A non-negative number in the [0, +inf) range, which represents\nthe absolute magnitude of sentiment regardless of score (positive or\nnegative).",
+          "format": "float"
+        }
+      }
+    },
+    "AnalyzeEntitiesRequest": {
+      "properties": {
+        "encodingType": {
+          "description": "The encoding type used by the API to calculate offsets.",
+          "type": "string",
+          "enumDescriptions": [
+            "If `EncodingType` is not specified, encoding-dependent information (such as\n`begin_offset`) will be set at `-1`.",
+            "Encoding-dependent information (such as `begin_offset`) is calculated based\non the UTF-8 encoding of the input. C++ and Go are examples of languages\nthat use this encoding natively.",
+            "Encoding-dependent information (such as `begin_offset`) is calculated based\non the UTF-16 encoding of the input. Java and Javascript are examples of\nlanguages that use this encoding natively.",
+            "Encoding-dependent information (such as `begin_offset`) is calculated based\non the UTF-32 encoding of the input. Python is an example of a language\nthat uses this encoding natively."
+          ],
+          "enum": [
+            "NONE",
+            "UTF8",
+            "UTF16",
+            "UTF32"
+          ]
+        },
+        "document": {
+          "$ref": "Document",
+          "description": "Input document."
+        }
+      },
+      "id": "AnalyzeEntitiesRequest",
+      "description": "The entity analysis request message.",
+      "type": "object"
+    }
+  },
+  "protocol": "rest",
+  "icons": {
+    "x16": "http://www.google.com/images/icons/product/search-16.gif",
+    "x32": "http://www.google.com/images/icons/product/search-32.gif"
+  },
+  "canonicalName": "Cloud Natural Language",
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/cloud-platform": {
+          "description": "View and manage your data across Google Cloud Platform services"
+        }
+      }
+    }
+  },
+  "rootUrl": "https://language.googleapis.com/",
+  "ownerDomain": "google.com",
+  "name": "language",
+  "batchPath": "batch",
+  "title": "Google Cloud Natural Language API",
+  "ownerName": "Google",
+  "resources": {
+    "documents": {
+      "methods": {
+        "analyzeSyntax": {
+          "path": "v1beta2/documents:analyzeSyntax",
+          "id": "language.documents.analyzeSyntax",
+          "description": "Analyzes the syntax of the text and provides sentence boundaries and\ntokenization along with part of speech tags, dependency trees, and other\nproperties.",
+          "request": {
+            "$ref": "AnalyzeSyntaxRequest"
+          },
+          "response": {
+            "$ref": "AnalyzeSyntaxResponse"
+          },
+          "parameterOrder": [],
+          "httpMethod": "POST",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform"
+          ],
+          "parameters": {},
+          "flatPath": "v1beta2/documents:analyzeSyntax"
+        },
+        "analyzeSentiment": {
+          "path": "v1beta2/documents:analyzeSentiment",
+          "id": "language.documents.analyzeSentiment",
+          "request": {
+            "$ref": "AnalyzeSentimentRequest"
+          },
+          "description": "Analyzes the sentiment of the provided text.",
+          "response": {
+            "$ref": "AnalyzeSentimentResponse"
+          },
+          "parameterOrder": [],
+          "httpMethod": "POST",
+          "parameters": {},
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform"
+          ],
+          "flatPath": "v1beta2/documents:analyzeSentiment"
+        },
+        "annotateText": {
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform"
+          ],
+          "parameters": {},
+          "flatPath": "v1beta2/documents:annotateText",
+          "id": "language.documents.annotateText",
+          "path": "v1beta2/documents:annotateText",
+          "description": "A convenience method that provides all syntax, sentiment, and entity\nfeatures in one call.",
+          "request": {
+            "$ref": "AnnotateTextRequest"
+          },
+          "httpMethod": "POST",
+          "parameterOrder": [],
+          "response": {
+            "$ref": "AnnotateTextResponse"
+          }
+        },
+        "analyzeEntitySentiment": {
+          "response": {
+            "$ref": "AnalyzeEntitySentimentResponse"
+          },
+          "parameterOrder": [],
+          "httpMethod": "POST",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform"
+          ],
+          "parameters": {},
+          "flatPath": "v1beta2/documents:analyzeEntitySentiment",
+          "path": "v1beta2/documents:analyzeEntitySentiment",
+          "id": "language.documents.analyzeEntitySentiment",
+          "description": "Finds entities, similar to AnalyzeEntities in the text and analyzes\nsentiment associated with each entity and its mentions.",
+          "request": {
+            "$ref": "AnalyzeEntitySentimentRequest"
+          }
+        },
+        "analyzeEntities": {
+          "response": {
+            "$ref": "AnalyzeEntitiesResponse"
+          },
+          "parameterOrder": [],
+          "httpMethod": "POST",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform"
+          ],
+          "parameters": {},
+          "flatPath": "v1beta2/documents:analyzeEntities",
+          "path": "v1beta2/documents:analyzeEntities",
+          "id": "language.documents.analyzeEntities",
+          "description": "Finds named entities (currently proper names and common nouns) in the text\nalong with entity types, salience, mentions for each entity, and\nother properties.",
+          "request": {
+            "$ref": "AnalyzeEntitiesRequest"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "upload_protocol": {
+      "location": "query",
+      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+      "type": "string"
+    },
+    "prettyPrint": {
+      "location": "query",
+      "description": "Returns response with indentations and line breaks.",
+      "type": "boolean",
+      "default": "true"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "type": "string",
+      "location": "query"
+    },
+    "uploadType": {
+      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+      "type": "string",
+      "location": "query"
+    },
+    "callback": {
+      "location": "query",
+      "description": "JSONP",
+      "type": "string"
+    },
+    "$.xgafv": {
+      "type": "string",
+      "enumDescriptions": [
+        "v1 error format",
+        "v2 error format"
+      ],
+      "location": "query",
+      "enum": [
+        "1",
+        "2"
+      ],
+      "description": "V1 error format."
+    },
+    "alt": {
+      "description": "Data format for response.",
+      "default": "json",
+      "enum": [
+        "json",
+        "media",
+        "proto"
+      ],
+      "type": "string",
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json",
+        "Media download with context-dependent Content-Type",
+        "Responses with Content-Type of application/x-protobuf"
+      ],
+      "location": "query"
+    },
+    "access_token": {
+      "description": "OAuth access token.",
+      "type": "string",
+      "location": "query"
+    },
+    "key": {
+      "location": "query",
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "type": "string"
+    },
+    "quotaUser": {
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+      "type": "string",
+      "location": "query"
+    },
+    "pp": {
+      "description": "Pretty-print response.",
+      "type": "boolean",
+      "default": "true",
+      "location": "query"
+    },
+    "bearer_token": {
+      "location": "query",
+      "description": "OAuth bearer token.",
+      "type": "string"
+    },
+    "oauth_token": {
+      "location": "query",
+      "description": "OAuth 2.0 token for the current user.",
+      "type": "string"
+    }
+  }
+}

--- a/src/NaturalLanguage/NaturalLanguageClient.php
+++ b/src/NaturalLanguage/NaturalLanguageClient.php
@@ -222,7 +222,7 @@ class NaturalLanguageClient
      * $annotation = $language->analyzeEntitySentiment('Google Cloud Platform is a powerful tool.');
      * $entities = $annotation->entities();
      *
-     * echo 'Entity name: '. $entities[0]['name'] . PHP_EOL;
+     * echo 'Entity name: ' . $entities[0]['name'] . PHP_EOL;
      * if ($entities[0]['sentiment']['score'] > 0) {
      *     echo 'This is a positive message.';
      * }

--- a/src/NaturalLanguage/NaturalLanguageClient.php
+++ b/src/NaturalLanguage/NaturalLanguageClient.php
@@ -220,9 +220,10 @@ class NaturalLanguageClient
      * Example:
      * ```
      * $annotation = $language->analyzeEntitySentiment('Google Cloud Platform is a powerful tool.');
-     * $sentiment = $annotation->sentiment();
+     * $entities = $annotation->entities();
      *
-     * if ($sentiment['score'] > 0) {
+     * echo 'Entity name: '. $entities[0]['name'] . PHP_EOL;
+     * if ($entities[0]['sentiment']['score'] > 0) {
      *     echo 'This is a positive message.';
      * }
      * ```

--- a/src/NaturalLanguage/NaturalLanguageClient.php
+++ b/src/NaturalLanguage/NaturalLanguageClient.php
@@ -113,7 +113,7 @@ class NaturalLanguageClient
      * ```
      *
      * @codingStandardsIgnoreStart
-     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1beta1/documents/analyzeEntities Analyze Entities API documentation
+     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1/documents/analyzeEntities Analyze Entities API documentation
      * @codingStandardsIgnoreEnd
      *
      * @param string|StorageObject $content The content to analyze. May be
@@ -170,7 +170,7 @@ class NaturalLanguageClient
      * ```
      *
      * @codingStandardsIgnoreStart
-     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1beta1/documents/analyzeSentiment Analyze Sentiment API documentation
+     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1/documents/analyzeSentiment Analyze Sentiment API documentation
      * @codingStandardsIgnoreEnd
      *
      * @param string|StorageObject $content The content to analyze. May be
@@ -214,6 +214,64 @@ class NaturalLanguageClient
     }
 
     /**
+     * Finds entities in the text and analyzes sentiment associated with each
+     * entity and its mentions.
+     *
+     * Example:
+     * ```
+     * $annotation = $language->analyzeEntitySentiment('Google Cloud Platform is a powerful tool.');
+     * $sentiment = $annotation->sentiment();
+     *
+     * if ($sentiment['score'] > 0) {
+     *     echo 'This is a positive message.';
+     * }
+     * ```
+     *
+     * @codingStandardsIgnoreStart
+     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1beta2/documents/analyzeEntitySentiment Analyze Entity Sentiment API documentation
+     * @codingStandardsIgnoreEnd
+     *
+     * @param string|StorageObject $content The content to analyze. May be
+     *        either a string of UTF-8 encoded content, a URI pointing to a
+     *        Google Cloud Storage object in the format of
+     *        `gs://{bucket-name}/{object-name}` or a
+     *        {@see Google\Cloud\Storage\StorageObject}.
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type bool $detectGcsUri When providing $content as a string, this
+     *           flag determines whether or not to attempt to detect if the
+     *           string represents a Google Cloud Storage URI in the format of
+     *           `gs://{bucket-name}/{object-name}`. **Defaults to** `true`.
+     *     @type string $type The document type. Acceptable values are
+     *           `PLAIN_TEXT` or `HTML`. **Defaults to** `"PLAIN_TEXT"`.
+     *     @type string $language The language of the document. Both ISO
+     *           (e.g., en, es) and BCP-47 (e.g., en-US, es-ES) language codes
+     *           are accepted. If no value is provided, the language will be
+     *           detected by the service.
+     *     @type string $encodingType The text encoding type used by the API to
+     *           calculate offsets. Acceptable values are `"NONE"`, `"UTF8"`,
+     *           `"UTF16"` and `"UTF32"`. **Defaults to** `"UTF8"`. Please note
+     *           the following behaviors for the encoding type setting: `"NONE"`
+     *           will return a value of "-1" for offsets. `"UTF8"` will
+     *           return byte offsets. `"UTF16"` will return
+     *           [code unit](http://unicode.org/glossary/#code_unit) offsets.
+     *           `"UTF32"` will return
+     *           [unicode character](http://unicode.org/glossary/#character)
+     *           offsets.
+     * }
+     * @return Annotation
+     */
+    public function analyzeEntitySentiment($content, array $options = [])
+    {
+        return new Annotation(
+            $this->connection->analyzeEntitySentiment(
+                $this->formatRequest($content, $options)
+            )
+        );
+    }
+
+    /**
      * Analyzes the document and provides a full set of text annotations.
      *
      * Example:
@@ -226,7 +284,7 @@ class NaturalLanguageClient
      * ```
      *
      * @codingStandardsIgnoreStart
-     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1beta1/documents/analyzeSyntax Analyze Syntax API documentation
+     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1/documents/analyzeSyntax Analyze Syntax API documentation
      * @codingStandardsIgnoreEnd
      *
      * @param string|StorageObject $content The content to analyze. May be
@@ -294,7 +352,7 @@ class NaturalLanguageClient
      * ```
      *
      * @codingStandardsIgnoreStart
-     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1beta1/documents/annotateText Annotate Text API documentation
+     * @see https://cloud.google.com/natural-language/docs/reference/rest/v1/documents/annotateText Annotate Text API documentation
      * @codingStandardsIgnoreEnd
      *
      * @param string|StorageObject $content The content to analyze. May be

--- a/tests/snippets/NaturalLanguage/NaturalLanguageClientTest.php
+++ b/tests/snippets/NaturalLanguage/NaturalLanguageClientTest.php
@@ -84,6 +84,25 @@ class NaturalLanguageClientTest extends SnippetTestCase
         $this->assertEquals("This is a positive message.", $res->output());
     }
 
+    public function testAnalyzeEntitySentiment()
+    {
+        $this->connection->analyzeEntitySentiment(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                'documentSentiment' => [
+                    'score' => 1.0
+                ]
+            ]);
+
+        $this->client->setConnection($this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(NaturalLanguageClient::class, 'analyzeEntitySentiment');
+        $snippet->addLocal('language', $this->client);
+
+        $res = $snippet->invoke();
+        $this->assertEquals("This is a positive message.", $res->output());
+    }
+
     public function testAnalyzeSyntax()
     {
         $this->connection->analyzeSyntax(Argument::any())

--- a/tests/snippets/NaturalLanguage/NaturalLanguageClientTest.php
+++ b/tests/snippets/NaturalLanguage/NaturalLanguageClientTest.php
@@ -89,8 +89,13 @@ class NaturalLanguageClientTest extends SnippetTestCase
         $this->connection->analyzeEntitySentiment(Argument::any())
             ->shouldBeCalled()
             ->willReturn([
-                'documentSentiment' => [
-                    'score' => 1.0
+                'entities' => [
+                    [
+                        'name' => 'Google Cloud Platform',
+                        'sentiment' => [
+                            'score' => 1.0
+                        ]
+                    ]
                 ]
             ]);
 
@@ -100,7 +105,9 @@ class NaturalLanguageClientTest extends SnippetTestCase
         $snippet->addLocal('language', $this->client);
 
         $res = $snippet->invoke();
-        $this->assertEquals("This is a positive message.", $res->output());
+        $lines = explode(PHP_EOL, $res->output());
+        $this->assertEquals('Entity name: Google Cloud Platform', $lines[0]);
+        $this->assertEquals("This is a positive message.", $lines[1]);
     }
 
     public function testAnalyzeSyntax()

--- a/tests/unit/NaturalLanguage/Connection/RestTest.php
+++ b/tests/unit/NaturalLanguage/Connection/RestTest.php
@@ -75,6 +75,7 @@ class RestTest extends \PHPUnit_Framework_TestCase
     {
         return [
             ['analyzeSentiment'],
+            ['analyzeEntitySentiment'],
             ['analyzeEntities'],
             ['analyzeSyntax'],
             ['annotateText']

--- a/tests/unit/NaturalLanguage/NaturalLanguageClientTest.php
+++ b/tests/unit/NaturalLanguage/NaturalLanguageClientTest.php
@@ -74,6 +74,23 @@ class NaturalLanguageClientTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider analyzeDataProvider
      */
+    public function testAnalyzeEntitySentiment($options, $expectedOptions)
+    {
+        $content = $options['content'];
+        unset($options['content']);
+        $this->connection
+            ->analyzeEntitySentiment($expectedOptions)
+            ->willReturn([])
+            ->shouldBeCalledTimes(1);
+        $this->client->setConnection($this->connection->reveal());
+        $annotation = $this->client->analyzeEntitySentiment($content, $options);
+
+        $this->assertInstanceOf(Annotation::class, $annotation);
+    }
+
+    /**
+     * @dataProvider analyzeDataProvider
+     */
     public function testAnalyzeSyntax($options, $expectedOptions)
     {
         $content = $options['content'];


### PR DESCRIPTION
I modified `Google\Cloud\Core\RestTrait` to accept an optional option called `$requestBuilder`, which if supplied and an instance of `Google\Cloud\Core\RequestBuilder`, will be used to construct the request in place of the default RequestBuilder instance.

### Affected packages
* `google-cloud-php-natural-language`: minor version bump
* `google-cloud-php-core`: minor version bump