### PR TITLE
[Docs] Fix incorrect Pub/Sub example resulting in BadRequestException

### DIFF
--- a/src/PubSub/Topic.php
+++ b/src/PubSub/Topic.php
@@ -268,7 +268,7 @@ class Topic
      * $topic->publish([
      *     'data' => 'New User Registered',
      *     'attributes' => [
-     *         'id' => 1,
+     *         'id' => '1',
      *         'userName' => 'John',
      *         'location' => 'Detroit'
      *     ]
@@ -295,14 +295,14 @@ class Topic
      *     [
      *         'data' => 'New User Registered',
      *         'attributes' => [
-     *             'id' => 1,
+     *             'id' => '1',
      *             'userName' => 'John',
      *             'location' => 'Detroit'
      *         ]
      *     ], [
      *         'data' => 'New User Registered',
      *         'attributes' => [
-     *             'id' => 2,
+     *             'id' => '2',
      *             'userName' => 'Steve',
      *             'location' => 'Mountain View'
      *         ]


### PR DESCRIPTION
Fix incorrect Pub/Sub example resulting in BadRequestException:

```
Fatal error: Uncaught Google\Cloud\Core\Exception\BadRequestException: {
  "error": {
    "code": 400,
    "message": "Invalid value at 'messages[0].attributes[0].value' (TYPE_STRING), 1",
    "status": "INVALID_ARGUMENT",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.BadRequest",
        "fieldViolations": [
          {
            "field": "messages[0].attributes[0].value",
            "description": "Invalid value at 'messages[0].attributes[0].value' (TYPE_STRING), 1"
          }
        ]
      }
    ]
  }
}
```
As documented [1] attributes must look like this `map (key: string, value: string)`


[1] https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage