### PR TITLE
Update docs to include new core classes

### DIFF
--- a/docs/contents/cloud-core.json
+++ b/docs/contents/cloud-core.json
@@ -31,7 +31,13 @@
             "type": "core/upload/streamableuploader"
         }]
     }, {
+        "title": "Duration",
+        "type": "core/duration"
+    }, {
         "title": "Int64",
         "type": "core/int64"
+    }, {
+        "title": "Timestamp",
+        "type": "core/timestamp"
     }]
 }

--- a/docs/contents/cloud-pubsub.json
+++ b/docs/contents/cloud-pubsub.json
@@ -17,12 +17,6 @@
         "title": "Topic",
         "type": "pubsub/topic"
     }, {
-        "title": "Duration",
-        "type": "pubsub/duration"
-    }, {
-        "title": "Timestamp",
-        "type": "pubsub/timestamp"
-    }, {
         "title": "v1",
         "type": "pubsub/v1/readme",
         "patterns": [


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/google-cloud-php/pull/462 included a change moving some classes from PubSub to Core. This follows up on that make sure our documentation is correct.