### PR TITLE
Test component composer integration, bump gax requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_script:
 
 script:
   - ./dev/sh/tests
+  - ./dev/sh/test-composer
   - vendor/bin/phpcs --standard=./phpcs-ruleset.xml
   - ./dev/sh/build-docs
 

--- a/dev/sh/test-composer
+++ b/dev/sh/test-composer
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Checking Component Installability"
+
+php $(dirname $0)/../../tests/component/TestComposerInstall.php

--- a/dev/sh/tests
+++ b/dev/sh/tests
@@ -5,19 +5,19 @@ set -e
 function unit () {
   echo "Running Unit Test Suite"
 
-  vendor/bin/phpunit
+  $(dirname $0)/../../vendor/bin/phpunit
 }
 
 function system () {
   echo "Running System Test Suite"
 
-  vendor/bin/phpunit -c phpunit-system.xml.dist
+  $(dirname $0)/../../vendor/bin/phpunit -c phpunit-system.xml.dist
 }
 
 function snippets() {
   echo "Running Snippet Test Suite"
 
-  vendor/bin/phpunit -c phpunit-snippets.xml.dist
+  $(dirname $0)/../../vendor/bin/phpunit -c phpunit-snippets.xml.dist
 }
 
 unit

--- a/src/ErrorReporting/composer.json
+++ b/src/ErrorReporting/composer.json
@@ -5,7 +5,6 @@
     "minimum-stability": "stable",
     "require": {
         "ext-grpc": "*",
-        "google/cloud-core": "^1.0",
         "google/proto-client-php": "^0.13",
         "google/gax": "^0.9"
     },

--- a/src/ErrorReporting/composer.json
+++ b/src/ErrorReporting/composer.json
@@ -7,7 +7,7 @@
         "ext-grpc": "*",
         "google/cloud-core": "^1.0",
         "google/proto-client-php": "^0.13",
-        "google/gax": "^0.8"
+        "google/gax": "^0.9"
     },
     "extra": {
         "component": {

--- a/src/Monitoring/composer.json
+++ b/src/Monitoring/composer.json
@@ -5,7 +5,6 @@
     "minimum-stability": "stable",
     "require": {
         "ext-grpc": "*",
-        "google/cloud-core": "^1.0",
         "google/proto-client-php": "^0.13",
         "google/gax": "^0.9"
     },

--- a/src/Monitoring/composer.json
+++ b/src/Monitoring/composer.json
@@ -7,7 +7,7 @@
         "ext-grpc": "*",
         "google/cloud-core": "^1.0",
         "google/proto-client-php": "^0.13",
-        "google/gax": "^0.8"
+        "google/gax": "^0.9"
     },
     "extra": {
         "component": {

--- a/tests/component/TestComposerInstall.php
+++ b/tests/component/TestComposerInstall.php
@@ -23,6 +23,11 @@
 
 use Google\Cloud\Dev\GetComponentsTrait;
 
+if (!extension_loaded('grpc')) {
+    echo "gRPC Not Installed.";
+    exit(0);
+}
+
 include __DIR__ .'/../../vendor/autoload.php';
 
 define('BASE_PATH', __DIR__ .'/../..');

--- a/tests/component/TestComposerInstall.php
+++ b/tests/component/TestComposerInstall.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This file tests that all google-cloud-php components can be installed alongside
+ * each other at their latest versions.
+ */
+
+use Google\Cloud\Dev\GetComponentsTrait;
+
+include __DIR__ .'/../../vendor/autoload.php';
+
+class GetComponentsImpl
+{
+    use GetComponentsTrait;
+
+    public function components()
+    {
+        return $this->getComponents(
+            __DIR__ .'/../../src',
+            __DIR__ .'/../../composer.json'
+        );
+    }
+}
+
+$composer = [];
+$composer['require'] = [];
+
+foreach((new GetComponentsImpl)->components() as $component) {
+    if ($component['id'] === 'google-cloud') continue;
+
+    $composer['require']['google/'. $component['id']] = '*';
+}
+
+file_put_contents(__DIR__ .'/composer.json', json_encode($composer));
+$out = [];
+$ret = null;
+exec('cd '. __DIR__ .' && composer install --dry-run', $out, $ret);
+unlink(__DIR__ .'/composer.json');
+
+if ($ret !== 0) {
+    echo "Problem installing components!";
+    exit(1);
+}

--- a/tests/component/TestComposerInstall.php
+++ b/tests/component/TestComposerInstall.php
@@ -58,12 +58,14 @@ foreach((new GetComponentsImpl)->components() as $component) {
 
 file_put_contents(__DIR__ .'/composer.json', json_encode($composer, JSON_UNESCAPED_SLASHES));
 
-$res = shell_exec('cd '. __DIR__ .' && composer install --dry-run 2>&1');
+$out = [];
+$return = null;
+exec('composer install --dry-run --working-dir='. __DIR__ .' 2>&1', $out, $return);
 unlink(__DIR__ .'/composer.json');
 
-if (strpos($res, 'Your requirements could not be resolved to an installable set of packages.') !== false) {
+if ($return !== 0) {
     echo "Problem installing components!" . PHP_EOL . PHP_EOL;
 
-    echo $res;
+    echo implode("\n", $out);
     exit(1);
 }

--- a/tests/component/TestComposerInstall.php
+++ b/tests/component/TestComposerInstall.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2016 Google Inc.
+ * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This adds a test which will attempt to run `composer install` against all google-cloud-php components, making sure they can be installed side by side at their latest version.

~~The trouble with this is that it can't catch errors until the releases have been tagged. Therefore it may be useful to inform us after the fact, but it may not give us forewarning. Feedback and ideas on that are welcomed.~~

I'm now using path repositories, which lets me get the package at the local version. PTAL @dwsupplee 