### PR TITLE
Modify exceptions when a whitelist may be present

### DIFF
--- a/src/Core/GrpcRequestWrapper.php
+++ b/src/Core/GrpcRequestWrapper.php
@@ -216,6 +216,7 @@ class GrpcRequestWrapper
                 break;
 
             case Grpc\STATUS_NOT_FOUND:
+            case Grpc\STATUS_UNIMPLEMENTED:
                 $exception = Exception\NotFoundException::class;
                 break;
 

--- a/src/Core/WhitelistTrait.php
+++ b/src/Core/WhitelistTrait.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core;
+
+use Google\Cloud\Core\Exception\NotFoundException;
+
+/**
+ * Manages exceptions for requests which may have whitelist restrictions.
+ */
+trait WhitelistTrait
+{
+    /**
+     * Check if the error is due to a whitelist restriction, modify the message
+     * and throw the updated exception, otherwise pass through with no changes.
+     *
+     * @param array $callable The request callable.
+     * @param array $args Request arguments.
+     * @return array
+     * @throws WhitelistException
+     * @throws ServiceException
+     */
+    private function whitelist(callable $callable, array $args)
+    {
+        try {
+            return call_user_func_array($callable, $args);
+        } catch (NotFoundException $e) {
+            $e->setMessage('NOTE: Error may be due to Whitelist Restriction. ' . $e->getMessage());
+
+            throw $e;
+        } catch (\Exception $e) {
+            throw $e;
+        }
+    }
+}

--- a/src/Core/WhitelistTrait.php
+++ b/src/Core/WhitelistTrait.php
@@ -31,7 +31,7 @@ trait WhitelistTrait
      * @param array $callable The request callable.
      * @param array $args Request arguments.
      * @return array
-     * @throws WhitelistException
+     * @throws NotFoundException
      * @throws ServiceException
      */
     private function whitelist(callable $callable, array $args)
@@ -41,8 +41,6 @@ trait WhitelistTrait
         } catch (NotFoundException $e) {
             $e->setMessage('NOTE: Error may be due to Whitelist Restriction. ' . $e->getMessage());
 
-            throw $e;
-        } catch (\Exception $e) {
             throw $e;
         }
     }

--- a/src/Core/WhitelistTrait.php
+++ b/src/Core/WhitelistTrait.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Google Inc.
+ * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Core/WhitelistTrait.php
+++ b/src/Core/WhitelistTrait.php
@@ -25,23 +25,15 @@ use Google\Cloud\Core\Exception\NotFoundException;
 trait WhitelistTrait
 {
     /**
-     * Check if the error is due to a whitelist restriction, modify the message
-     * and throw the updated exception, otherwise pass through with no changes.
+     * Modify the error message of a whitelisted exception.
      *
-     * @param array $callable The request callable.
-     * @param array $args Request arguments.
-     * @return array
-     * @throws NotFoundException
-     * @throws ServiceException
+     * @param NotFoundException $e The exception.
+     * @return NotFoundException
      */
-    private function whitelist(callable $callable, array $args)
+    private function modifyWhitelistedError(NotFoundException $e)
     {
-        try {
-            return call_user_func_array($callable, $args);
-        } catch (NotFoundException $e) {
-            $e->setMessage('NOTE: Error may be due to Whitelist Restriction. ' . $e->getMessage());
+        $e->setMessage('NOTE: Error may be due to Whitelist Restriction. ' . $e->getMessage());
 
-            throw $e;
-        }
+        return $e;
     }
 }

--- a/src/PubSub/Connection/Grpc.php
+++ b/src/PubSub/Connection/Grpc.php
@@ -22,7 +22,6 @@ use Google\Cloud\Core\EmulatorTrait;
 use Google\Cloud\Core\GrpcRequestWrapper;
 use Google\Cloud\Core\GrpcTrait;
 use Google\Cloud\Core\PhpArray;
-use Google\Cloud\Core\WhitelistTrait;
 use Google\Cloud\PubSub\PubSubClient;
 use Google\Cloud\PubSub\V1\PublisherClient;
 use Google\Cloud\PubSub\V1\SubscriberClient;
