### PR TITLE
Cast keySet keys to arrays instead of wrapping them

### DIFF
--- a/src/Spanner/Connection/Grpc.php
+++ b/src/Spanner/Connection/Grpc.php
@@ -661,7 +661,7 @@ class Grpc implements ConnectionInterface
             $keySet['keys'] = [];
 
             foreach ($keys as $key) {
-                $keySet['keys'][] = $this->formatListForApi([$key]);
+                $keySet['keys'][] = $this->formatListForApi((array) $key);
             }
         }
 

--- a/tests/unit/Spanner/Connection/GrpcTest.php
+++ b/tests/unit/Spanner/Connection/GrpcTest.php
@@ -124,6 +124,10 @@ class GrpcTest extends \PHPUnit_Framework_TestCase
         $keySetArgs = [];
         $keySet = (new KeySet)
             ->deserialize($keySetArgs, $codec);
+        $keySetSingular = (new KeySet())
+            ->deserialize(['keys' => [['values' => ['number_value' => 1]]]], $codec);
+        $keySetComposite = (new KeySet())
+            ->deserialize(['keys' => [['values' => [['number_value' => 1], ['number_value' => 1]]]]], $codec);
 
         $readWriteTransactionArgs = ['readWrite' => []];
         $readWriteTransactionOptions = new TransactionOptions;
@@ -307,6 +311,30 @@ class GrpcTest extends \PHPUnit_Framework_TestCase
                     'database' => $databaseName,
                 ],
                 [$sessionName, $tableName, $columns, $keySet, ['transaction' => $transactionSelector, 'userHeaders' => ['google-cloud-resource-prefix' => [$databaseName]]]]
+            ],
+            [
+                'streamingRead',
+                [
+                    'keySet' => ['keys' => [1]],
+                    'transactionId' => $transactionName,
+                    'session' => $sessionName,
+                    'table' => $tableName,
+                    'columns' => $columns,
+                    'database' => $databaseName,
+                ],
+                [$sessionName, $tableName, $columns, $keySetSingular, ['transaction' => $transactionSelector, 'userHeaders' => ['google-cloud-resource-prefix' => [$databaseName]]]]
+            ],
+            [
+                'streamingRead',
+                [
+                    'keySet' => ['keys' => [[1,1]]],
+                    'transactionId' => $transactionName,
+                    'session' => $sessionName,
+                    'table' => $tableName,
+                    'columns' => $columns,
+                    'database' => $databaseName,
+                ],
+                [$sessionName, $tableName, $columns, $keySetComposite, ['transaction' => $transactionSelector, 'userHeaders' => ['google-cloud-resource-prefix' => [$databaseName]]]]
             ],
             // test read write
             [


### PR DESCRIPTION
I received the following error when using a composite key:

```sh
  [Google\Cloud\Core\Exception\FailedPreconditionException (9)]  
  Wrong number of key parts for TableName. Expected: 2. Got: [["2","2"]] 
```

Code:
```php
$keySet = $spanner->keySet(['keys' => [[2,2]]]);
$result = $t->read(
    'TableName',
    $keySet,
    ['ColumnName'],
    ['limit' => 1]
);
```

Looks like the connection class is wrapping keys in an array, I assume because single keys are actually a composite key of *one*. I believe changing the wrapping array into a cast is the proper way to fix this issue.