### PR TITLE
Support context & extra arrays from monolog #470

### DIFF
--- a/src/Core/Logger/AppEngineFlexFormatter.php
+++ b/src/Core/Logger/AppEngineFlexFormatter.php
@@ -31,7 +31,7 @@ class AppEngineFlexFormatter extends LineFormatter
      * @param string $dateFormat [optional] The format of the timestamp
      * @param bool $ignoreEmptyContextAndExtra [optional]
      */
-    public function __construct($format = null, $dateFormat = null, $ignoreEmptyContextAndExtra = false)
+    public function __construct($format = '%message%', $dateFormat = null, $ignoreEmptyContextAndExtra = false)
     {
         parent::__construct($format, $dateFormat, true, $ignoreEmptyContextAndExtra);
     }
@@ -56,6 +56,12 @@ class AppEngineFlexFormatter extends LineFormatter
             'thread' => '',
             'severity' => $record['level_name'],
         ];
+        if (!empty($record['context'])) {
+            $payload['context'] = $record['context'];
+        }
+        if (!empty($record['extra'])) {
+            $payload['extra'] = $record['extra'];
+        }
         if (isset($_SERVER['HTTP_X_CLOUD_TRACE_CONTEXT'])) {
             $payload['traceId'] = explode(
                 "/",


### PR DESCRIPTION
Changes for suggestion in ticket #470 

If the arrays are empty, it'll go in as normal with a textPayload.

If either of the arrays contain data, it'll get logged as a jsonPayload, with a "message" element that still contains the log line and shows up under the request in the nginx.request log.

Log entry can be viewed in the "app" log to view the attached data inside the jsonPayload.