@@ -41,7 +40,6 @@ class Grpc implements ConnectionInterface
 {
     use EmulatorTrait;
     use GrpcTrait;
-    use WhitelistTrait;
 
     const BASE_URI = 'https://pubsub.googleapis.com/';
 
@@ -290,13 +288,11 @@ class Grpc implements ConnectionInterface
      */
     public function listSnapshots(array $args)
     {
-        return $this->whitelist([$this, 'send'], [
-            [$this->subscriberClient, 'listSnapshots'],
-            [
-                $this->pluck('project', $args),
-                $args
-            ]
-        ]);
+        $whitelisted = true;
+        return $this->send([$this->subscriberClient, 'listSnapshots'], [
+            $this->pluck('project', $args),
+            $args
+        ], $whitelisted);
     }
 
     /**
@@ -304,14 +300,12 @@ class Grpc implements ConnectionInterface
      */
     public function createSnapshot(array $args)
     {
-        return $this->whitelist([$this, 'send'], [
-            [$this->subscriberClient, 'createSnapshot'],
-            [
-                $this->pluck('name', $args),
-                $this->pluck('subscription', $args),
-                $args
-            ]
-        ]);
+        $whitelisted = true;
+        return $this->send([$this->subscriberClient, 'createSnapshot'], [
+            $this->pluck('name', $args),
+            $this->pluck('subscription', $args),
+            $args
+        ], $whitelisted);
     }
 
     /**
@@ -319,13 +313,11 @@ class Grpc implements ConnectionInterface
      */
     public function deleteSnapshot(array $args)
     {
-        return $this->whitelist([$this, 'send'], [
-            [$this->subscriberClient, 'deleteSnapshot'],
-            [
-                $this->pluck('snapshot', $args),
-                $args
-            ]
-        ]);
+        $whitelisted = true;
+        return $this->send([$this->subscriberClient, 'deleteSnapshot'], [
+            $this->pluck('snapshot', $args),
+            $args
+        ], $whitelisted);
     }
 
     /**
@@ -338,13 +330,11 @@ class Grpc implements ConnectionInterface
             $args['time'] = (new protobuf\Timestamp)->deserialize($time, $this->codec);
         }
 
-        return $this->whitelist([$this, 'send'], [
-            [$this->subscriberClient, 'seek'],
-            [
-                $this->pluck('subscription', $args),
-                $args
-            ]
-        ]);
+        $whitelisted = true;
+        return $this->send([$this->subscriberClient, 'seek'], [
+            $this->pluck('subscription', $args),
+            $args
+        ], $whitelisted);
     }
 
     /**

--- a/src/PubSub/Connection/Grpc.php
+++ b/src/PubSub/Connection/Grpc.php
@@ -22,6 +22,7 @@ use Google\Cloud\Core\EmulatorTrait;
 use Google\Cloud\Core\GrpcRequestWrapper;
 use Google\Cloud\Core\GrpcTrait;
 use Google\Cloud\Core\PhpArray;
+use Google\Cloud\Core\WhitelistTrait;
 use Google\Cloud\PubSub\PubSubClient;
 use Google\Cloud\PubSub\V1\PublisherClient;
 use Google\Cloud\PubSub\V1\SubscriberClient;
@@ -40,6 +41,7 @@ class Grpc implements ConnectionInterface
 {
     use EmulatorTrait;
     use GrpcTrait;
+    use WhitelistTrait;
 
     const BASE_URI = 'https://pubsub.googleapis.com/';
 
@@ -288,9 +290,12 @@ class Grpc implements ConnectionInterface
      */
     public function listSnapshots(array $args)
     {
-        return $this->send([$this->subscriberClient, 'listSnapshots'], [
-            $this->pluck('project', $args),
-            $args
+        return $this->whitelist([$this, 'send'], [
+            [$this->subscriberClient, 'listSnapshots'],
+            [
+                $this->pluck('project', $args),
+                $args
+            ]
         ]);
     }
 
@@ -299,10 +304,13 @@ class Grpc implements ConnectionInterface
      */
     public function createSnapshot(array $args)
     {
-        return $this->send([$this->subscriberClient, 'createSnapshot'], [
-            $this->pluck('name', $args),
-            $this->pluck('subscription', $args),
-            $args
+        return $this->whitelist([$this, 'send'], [
+            [$this->subscriberClient, 'createSnapshot'],
+            [
+                $this->pluck('name', $args),
+                $this->pluck('subscription', $args),
+                $args
+            ]
         ]);
     }
 
@@ -311,9 +319,12 @@ class Grpc implements ConnectionInterface
      */
     public function deleteSnapshot(array $args)
     {
-        return $this->send([$this->subscriberClient, 'deleteSnapshot'], [
-            $this->pluck('snapshot', $args),
-            $args
+        return $this->whitelist([$this, 'send'], [
+            [$this->subscriberClient, 'deleteSnapshot'],
+            [
+                $this->pluck('snapshot', $args),
+                $args
+            ]
         ]);
     }
 
@@ -327,9 +338,12 @@ class Grpc implements ConnectionInterface
             $args['time'] = (new protobuf\Timestamp)->deserialize($time, $this->codec);
         }
 
-        return $this->send([$this->subscriberClient, 'seek'], [
-            $this->pluck('subscription', $args),
-            $args
+        return $this->whitelist([$this, 'send'], [
+            [$this->subscriberClient, 'seek'],
+            [
+                $this->pluck('subscription', $args),
+                $args
+            ]
         ]);
     }
 

--- a/src/PubSub/Connection/Rest.php
+++ b/src/PubSub/Connection/Rest.php
@@ -22,7 +22,6 @@ use Google\Cloud\Core\RequestBuilder;
 use Google\Cloud\Core\RequestWrapper;
 use Google\Cloud\Core\RestTrait;
 use Google\Cloud\Core\UriTrait;
-use Google\Cloud\Core\WhitelistTrait;
 use Google\Cloud\PubSub\PubSubClient;
 
 /**
@@ -37,7 +36,6 @@ class Rest implements ConnectionInterface
     use EmulatorTrait;
     use RestTrait;
     use UriTrait;
-    use WhitelistTrait;
 
     const BASE_URI = 'https://pubsub.googleapis.com/';
 
@@ -216,11 +214,8 @@ class Rest implements ConnectionInterface
      */
     public function listSnapshots(array $args)
     {
-        return $this->whitelist([$this, 'send'], [
-            'snapshots',
-            'list',
-            $args
-        ]);
+        $whitelisted = true;
+        return $this->send('snapshots', 'list', $args, $whitelisted);
     }
 
     /**
@@ -228,11 +223,8 @@ class Rest implements ConnectionInterface
      */
     public function createSnapshot(array $args)
     {
-        return $this->whitelist([$this, 'send'], [
-            'snapshots',
-            'create',
-            $args
-        ]);
+        $whitelisted = true;
+        return $this->send('snapshots', 'create', $args, $whitelisted);
     }
 
     /**
@@ -240,11 +232,8 @@ class Rest implements ConnectionInterface
      */
     public function deleteSnapshot(array $args)
     {
-        return $this->whitelist([$this, 'send'], [
-            'snapshots',
-            'delete',
-            $args
-        ]);
+        $whitelisted = true;
+        return $this->send('snapshots', 'delete', $args, $whitelisted);
     }
 
     /**
@@ -252,11 +241,8 @@ class Rest implements ConnectionInterface
      */
     public function seek(array $args)
     {
-        return $this->whitelist([$this, 'send'], [
-            'subscriptions',
-            'seek',
-            $args
-        ]);
+        $whitelisted = true;
+        return $this->send('subscriptions', 'seek', $args, $whitelisted);
     }
 
     /**

--- a/src/PubSub/Connection/Rest.php
+++ b/src/PubSub/Connection/Rest.php
@@ -22,6 +22,7 @@ use Google\Cloud\Core\RequestBuilder;
 use Google\Cloud\Core\RequestWrapper;
 use Google\Cloud\Core\RestTrait;
 use Google\Cloud\Core\UriTrait;
+use Google\Cloud\Core\WhitelistTrait;
 use Google\Cloud\PubSub\PubSubClient;
 
 /**
@@ -36,6 +37,7 @@ class Rest implements ConnectionInterface
     use EmulatorTrait;
     use RestTrait;
     use UriTrait;
+    use WhitelistTrait;
 
     const BASE_URI = 'https://pubsub.googleapis.com/';
 
@@ -214,7 +216,11 @@ class Rest implements ConnectionInterface
      */
     public function listSnapshots(array $args)
     {
-        return $this->send('snapshots', 'list', $args);
+        return $this->whitelist([$this, 'send'], [
+            'snapshots',
+            'list',
+            $args
+        ]);
     }
 
     /**
@@ -222,7 +228,11 @@ class Rest implements ConnectionInterface
      */
     public function createSnapshot(array $args)
     {
-        return $this->send('snapshots', 'create', $args);
+        return $this->whitelist([$this, 'send'], [
+            'snapshots',
+            'create',
+            $args
+        ]);
     }
 
     /**
@@ -230,7 +240,11 @@ class Rest implements ConnectionInterface
      */
     public function deleteSnapshot(array $args)
     {
-        return $this->send('snapshots', 'delete', $args);
+        return $this->whitelist([$this, 'send'], [
+            'snapshots',
+            'delete',
+            $args
+        ]);
     }
 
     /**
@@ -238,7 +252,11 @@ class Rest implements ConnectionInterface
      */
     public function seek(array $args)
     {
-        return $this->send('subscriptions', 'seek', $args);
+        return $this->whitelist([$this, 'send'], [
+            'subscriptions',
+            'seek',
+            $args
+        ]);
     }
 
     /**

--- a/tests/system/ServiceWhitelist/WhitelistTest.php
+++ b/tests/system/ServiceWhitelist/WhitelistTest.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\System\Whitelist;
+
+use Google\Cloud\Core\Exception\NotFoundException;
+use Google\Cloud\Core\Timestamp;
+use Google\Cloud\PubSub\PubSubClient;
+
+/**
+ * @group whitelist
+ */
+class WhitelistTest extends \PHPUnit_Framework_TestCase
+{
+    const MESSAGE = 'NOTE: Error may be due to Whitelist Restriction.';
+    const TESTING_PREFIX = 'gcloud_whitelist_testing_';
+
+    private static $deletionQueue = [];
+    private $keyFilePath;
+
+    public function setUp()
+    {
+        if (!defined('GOOGLE_CLOUD_WHITELIST_KEY_PATH')) {
+            $this->markTestSkipped('Missing whitelist keyfile path for whitelist system tests.');
+        }
+
+        $this->keyFilePath = GOOGLE_CLOUD_WHITELIST_KEY_PATH;
+    }
+
+    public function testPubSubListSnapshotsRest()
+    {
+        $client = new PubSubClient([
+            'keyFilePath' => $this->keyFilePath,
+            'transport' => 'rest'
+        ]);
+
+        $this->checkException(function() use ($client) {
+            iterator_to_array($client->snapshots());
+        });
+    }
+
+    public function testPubSubListSnapshotsGrpc()
+    {
+        $client = new PubSubClient([
+            'keyFilePath' => $this->keyFilePath,
+            'transport' => 'grpc'
+        ]);
+
+        $this->checkException(function() use ($client) {
+            iterator_to_array($client->snapshots());
+        });
+    }
+
+    public function testPubSubCreateSnapshotRest()
+    {
+        $client = new PubSubClient([
+            'keyFilePath' => $this->keyFilePath,
+            'transport' => 'rest'
+        ]);
+
+        $topic = $client->createTopic(uniqid(self::TESTING_PREFIX));
+        self::$deletionQueue[] = function () use ($topic) {
+            $topic->delete();
+        };
+
+        $sub = $topic->subscribe(uniqid(self::TESTING_PREFIX));
+        self::$deletionQueue[] = function () use ($sub) {
+            $sub->delete();
+        };
+
+        $this->checkException(function () use ($client, $sub) {
+            $client->createSnapshot(uniqid(self::TESTING_PREFIX), $sub);
+        });
+    }
+
+    public function testPubSubCreateSnapshotGrpc()
+    {
+        $client = new PubSubClient([
+            'keyFilePath' => $this->keyFilePath,
+            'transport' => 'grpc'
+        ]);
+
+        $topic = $client->createTopic(uniqid(self::TESTING_PREFIX));
+        self::$deletionQueue[] = function () use ($topic) {
+            $topic->delete();
+        };
+
+        $sub = $topic->subscribe(uniqid(self::TESTING_PREFIX));
+        self::$deletionQueue[] = function () use ($sub) {
+            $sub->delete();
+        };
+
+        $this->checkException(function () use ($client, $sub) {
+            $client->createSnapshot(uniqid(self::TESTING_PREFIX), $sub);
+        });
+    }
+
+    public function testPubSubSeekRest()
+    {
+        $client = new PubSubClient([
+            'keyFilePath' => $this->keyFilePath,
+            'transport' => 'rest'
+        ]);
+
+        $topic = $client->createTopic(uniqid(self::TESTING_PREFIX));
+        self::$deletionQueue[] = function () use ($topic) {
+            $topic->delete();
+        };
+
+        $sub = $topic->subscribe(uniqid(self::TESTING_PREFIX));
+        self::$deletionQueue[] = function () use ($sub) {
+            $sub->delete();
+        };
+
+        $this->checkException(function () use ($sub) {
+            $sub->seekToTime(new Timestamp(new \DateTime));
+        });
+    }
+
+    public function testPubSubSeekGrpc()
+    {
+        $client = new PubSubClient([
+            'keyFilePath' => $this->keyFilePath,
+            'transport' => 'grpc'
+        ]);
+
+        $topic = $client->createTopic(uniqid(self::TESTING_PREFIX));
+        self::$deletionQueue[] = function () use ($topic) {
+            $topic->delete();
+        };
+
+        $sub = $topic->subscribe(uniqid(self::TESTING_PREFIX));
+        self::$deletionQueue[] = function () use ($sub) {
+            $sub->delete();
+        };
+
+        $this->checkException(function () use ($sub) {
+            $sub->seekToTime(new Timestamp(new \DateTime));
+        });
+    }
+
+    private function checkException(callable $call)
+    {
+        $thrown = false;
+        $ex = null;
+        try {
+            $call();
+        } catch (\Exception $e) {
+            $thrown = true;
+            $ex = $e;
+        }
+
+        $this->assertTrue($thrown);
+        $this->assertInstanceOf(NotFoundException::class, $ex);
+        $this->assertTrue(strpos($ex->getMessage(), self::MESSAGE) !== false);
+    }
+
+    public static function tearDownFixtures()
+    {
+        foreach (self::$deletionQueue as $toDelete) {
+            if (!is_callable($toDelete)) {
+                throw new \Exception('fixtures must be callables');
+            }
+
+            call_user_func($toDelete);
+        }
+    }
+}

--- a/tests/system/bootstrap.php
+++ b/tests/system/bootstrap.php
@@ -8,11 +8,16 @@ use Google\Cloud\Tests\System\Logging\LoggingTestCase;
 use Google\Cloud\Tests\System\PubSub\PubSubTestCase;
 use Google\Cloud\Tests\System\Spanner\SpannerTestCase;
 use Google\Cloud\Tests\System\Storage\StorageTestCase;
+use Google\Cloud\Tests\System\Whitelist\WhitelistTest;
 
 if (!getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH')) {
     throw new \Exception(
         'Please set the \'GOOGLE_CLOUD_PHP_TESTS_KEY_PATH\' env var to run the system tests'
     );
+}
+
+if (getenv('GOOGLE_CLOUD_PHP_TESTS_WHITELIST_KEY_PATH')) {
+    define('GOOGLE_CLOUD_WHITELIST_KEY_PATH', getenv('GOOGLE_CLOUD_PHP_TESTS_WHITELIST_KEY_PATH'));
 }
 
 register_shutdown_function(function () {
@@ -22,4 +27,5 @@ register_shutdown_function(function () {
     LoggingTestCase::tearDownFixtures();
     BigQueryTestCase::tearDownFixtures();
     SpannerTestCase::tearDownFixtures();
+    WhitelistTest::tearDownFixtures();
 });

--- a/tests/unit/Core/Exception/NotFoundExceptionTest.php
+++ b/tests/unit/Core/Exception/NotFoundExceptionTest.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,22 +15,22 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Core\Exception;
+namespace Google\Cloud\Tests\Unit\Core\Exception;
+
+use Google\Cloud\Core\Exception\NotFoundException;
 
 /**
- * Exception thrown when a resource is not found.
+ * @group core
+ * @group exception
  */
-class NotFoundException extends ServiceException
+class NotFoundExceptionTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * Allows overriding message for injection of Whitelist Notice.
-     *
-     * @param string $message the new message
-     * @return void
-     * @access private
-     */
-    public function setMessage($message)
+    public function testSetMessage()
     {
-        $this->message = $message;
+        $ex = new NotFoundException('hello');
+        $this->assertEquals($ex->getMessage(), 'hello');
+
+        $ex->setMessage('world');
+        $this->assertEquals($ex->getMessage(), 'world');
     }
 }

--- a/tests/unit/Core/WhitelistTraitTest.php
+++ b/tests/unit/Core/WhitelistTraitTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Core;
+
+use Google\Cloud\Core\Exception\NotFoundException;
+use Google\Cloud\Core\Exception\ServiceException;
+use Google\Cloud\Core\WhitelistTrait;
+
+/**
+ * @group core
+ */
+class WhitelistTraitTest extends \PHPUnit_Framework_TestCase
+{
+    private $trait;
+
+    public function setUp()
+    {
+        $this->trait = new WhitelistTraitStub;
+    }
+
+    public function testWhitelistWithNotFoundException()
+    {
+        $callable = function() {
+            throw new NotFoundException('hello world');
+        };
+
+        try {
+            $res = $this->trait->call('whitelist', [$callable, []]);
+        } catch (\Exception $e) {
+            $this->assertInstanceOf(NotFoundException::class, $e);
+            $this->assertTrue(strpos($e->getMessage(), 'hello world') !== false);
+        }
+    }
+
+    public function testWhitelistWithNotOtherException()
+    {
+        $callable = function() {
+            throw new ServiceException('hello world');
+        };
+
+        try {
+            $res = $this->trait->call('whitelist', [$callable, []]);
+        } catch (\Exception $e) {
+            $this->assertInstanceOf(ServiceException::class, $e);
+            $this->assertEquals('hello world', $e->getMessage());
+        }
+    }
+}
+
+class WhitelistTraitStub
+{
+    use WhitelistTrait;
+
+    public function call($method, array $args)
+    {
+        return call_user_func_array([$this, $method], $args);
+    }
+}

--- a/tests/unit/Core/WhitelistTraitTest.php
+++ b/tests/unit/Core/WhitelistTraitTest.php
@@ -33,32 +33,17 @@ class WhitelistTraitTest extends \PHPUnit_Framework_TestCase
         $this->trait = new WhitelistTraitStub;
     }
 
-    public function testWhitelistWithNotFoundException()
+    public function testModifyWhitelistedError()
     {
-        $callable = function() {
-            throw new NotFoundException('hello world');
-        };
+        $ex = new NotFoundException('hello world');
 
-        try {
-            $res = $this->trait->call('whitelist', [$callable, []]);
-        } catch (\Exception $e) {
-            $this->assertInstanceOf(NotFoundException::class, $e);
-            $this->assertTrue(strpos($e->getMessage(), 'hello world') !== false);
-        }
-    }
+        $res = $this->trait->call('modifyWhitelistedError', [$ex]);
 
-    public function testWhitelistWithNotOtherException()
-    {
-        $callable = function() {
-            throw new ServiceException('hello world');
-        };
-
-        try {
-            $res = $this->trait->call('whitelist', [$callable, []]);
-        } catch (\Exception $e) {
-            $this->assertInstanceOf(ServiceException::class, $e);
-            $this->assertEquals('hello world', $e->getMessage());
-        }
+        $this->assertInstanceOf(NotFoundException::class, $res);
+        $this->assertEquals(
+            $res->getMessage(),
+            'NOTE: Error may be due to Whitelist Restriction. hello world'
+        );
     }
 }
 


### PR DESCRIPTION
When a `NotFoundException` is thrown by a method which may be under whitelist restriction, the exception is intercepted and the error message is modified to indicate the possible problem to the user.

Still to come is integrating into system tests to help keep this up to date and alert us when a whitelist is removed.