### PR TITLE
Ensure the correct Content-Length header when streaming uploads

### DIFF
--- a/src/Core/Upload/StreamableUploader.php
+++ b/src/Core/Upload/StreamableUploader.php
@@ -50,7 +50,8 @@ class StreamableUploader extends ResumableUploader
             $data = $this->data->read($writeSize);
         } else {
             $rangeEnd = '*';
-            $data = $this->data;
+            $data = $this->data->getContents();
+            $writeSize = strlen($data);
         }
 
         // do the streaming write

--- a/tests/unit/Core/Upload/StreamableUploaderTest.php
+++ b/tests/unit/Core/Upload/StreamableUploaderTest.php
@@ -90,7 +90,7 @@ class StreamableUploaderTest extends \PHPUnit_Framework_TestCase
         $this->requestWrapper->send(
             Argument::type(RequestInterface::class),
             Argument::type('array')
-        )->willReturn($response)->shouldHaveBeenCalledOnce();
+        )->willReturn($response)->shouldBeCalled();
 
         $uploader = new StreamableUploader(
             $this->requestWrapper->reveal(),
@@ -110,7 +110,7 @@ class StreamableUploaderTest extends \PHPUnit_Framework_TestCase
         $this->requestWrapper->send(
             Argument::type(RequestInterface::class),
             Argument::type('array')
-        )->willReturn($response)->shouldHaveBeenCalledOnce();
+        )->willReturn($response)->shouldBeCalled();
 
         $uploader = new StreamableUploader(
             $this->requestWrapper->reveal(),
@@ -132,12 +132,12 @@ class StreamableUploaderTest extends \PHPUnit_Framework_TestCase
         $this->requestWrapper->send(
             Argument::which('getMethod', 'POST'),
             Argument::type('array')
-        )->willReturn($resumeUriResponse)->shouldHaveBeenCalledOnce();
+        )->willReturn($resumeUriResponse)->shouldBeCalled();
 
         $this->requestWrapper->send(
             Argument::which('getMethod', 'PUT'),
             Argument::type('array')
-        )->willThrow(GoogleException::class)->shouldHaveBeenCalledOnce();
+        )->willThrow(GoogleException::class)->shouldBeCalled();
 
         $uploader = new StreamableUploader(
             $this->requestWrapper->reveal(),
@@ -156,14 +156,14 @@ class StreamableUploaderTest extends \PHPUnit_Framework_TestCase
         $this->requestWrapper->send(
             Argument::which('getMethod', 'POST'),
             Argument::type('array')
-        )->willReturn($resumeUriResponse)->shouldHaveBeenCalledOnce();
+        )->willReturn($resumeUriResponse)->shouldBeCalled();
 
         $this->requestWrapper->send(
             Argument::that(function($request) {
                 return $request->getHeaderLine('Content-Length') == '10';
             }),
             Argument::type('array')
-        )->willReturn($response)->shouldHaveBeenCalledOnce();
+        )->willReturn($response)->shouldBeCalled();
 
         $uploader = new StreamableUploader(
             $this->requestWrapper->reveal(),

--- a/tests/unit/Core/Upload/StreamableUploaderTest.php
+++ b/tests/unit/Core/Upload/StreamableUploaderTest.php
@@ -90,7 +90,7 @@ class StreamableUploaderTest extends \PHPUnit_Framework_TestCase
         $this->requestWrapper->send(
             Argument::type(RequestInterface::class),
             Argument::type('array')
-        )->willReturn($response);
+        )->willReturn($response)->shouldHaveBeenCalledOnce();
 
         $uploader = new StreamableUploader(
             $this->requestWrapper->reveal(),
@@ -110,7 +110,7 @@ class StreamableUploaderTest extends \PHPUnit_Framework_TestCase
         $this->requestWrapper->send(
             Argument::type(RequestInterface::class),
             Argument::type('array')
-        )->willReturn($response);
+        )->willReturn($response)->shouldHaveBeenCalledOnce();
 
         $uploader = new StreamableUploader(
             $this->requestWrapper->reveal(),
@@ -132,12 +132,12 @@ class StreamableUploaderTest extends \PHPUnit_Framework_TestCase
         $this->requestWrapper->send(
             Argument::which('getMethod', 'POST'),
             Argument::type('array')
-        )->willReturn($resumeUriResponse);
+        )->willReturn($resumeUriResponse)->shouldHaveBeenCalledOnce();
 
         $this->requestWrapper->send(
             Argument::which('getMethod', 'PUT'),
             Argument::type('array')
-        )->willThrow(GoogleException::class);
+        )->willThrow(GoogleException::class)->shouldHaveBeenCalledOnce();
 
         $uploader = new StreamableUploader(
             $this->requestWrapper->reveal(),
@@ -156,14 +156,14 @@ class StreamableUploaderTest extends \PHPUnit_Framework_TestCase
         $this->requestWrapper->send(
             Argument::which('getMethod', 'POST'),
             Argument::type('array')
-        )->willReturn($resumeUriResponse);
+        )->willReturn($resumeUriResponse)->shouldHaveBeenCalledOnce();
 
         $this->requestWrapper->send(
             Argument::that(function($request) {
                 return $request->getHeaderLine('Content-Length') == '10';
             }),
             Argument::type('array')
-        )->willReturn($response);
+        )->willReturn($response)->shouldHaveBeenCalledOnce();
 
         $uploader = new StreamableUploader(
             $this->requestWrapper->reveal(),

--- a/tests/unit/Core/Upload/StreamableUploaderTest.php
+++ b/tests/unit/Core/Upload/StreamableUploaderTest.php
@@ -147,4 +147,31 @@ class StreamableUploaderTest extends \PHPUnit_Framework_TestCase
 
         $uploader->upload();
     }
+
+    public function testLastChunkSendsCorrectHeaders()
+    {
+        $resumeUriResponse = new Response(200, ['Location' => 'theResumeUri']);
+        $response = new Response(200, ['Location' => 'theResumeUri'], $this->successBody);
+
+        $this->requestWrapper->send(
+            Argument::which('getMethod', 'POST'),
+            Argument::type('array')
+        )->willReturn($resumeUriResponse);
+
+        $this->requestWrapper->send(
+            Argument::that(function($request) {
+                return $request->getHeaderLine('Content-Length') == '10';
+            }),
+            Argument::type('array')
+        )->willReturn($response);
+
+        $uploader = new StreamableUploader(
+            $this->requestWrapper->reveal(),
+            $this->stream,
+            'http://www.example.com'
+        );
+        $this->stream->setUploader($uploader);
+        $this->stream->write('0123456789');
+        $uploader->upload();
+    }
 }


### PR DESCRIPTION
Fixes #447 

When the user's PHP installation includes the curl extension (most do), the curl handler would fix the content length. This only surfaced for PHP instances without curl, but should still be fixed.