### PR TITLE
WIP: Add vision GAPIC helpers

### DIFF
--- a/src/Vision/ImageAnnotatorClient.php
+++ b/src/Vision/ImageAnnotatorClient.php
@@ -17,5 +17,7 @@
 
 namespace Google\Cloud\Vision;
 
-class_alias('\Google\Cloud\Vision\V1\ImageAnnotatorClient',
-    '\Google\Cloud\Vision\ImageAnnotatorClient');
+class_alias(
+    '\Google\Cloud\Vision\V1\ImageAnnotatorClient',
+    '\Google\Cloud\Vision\ImageAnnotatorClient'
+);

--- a/src/Vision/ImageAnnotatorClient.php
+++ b/src/Vision/ImageAnnotatorClient.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: michaelbausor
+ * Date: 5/6/17
+ * Time: 11:08 PM
+ */
+
+namespace Google\Cloud\Vision;
+
+class_alias('\Google\Cloud\Vision\V1\ImageAnnotatorClient',
+    '\Google\Cloud\Vision\ImageAnnotatorClient');

--- a/src/Vision/ImageAnnotatorClient.php
+++ b/src/Vision/ImageAnnotatorClient.php
@@ -1,9 +1,18 @@
 <?php
 /**
- * Created by IntelliJ IDEA.
- * User: michaelbausor
- * Date: 5/6/17
- * Time: 11:08 PM
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 namespace Google\Cloud\Vision;

--- a/src/Vision/ImageAnnotatorTrait.php
+++ b/src/Vision/ImageAnnotatorTrait.php
@@ -126,7 +126,7 @@ trait ImageAnnotatorTrait
      */
     protected function getFaceLandmarkPositionImpl($faceAnnotation, $landmarkType)
     {
-        foreach($faceAnnotation->getLandmarksList() as $landmark) {
+        foreach ($faceAnnotation->getLandmarksList() as $landmark) {
             if ($landmark->getType() === $landmarkType) {
                 return $landmark->getPosition();
             }
@@ -140,9 +140,11 @@ trait ImageAnnotatorTrait
      * @param string $imageSourceClass
      * @return Image
      */
-    protected function resolveImage($imageInput, $imageObjClass = '\google\cloud\vision\v1\Image',
-                                    $imageSourceClass = '\google\cloud\vision\v1\ImageSource')
-    {
+    protected function resolveImage(
+        $imageInput,
+        $imageObjClass = '\google\cloud\vision\v1\Image',
+        $imageSourceClass = '\google\cloud\vision\v1\ImageSource'
+    ) {
         $imageObj = new $imageObjClass();
         $imageSource = new $imageSourceClass();
         if (is_string($imageInput) && in_array(parse_url($imageInput, PHP_URL_SCHEME), self::$URL_SCHEMES)) {
@@ -163,4 +165,3 @@ trait ImageAnnotatorTrait
         return $imageObj;
     }
 }
-

--- a/src/Vision/ImageAnnotatorTrait.php
+++ b/src/Vision/ImageAnnotatorTrait.php
@@ -18,9 +18,7 @@
 namespace Google\Cloud\Vision;
 
 use Google\Cloud\Storage\StorageObject;
-use google\cloud\vision\v1\AnnotateImageRequest;
 use google\cloud\vision\v1\FaceAnnotation;
-use google\cloud\vision\v1\Feature;
 use google\cloud\vision\v1\ImageSource;
 use google\cloud\vision\v1\Position;
 use InvalidArgumentException;

--- a/src/Vision/ImageAnnotatorTrait.php
+++ b/src/Vision/ImageAnnotatorTrait.php
@@ -95,7 +95,7 @@ trait ImageAnnotatorTrait
 
     /**
      * @param resource|string|StorageObject $image
-     * @param \Google\Cloud\Vision\V1\Feature\Type $featureType
+     * @param \Google\Cloud\Vision\V1\Feature\Type|int $featureType
      * @param string $getFeatureMethod
      * @param array $optionalArgs {
      *
@@ -123,7 +123,7 @@ trait ImageAnnotatorTrait
 
     /**
      * @param FaceAnnotation $faceAnnotation
-     * @param FaceAnnotation\Landmark\Type $landmarkType
+     * @param FaceAnnotation\Landmark\Type|int $landmarkType
      * @return Position|null Landmark position
      */
     protected function getFaceLandmarkPositionImpl($faceAnnotation, $landmarkType)

--- a/src/Vision/ImageAnnotatorTrait.php
+++ b/src/Vision/ImageAnnotatorTrait.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Vision;
+
+use Google\Cloud\Storage\StorageObject;
+use google\cloud\vision\v1\AnnotateImageRequest;
+use google\cloud\vision\v1\FaceAnnotation;
+use google\cloud\vision\v1\Feature;
+use google\cloud\vision\v1\ImageSource;
+use google\cloud\vision\v1\Position;
+use InvalidArgumentException;
+
+trait ImageAnnotatorTrait
+{
+    private static $URL_SCHEMES = [
+        'http',
+        'https',
+        'gs',
+    ];
+
+    private $client;
+
+    protected function setClient($client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @param resource|string|StorageObject $image
+     * @param \Google\Cloud\Vision\V1\Feature\Type[] $features
+     * @param array $optionalArgs {
+     *
+     *     @type array $maxResults An array of maximum number of features to return
+     *     @type \Google\Cloud\Vision\V1\ImageContext $imageContext
+     *     @type string $requestClass The request class to use
+     *     @type string $featureClass The feature class to use
+     *     @type \Google\GAX\RetrySettings $retrySettings
+     *          Retry settings to use for this call. If present, then
+     *          $timeoutMillis is ignored.
+     *     @type int $timeoutMillis
+     *          Timeout to use for this call. Only used if $retrySettings
+     *          is not set.
+     * }
+     * @return \Google\Cloud\Vision\V1\AnnotateImageResponse The server response
+     */
+    protected function detectFeaturesImpl($image, $features, $optionalArgs = [])
+    {
+        $defaultArgs = [
+            'maxResults' => [],
+            'imageContext' => null,
+            'requestClass' => '\google\cloud\vision\v1\AnnotateImageRequest',
+            'featureClass' => '\google\cloud\vision\v1\Feature',
+        ];
+        $optionalArgs = $optionalArgs + $defaultArgs;
+
+        $maxResults = $optionalArgs['maxResults'];
+        $imageContext = $optionalArgs['imageContext'];
+        $requestClass = $optionalArgs['requestClass'];
+        $featureClass = $optionalArgs['featureClass'];
+
+        $annotateImageRequest = new $requestClass();
+        $annotateImageRequest->setImage($this->resolveImage($image));
+
+        foreach ($features as $featureType) {
+            $feature = new $featureClass();
+            $feature->setType($featureType);
+            if (isset($maxResults[$featureType])) {
+                $feature->setMaxResults($maxResults[$featureType]);
+            }
+            $annotateImageRequest->addFeatures($feature);
+        }
+        if (isset($imageContext)) {
+            $annotateImageRequest->setImageContext($imageContext);
+        }
+
+        $optionalArgs = array_diff_key($optionalArgs, $defaultArgs);
+        $batchResponse = $this->client->batchAnnotateImages([$annotateImageRequest], $optionalArgs);
+        return $batchResponse->getResponses(0);
+    }
+
+    /**
+     * @param resource|string|StorageObject $image
+     * @param \Google\Cloud\Vision\V1\Feature\Type $featureType
+     * @param string $getFeatureMethod
+     * @param array $optionalArgs {
+     *
+     *     @type integer $maxResults A maximum number of features to return
+     *     @type \Google\Cloud\Vision\V1\ImageContext $imageContext
+     *     @type \Google\GAX\RetrySettings $retrySettings
+     *          Retry settings to use for this call. If present, then
+     *          $timeoutMillis is ignored.
+     *     @type int $timeoutMillis
+     *          Timeout to use for this call. Only used if $retrySettings
+     *          is not set.
+     * }
+     * @return FaceAnnotation[] Array of face annotations
+     */
+    protected function detectFeatureTypeImpl($image, $featureType, $getFeatureMethod, $optionalArgs = [])
+    {
+        $maxResults = [];
+        if (isset($optionalArgs['maxResults'])) {
+            $maxResults[$featureType] = $optionalArgs['maxResults'];
+        }
+        $optionalArgs['maxResults'] = $maxResults;
+        $response = $this->detectFeatures($image, [$featureType], $optionalArgs);
+        return $response->$getFeatureMethod();
+    }
+
+    /**
+     * @param FaceAnnotation $faceAnnotation
+     * @param FaceAnnotation\Landmark\Type $landmarkType
+     * @return Position|null Landmark position
+     */
+    protected function getFaceLandmarkPositionImpl($faceAnnotation, $landmarkType)
+    {
+        foreach($faceAnnotation->getLandmarksList() as $landmark) {
+            if ($landmark->getType() === $landmarkType) {
+                return $landmark->getPosition();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param resource|string|StorageObject $imageInput
+     * @param \google\cloud\vision\v1\Image $imageObj
+     * @param \google\cloud\vision\v1\ImageSource $imageSource
+     * @return \google\cloud\vision\v1\Image
+     */
+    protected function resolveImage($imageInput, $imageObj = null, $imageSource = null)
+    {
+        if (is_null($imageObj)) {
+            $imageObj = new \google\cloud\vision\v1\Image();
+        }
+        if (is_null($imageSource)) {
+            $imageSource = new ImageSource();
+        }
+        if (is_string($imageInput) && in_array(parse_url($imageInput, PHP_URL_SCHEME), self::$URL_SCHEMES)) {
+            $imageSource->setImageUri($imageInput);
+            $imageObj->setSource($imageSource);
+        } elseif (is_string($imageInput)) {
+            $imageObj->setContent($imageInput);
+        } elseif ($imageInput instanceof StorageObject) {
+            $imageSource->setImageUri($imageInput->gcsUri());
+            $imageObj->setSource($imageSource);
+        } elseif (is_resource($imageInput)) {
+            $imageObj->setContent(stream_get_contents($imageInput));
+        } else {
+            throw new InvalidArgumentException(
+                'Given image is not valid. Image must be a string of bytes, ' .
+                'a google storage object, a valid image URI, or a resource.'
+            );
+        }
+        return $imageObj;
+    }
+}
+

--- a/src/Vision/V1/ImageAnnotatorClient.php
+++ b/src/Vision/V1/ImageAnnotatorClient.php
@@ -22,7 +22,7 @@ class ImageAnnotatorClient extends ImageAnnotatorGapicClient
 
     /**
      * @param resource|string|StorageObject $image
-     * @param \Google\Cloud\Vision\V1\Feature\Type[] $features
+     * @param \Google\Cloud\Vision\V1\Feature\Type[]|int $features
      * @param array $optionalArgs {
      *
      *     @type array $maxResults An array of maximum number of features to return
@@ -64,10 +64,10 @@ class ImageAnnotatorClient extends ImageAnnotatorGapicClient
 
     /**
      * @param FaceAnnotation $faceAnnotation
-     * @param FaceAnnotation\Landmark\Type $landmarkType
+     * @param FaceAnnotation\Landmark\Type|int $landmarkType
      * @return Position|null Landmark position
      */
-    function getLandmarkByType($faceAnnotation, $landmarkType)
+    function getFaceLandmarkPosition($faceAnnotation, $landmarkType)
     {
         return $this->getFaceLandmarkPositionImpl($faceAnnotation, $landmarkType);
     }

--- a/src/Vision/V1/ImageAnnotatorClient.php
+++ b/src/Vision/V1/ImageAnnotatorClient.php
@@ -30,7 +30,7 @@ class ImageAnnotatorClient extends ImageAnnotatorGapicClient
     }
 
     /**
-     * @param resource|string|StorageObject $image
+     * @param resource|string|Image $image
      * @param \Google\Cloud\Vision\V1\Feature\Type[]|int $features
      * @param array $optionalArgs {
      *
@@ -45,13 +45,13 @@ class ImageAnnotatorClient extends ImageAnnotatorGapicClient
      * }
      * @return \Google\Cloud\Vision\V1\AnnotateImageResponse The server response
      */
-    function detectFeatures($image, $features, $optionalArgs = [])
+    function annotateImage($image, $features, $optionalArgs = [])
     {
-        return $this->detectFeaturesImpl($image, $features, $optionalArgs);
+        return $this->annotateImageImpl($image, $features, $optionalArgs);
     }
 
     /**
-     * @param resource|string|StorageObject $image
+     * @param resource|string|Image $image
      * @param array $optionalArgs {
      *
      *     @type integer $maxResults A maximum number of features to return
@@ -65,9 +65,9 @@ class ImageAnnotatorClient extends ImageAnnotatorGapicClient
      * }
      * @return FaceAnnotation[] Array of face annotations
      */
-    function detectFaces($image, $optionalArgs = [])
+    function annotateFaces($image, $optionalArgs = [])
     {
-        return $this->detectFeatureTypeImpl($image, Feature\Type::FACE_DETECTION,
+        return $this->annotateFeatureTypeImpl($image, Feature\Type::FACE_DETECTION,
             'getFaceAnnotationsList', $optionalArgs);
     }
 

--- a/src/Vision/V1/ImageAnnotatorClient.php
+++ b/src/Vision/V1/ImageAnnotatorClient.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: michaelbausor
+ * Date: 5/6/17
+ * Time: 9:14 PM
+ */
+
+namespace Google\Cloud\Vision\V1;
+
+use Google\Cloud\Vision\ImageAnnotatorTrait;
+
+class ImageAnnotatorClient extends ImageAnnotatorGapicClient
+{
+    use ImageAnnotatorTrait;
+
+    function __construct(array $options = [])
+    {
+        parent::__construct($options);
+        $this->setClient($this);
+    }
+
+    /**
+     * @param resource|string|StorageObject $image
+     * @param \Google\Cloud\Vision\V1\Feature\Type[] $features
+     * @param array $optionalArgs {
+     *
+     *     @type array $maxResults An array of maximum number of features to return
+     *     @type \Google\Cloud\Vision\V1\ImageContext $imageContext
+     *     @type \Google\GAX\RetrySettings $retrySettings
+     *          Retry settings to use for this call. If present, then
+     *          $timeoutMillis is ignored.
+     *     @type int $timeoutMillis
+     *          Timeout to use for this call. Only used if $retrySettings
+     *          is not set.
+     * }
+     * @return \Google\Cloud\Vision\V1\AnnotateImageResponse The server response
+     */
+    function detectFeatures($image, $features, $optionalArgs = [])
+    {
+        return $this->detectFeaturesImpl($image, $features, $optionalArgs);
+    }
+
+    /**
+     * @param resource|string|StorageObject $image
+     * @param array $optionalArgs {
+     *
+     *     @type integer $maxResults A maximum number of features to return
+     *     @type \Google\Cloud\Vision\V1\ImageContext $imageContext
+     *     @type \Google\GAX\RetrySettings $retrySettings
+     *          Retry settings to use for this call. If present, then
+     *          $timeoutMillis is ignored.
+     *     @type int $timeoutMillis
+     *          Timeout to use for this call. Only used if $retrySettings
+     *          is not set.
+     * }
+     * @return FaceAnnotation[] Array of face annotations
+     */
+    function detectFaces($image, $optionalArgs = [])
+    {
+        return $this->detectFeatureTypeImpl($image, Feature\Type::FACE_DETECTION,
+            'getFaceAnnotationsList', $optionalArgs);
+    }
+
+    /**
+     * @param FaceAnnotation $faceAnnotation
+     * @param FaceAnnotation\Landmark\Type $landmarkType
+     * @return Position|null Landmark position
+     */
+    function getLandmarkByType($faceAnnotation, $landmarkType)
+    {
+        return $this->getFaceLandmarkPositionImpl($faceAnnotation, $landmarkType);
+    }
+}

--- a/src/Vision/V1/ImageAnnotatorClient.php
+++ b/src/Vision/V1/ImageAnnotatorClient.php
@@ -23,7 +23,7 @@ class ImageAnnotatorClient extends ImageAnnotatorGapicClient
 {
     use ImageAnnotatorTrait;
 
-    function __construct(array $options = [])
+    public function __construct(array $options = [])
     {
         parent::__construct($options);
         $this->setClient($this);
@@ -45,7 +45,7 @@ class ImageAnnotatorClient extends ImageAnnotatorGapicClient
      * }
      * @return \Google\Cloud\Vision\V1\AnnotateImageResponse The server response
      */
-    function annotateImage($image, $features, $optionalArgs = [])
+    public function annotateImage($image, $features, $optionalArgs = [])
     {
         return $this->annotateImageImpl($image, $features, $optionalArgs);
     }
@@ -65,10 +65,14 @@ class ImageAnnotatorClient extends ImageAnnotatorGapicClient
      * }
      * @return FaceAnnotation[] Array of face annotations
      */
-    function annotateFaces($image, $optionalArgs = [])
+    public function annotateFaces($image, $optionalArgs = [])
     {
-        return $this->annotateFeatureTypeImpl($image, Feature\Type::FACE_DETECTION,
-            'getFaceAnnotationsList', $optionalArgs);
+        return $this->annotateFeatureTypeImpl(
+            $image,
+            Feature\Type::FACE_DETECTION,
+            'getFaceAnnotationsList',
+            $optionalArgs
+        );
     }
 
     /**
@@ -76,7 +80,7 @@ class ImageAnnotatorClient extends ImageAnnotatorGapicClient
      * @param FaceAnnotation\Landmark\Type|int $landmarkType
      * @return Position|null Landmark position
      */
-    function getFaceLandmarkPosition($faceAnnotation, $landmarkType)
+    public function getFaceLandmarkPosition($faceAnnotation, $landmarkType)
     {
         return $this->getFaceLandmarkPositionImpl($faceAnnotation, $landmarkType);
     }

--- a/src/Vision/V1/ImageAnnotatorClient.php
+++ b/src/Vision/V1/ImageAnnotatorClient.php
@@ -1,9 +1,18 @@
 <?php
 /**
- * Created by IntelliJ IDEA.
- * User: michaelbausor
- * Date: 5/6/17
- * Time: 9:14 PM
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 namespace Google\Cloud\Vision\V1;

--- a/src/Vision/V1/ImageAnnotatorGapicClient.php
+++ b/src/Vision/V1/ImageAnnotatorGapicClient.php
@@ -64,7 +64,7 @@ use google\cloud\vision\v1\ImageAnnotatorGrpcClient;
  * a parse method to extract the individual identifiers contained within names that are
  * returned.
  */
-class ImageAnnotatorClient
+class ImageAnnotatorGapicClient
 {
     /**
      * The default address of the service.

--- a/tests/system/Vision/ImageAnnotatorClientV1Test.php
+++ b/tests/system/Vision/ImageAnnotatorClientV1Test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Google Inc.
+ * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/system/Vision/ImageAnnotatorClientV1Test.php
+++ b/tests/system/Vision/ImageAnnotatorClientV1Test.php
@@ -44,7 +44,7 @@ class ImageAnnotatorClientV1Test extends \PHPUnit_Framework_TestCase
     public function testFeatureDetection()
     {
         $image = file_get_contents($this->getFixtureFilePath('obama.jpg'));
-        $response = self::$client->detectFeatures($image, [Feature\Type::FACE_DETECTION]);
+        $response = self::$client->annotateImage($image, [Feature\Type::FACE_DETECTION]);
         $this->assertSame(1, count($response->getFaceAnnotationsList()));
         $face = $response->getFaceAnnotationsList()[0];
         $leftEyePosition = self::$client->getFaceLandmarkPosition(
@@ -56,7 +56,7 @@ class ImageAnnotatorClientV1Test extends \PHPUnit_Framework_TestCase
     public function testFaceDetection()
     {
         $image = file_get_contents($this->getFixtureFilePath('obama.jpg'));
-        $faces = self::$client->detectFaces($image);
+        $faces = self::$client->annotateFaces($image);
         $this->assertSame(1, count($faces));
         $this->assertInstanceOf('\google\cloud\vision\v1\FaceAnnotation', $faces[0]);
     }

--- a/tests/system/Vision/ImageAnnotatorClientV1Test.php
+++ b/tests/system/Vision/ImageAnnotatorClientV1Test.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\System\Vision;
+
+use Google\Cloud\Vision\V1\ImageAnnotatorClient;
+use google\cloud\vision\v1\Feature;
+use google\cloud\vision\v1\FaceAnnotation;
+
+/**
+ * @group vision
+ * @group grpc
+ */
+class ImageAnnotatorClientV1Test extends \PHPUnit_Framework_TestCase
+{
+    /** @var ImageAnnotatorClient */
+    private static $client;
+    private static $hasSetUp = false;
+
+    public static function setUpBeforeClass()
+    {
+        if (self::$hasSetUp) {
+            return;
+        }
+
+        self::$client = new ImageAnnotatorClient();
+        self::$hasSetUp = true;
+    }
+
+    public function testFeatureDetection()
+    {
+        $image = file_get_contents($this->getFixtureFilePath('obama.jpg'));
+        $response = self::$client->detectFeatures($image, [Feature\Type::FACE_DETECTION]);
+        $this->assertSame(1, count($response->getFaceAnnotationsList()));
+        $face = $response->getFaceAnnotationsList()[0];
+        $leftEyePosition = self::$client->getFaceLandmarkPosition(
+            $face,
+            FaceAnnotation\Landmark\Type::LEFT_EYE);
+        $this->assertNotNull($leftEyePosition);
+    }
+
+    public function testFaceDetection()
+    {
+        $image = file_get_contents($this->getFixtureFilePath('obama.jpg'));
+        $faces = self::$client->detectFaces($image);
+        $this->assertSame(1, count($faces));
+        $this->assertInstanceOf('\google\cloud\vision\v1\FaceAnnotation', $faces[0]);
+    }
+
+    protected function getFixtureFilePath($file)
+    {
+        return __DIR__ .'/fixtures/'. $file;
+    }
+}

--- a/tests/unit/Vision/ImageAnnotatorClientTest.php
+++ b/tests/unit/Vision/ImageAnnotatorClientTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Vision;
+
+use Google\Cloud\Vision\ImageAnnotatorClient;
+
+/**
+ * @group vision
+ * @group grpc
+ */
+class ImageAnnotatorClientTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInstantiateClient()
+    {
+        $client = new ImageAnnotatorClient();
+        $this->assertInstanceOf('\Google\Cloud\Vision\V1\ImageAnnotatorClient', $client);
+    }
+}


### PR DESCRIPTION
This PR is a work-in-progress to show what these helpers could look like. Some points:
- We rename the GAPIC client to ImageAnnotatorGapicClient, and replace it with an extending class that includes helper methods
  - A single image detection method, `detectFeatures`
  - An example of a single-feature helper, in this case `detectFaces`
  - A helper to filter a FaceAnnotation object to look for particular facial landmarks
- We support multiple different inputs for `image`, and convert to a protobuf message type
- We add an alias from Google\Cloud\Vision\ImageAnnotatorClient to Google\Cloud\Vision\V1\ImageAnnotatorClient