### PR TITLE
Increase ServiceBuilder version for v0.29.0 release

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -11,6 +11,7 @@
             "name": "google/cloud",
             "defaultService": "servicebuilder",
             "versions": [
+                "v0.29.0",
                 "v0.28.0",
                 "v0.27.0",
                 "v0.26.0",

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -49,7 +49,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class ServiceBuilder
 {
-    const VERSION = '0.28.0';
+    const VERSION = '0.29.0';
 
     /**
      * @var array Configuration options to be used between clients.


### PR DESCRIPTION
Missed this in https://github.com/GoogleCloudPlatform/google-cloud-php/pull/493