### PR TITLE
Fix http method for translation api methods

### DIFF
--- a/src/Translate/Connection/ServiceDefinition/translate-v2.json
+++ b/src/Translate/Connection/ServiceDefinition/translate-v2.json
@@ -167,7 +167,7 @@
         "list": {
           "id": "language.detections.list",
           "path": "v2/detect",
-          "httpMethod": "GET",
+          "httpMethod": "POST",
           "description": "Detect the language of text.",
           "parameters": {
             "q": {
@@ -212,7 +212,7 @@
         "list": {
           "id": "language.translations.list",
           "path": "v2",
-          "httpMethod": "GET",
+          "httpMethod": "POST",
           "description": "Returns text translations from one language to another.",
           "parameters": {
             "cid": {


### PR DESCRIPTION
According to [docs](https://cloud.google.com/translate/docs/reference/rest) of translation api v2 methods `translate` and `detect` should be requested by `POST` http method.
This patch will fix it in translate `ServiceDefinition` json file
