### PR TITLE
[BC Break] Move type constants to Database

### DIFF
--- a/src/Spanner/Bytes.php
+++ b/src/Spanner/Bytes.php
@@ -80,7 +80,7 @@ class Bytes implements ValueInterface
      */
     public function type()
     {
-        return ValueMapper::TYPE_BYTES;
+        return Database::TYPE_BYTES;
     }
 
     /**

--- a/src/Spanner/Database.php
+++ b/src/Spanner/Database.php
@@ -33,6 +33,7 @@ use Google\Cloud\Spanner\Session\SessionPoolInterface;
 use Google\Cloud\Spanner\Transaction;
 use Google\Cloud\Spanner\V1\SpannerClient as GrpcSpannerClient;
 use Google\GAX\ValidationException;
+use google\spanner\v1\TypeCode;
 
 /**
  * Represents a Cloud Spanner Database.
@@ -97,6 +98,16 @@ class Database
     use TransactionConfigurationTrait;
 
     const MAX_RETRIES = 10;
+
+    const TYPE_BOOL = TypeCode::TYPE_BOOL;
+    const TYPE_INT64 = TypeCode::TYPE_INT64;
+    const TYPE_FLOAT64 = TypeCode::TYPE_FLOAT64;
+    const TYPE_TIMESTAMP = TypeCode::TYPE_TIMESTAMP;
+    const TYPE_DATE = TypeCode::TYPE_DATE;
+    const TYPE_STRING = TypeCode::TYPE_STRING;
+    const TYPE_BYTES = TypeCode::TYPE_BYTES;
+    const TYPE_ARRAY = TypeCode::TYPE_ARRAY;
+    const TYPE_STRUCT = TypeCode::TYPE_STRUCT;
 
     /**
      * @var ConnectionInterface
@@ -1093,7 +1104,7 @@ class Database
      *         'timestamp' => $timestamp
      *     ],
      *     'types' => [
-     *         'timestamp' => ValueMapper::TYPE_TIMESTAMP
+     *         'timestamp' => Database::TYPE_TIMESTAMP
      *     ]
      * ]);
      *
@@ -1107,7 +1118,7 @@ class Database
      *         'emptyArrayOfIntegers' => []
      *     ],
      *     'types' => [
-     *         'emptyArrayOfIntegers' => [ValueMapper::TYPE_ARRAY, ValueMapper::TYPE_INT64]
+     *         'emptyArrayOfIntegers' => [Database::TYPE_ARRAY, Database::TYPE_INT64]
      *     ]
      * ]);
      *
@@ -1137,14 +1148,14 @@ class Database
      *           definitions are only necessary for null parameter values.
      *           Accepted values are defined as constants on
      *           {@see Google\Cloud\Spanner\ValueMapper}, and are as follows:
-     *           `ValueMapper::TYPE_BOOL`, `ValueMapper::TYPE_INT64`,
-     *           `ValueMapper::TYPE_FLOAT64`, `ValueMapper::TYPE_TIMESTAMP`,
-     *           `ValueMapper::TYPE_DATE`, `ValueMapper::TYPE_STRING`,
-     *           `ValueMapper::TYPE_BYTES`, `ValueMapper::TYPE_ARRAY` and
-     *           `ValueMapper::TYPE_STRUCT`. If the parameter type is an array,
+     *           `Database::TYPE_BOOL`, `Database::TYPE_INT64`,
+     *           `Database::TYPE_FLOAT64`, `Database::TYPE_TIMESTAMP`,
+     *           `Database::TYPE_DATE`, `Database::TYPE_STRING`,
+     *           `Database::TYPE_BYTES`, `Database::TYPE_ARRAY` and
+     *           `Database::TYPE_STRUCT`. If the parameter type is an array,
      *           the type should be given as an array, where the first element
-     *           is `ValueMapper::TYPE_ARRAY` and the second element is the
-     *           array type, for instance `[ValueMapper::TYPE_ARRAY, ValueMapper::TYPE_INT64]`.
+     *           is `Database::TYPE_ARRAY` and the second element is the
+     *           array type, for instance `[Database::TYPE_ARRAY, Database::TYPE_INT64]`.
      *     @type bool $returnReadTimestamp If true, the Cloud Spanner-selected
      *           read timestamp is included in the Transaction message that
      *           describes the transaction.

--- a/src/Spanner/Date.php
+++ b/src/Spanner/Date.php
@@ -100,7 +100,7 @@ class Date implements ValueInterface
      */
     public function type()
     {
-        return ValueMapper::TYPE_DATE;
+        return Database::TYPE_DATE;
     }
 
     /**

--- a/src/Spanner/Timestamp.php
+++ b/src/Spanner/Timestamp.php
@@ -94,7 +94,7 @@ class Timestamp implements ValueInterface
      */
     public function type()
     {
-        return ValueMapper::TYPE_TIMESTAMP;
+        return Database::TYPE_TIMESTAMP;
     }
 
     /**

--- a/src/Spanner/Transaction.php
+++ b/src/Spanner/Transaction.php
@@ -96,14 +96,14 @@ use RuntimeException;
  *               definitions are only necessary for null parameter values.
  *               Accepted values are defined as constants on
  *               {@see Google\Cloud\Spanner\ValueMapper}, and are as follows:
- *               `ValueMapper::TYPE_BOOL`, `ValueMapper::TYPE_INT64`,
- *               `ValueMapper::TYPE_FLOAT64`, `ValueMapper::TYPE_TIMESTAMP`,
- *               `ValueMapper::TYPE_DATE`, `ValueMapper::TYPE_STRING`,
- *               `ValueMapper::TYPE_BYTES`, `ValueMapper::TYPE_ARRAY` and
- *               `ValueMapper::TYPE_STRUCT`. If the parameter type is an array,
+ *               `Database::TYPE_BOOL`, `Database::TYPE_INT64`,
+ *               `Database::TYPE_FLOAT64`, `Database::TYPE_TIMESTAMP`,
+ *               `Database::TYPE_DATE`, `Database::TYPE_STRING`,
+ *               `Database::TYPE_BYTES`, `Database::TYPE_ARRAY` and
+ *               `Database::TYPE_STRUCT`. If the parameter type is an array,
  *               the type should be given as an array, where the first element
- *               is `ValueMapper::TYPE_ARRAY` and the second element is the
- *               array type, for instance `[ValueMapper::TYPE_ARRAY, ValueMapper::TYPE_INT64]`.
+ *               is `Database::TYPE_ARRAY` and the second element is the
+ *               array type, for instance `[Database::TYPE_ARRAY, Database::TYPE_INT64]`.
  *     }
  *     @return Result
  * }

--- a/src/Spanner/TransactionalReadTrait.php
+++ b/src/Spanner/TransactionalReadTrait.php
@@ -76,14 +76,14 @@ trait TransactionalReadTrait
      *           definitions are only necessary for null parameter values.
      *           Accepted values are defined as constants on
      *           {@see Google\Cloud\Spanner\ValueMapper}, and are as follows:
-     *           `ValueMapper::TYPE_BOOL`, `ValueMapper::TYPE_INT64`,
-     *           `ValueMapper::TYPE_FLOAT64`, `ValueMapper::TYPE_TIMESTAMP`,
-     *           `ValueMapper::TYPE_DATE`, `ValueMapper::TYPE_STRING`,
-     *           `ValueMapper::TYPE_BYTES`, `ValueMapper::TYPE_ARRAY` and
-     *           `ValueMapper::TYPE_STRUCT`. If the parameter type is an array,
+     *           `Database::TYPE_BOOL`, `Database::TYPE_INT64`,
+     *           `Database::TYPE_FLOAT64`, `Database::TYPE_TIMESTAMP`,
+     *           `Database::TYPE_DATE`, `Database::TYPE_STRING`,
+     *           `Database::TYPE_BYTES`, `Database::TYPE_ARRAY` and
+     *           `Database::TYPE_STRUCT`. If the parameter type is an array,
      *           the type should be given as an array, where the first element
-     *           is `ValueMapper::TYPE_ARRAY` and the second element is the
-     *           array type, for instance `[ValueMapper::TYPE_ARRAY, ValueMapper::TYPE_INT64]`.
+     *           is `Database::TYPE_ARRAY` and the second element is the
+     *           array type, for instance `[Database::TYPE_ARRAY, Database::TYPE_INT64]`.
      * }
      * @return Result
      */

--- a/tests/snippets/Spanner/BytesTest.php
+++ b/tests/snippets/Spanner/BytesTest.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Tests\Snippets\Spanner;
 
 use Google\Cloud\Dev\Snippet\SnippetTestCase;
 use Google\Cloud\Spanner\Bytes;
+use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\ValueMapper;
 use Psr\Http\Message\StreamInterface;
 
@@ -71,7 +72,7 @@ class BytesTest extends SnippetTestCase
         $snippet = $this->snippetFromMethod(Bytes::class, 'type');
         $snippet->addLocal('bytes', $this->bytes);
         $res = $snippet->invoke();
-        $this->assertEquals(ValueMapper::TYPE_BYTES, $res->output());
+        $this->assertEquals(Database::TYPE_BYTES, $res->output());
     }
 
     public function testFormatAsString()

--- a/tests/snippets/Spanner/DatabaseTest.php
+++ b/tests/snippets/Spanner/DatabaseTest.php
@@ -337,7 +337,7 @@ class DatabaseTest extends SnippetTestCase
                             [
                                 'name' => 'loginCount',
                                 'type' => [
-                                    'code' => ValueMapper::TYPE_INT64
+                                    'code' => Database::TYPE_INT64
                                 ]
                             ]
                         ]
@@ -573,7 +573,7 @@ class DatabaseTest extends SnippetTestCase
                             [
                                 'name' => 'loginCount',
                                 'type' => [
-                                    'code' => ValueMapper::TYPE_INT64
+                                    'code' => Database::TYPE_INT64
                                 ]
                             ]
                         ]
@@ -602,7 +602,7 @@ class DatabaseTest extends SnippetTestCase
                             [
                                 'name' => 'loginCount',
                                 'type' => [
-                                    'code' => ValueMapper::TYPE_INT64
+                                    'code' => Database::TYPE_INT64
                                 ]
                             ]
                         ]
@@ -636,7 +636,7 @@ class DatabaseTest extends SnippetTestCase
                             [
                                 'name' => 'loginCount',
                                 'type' => [
-                                    'code' => ValueMapper::TYPE_INT64
+                                    'code' => Database::TYPE_INT64
                                 ]
                             ]
                         ]
@@ -664,7 +664,7 @@ class DatabaseTest extends SnippetTestCase
         $this->connection->executeStreamingSql(Argument::that(function ($arg) {
             if (!isset($arg['params'])) return false;
             if (!isset($arg['paramTypes'])) return false;
-            if ($arg['paramTypes']['timestamp']['code'] !== ValueMapper::TYPE_TIMESTAMP) return false;
+            if ($arg['paramTypes']['timestamp']['code'] !== Database::TYPE_TIMESTAMP) return false;
 
             return true;
         }))->shouldBeCalled()->willReturn($this->resultGenerator([
@@ -674,7 +674,7 @@ class DatabaseTest extends SnippetTestCase
                         [
                             'name' => 'lastModifiedTime',
                             'type' => [
-                                'code' => ValueMapper::TYPE_TIMESTAMP
+                                'code' => Database::TYPE_TIMESTAMP
                             ]
                         ]
                     ]
@@ -688,7 +688,7 @@ class DatabaseTest extends SnippetTestCase
         $snippet = $this->snippetFromMethod(Database::class, 'execute', 3);
         $snippet->addLocal('database', $this->database);
         $snippet->addLocal('timestamp', null);
-        $snippet->addUse(ValueMapper::class);
+        $snippet->addUse(Database::class);
 
         $res = $snippet->invoke('neverEditedPosts');
         $this->assertNull($res->returnVal()->current()['lastModifiedTime']);
@@ -699,8 +699,8 @@ class DatabaseTest extends SnippetTestCase
         $this->connection->executeStreamingSql(Argument::that(function ($arg) {
             if (!isset($arg['params'])) return false;
             if (!isset($arg['paramTypes'])) return false;
-            if ($arg['paramTypes']['emptyArrayOfIntegers']['code'] !== ValueMapper::TYPE_ARRAY) return false;
-            if ($arg['paramTypes']['emptyArrayOfIntegers']['arrayElementType']['code'] !== ValueMapper::TYPE_INT64) return false;
+            if ($arg['paramTypes']['emptyArrayOfIntegers']['code'] !== Database::TYPE_ARRAY) return false;
+            if ($arg['paramTypes']['emptyArrayOfIntegers']['arrayElementType']['code'] !== Database::TYPE_INT64) return false;
 
             return true;
         }))->shouldBeCalled()->willReturn($this->resultGenerator([
@@ -710,9 +710,9 @@ class DatabaseTest extends SnippetTestCase
                         [
                             'name' => 'numbers',
                             'type' => [
-                                'code' => ValueMapper::TYPE_ARRAY,
+                                'code' => Database::TYPE_ARRAY,
                                 'arrayElementType' => [
-                                    'code' => ValueMapper::TYPE_INT64
+                                    'code' => Database::TYPE_INT64
                                 ]
                             ]
                         ]
@@ -726,7 +726,7 @@ class DatabaseTest extends SnippetTestCase
 
         $snippet = $this->snippetFromMethod(Database::class, 'execute', 4);
         $snippet->addLocal('database', $this->database);
-        $snippet->addUse(ValueMapper::class);
+        $snippet->addUse(Database::class);
 
         $res = $snippet->invoke('emptyArray');
         $this->assertEmpty($res->returnVal());
@@ -743,7 +743,7 @@ class DatabaseTest extends SnippetTestCase
                             [
                                 'name' => 'loginCount',
                                 'type' => [
-                                    'code' => ValueMapper::TYPE_INT64
+                                    'code' => Database::TYPE_INT64
                                 ]
                             ]
                         ]
@@ -773,7 +773,7 @@ class DatabaseTest extends SnippetTestCase
                             [
                                 'name' => 'loginCount',
                                 'type' => [
-                                    'code' => ValueMapper::TYPE_INT64
+                                    'code' => Database::TYPE_INT64
                                 ]
                             ]
                         ]
@@ -808,7 +808,7 @@ class DatabaseTest extends SnippetTestCase
                             [
                                 'name' => 'loginCount',
                                 'type' => [
-                                    'code' => ValueMapper::TYPE_INT64
+                                    'code' => Database::TYPE_INT64
                                 ]
                             ]
                         ]

--- a/tests/snippets/Spanner/DateTest.php
+++ b/tests/snippets/Spanner/DateTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Tests\Snippets\Spanner;
 
 use Google\Cloud\Dev\Snippet\SnippetTestCase;
+use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Date;
 use Google\Cloud\Spanner\ValueMapper;
 
@@ -78,7 +79,7 @@ class DateTest extends SnippetTestCase
         $snippet = $this->snippetFromMethod(Date::class, 'type');
         $snippet->addLocal('date', $this->date);
         $res = $snippet->invoke();
-        $this->assertEquals(ValueMapper::TYPE_DATE, $res->output());
+        $this->assertEquals(Database::TYPE_DATE, $res->output());
     }
 
     public function testFormatAsString()

--- a/tests/snippets/Spanner/SnapshotTest.php
+++ b/tests/snippets/Spanner/SnapshotTest.php
@@ -97,7 +97,7 @@ class SnapshotTest extends SnippetTestCase
                             [
                                 'name' => 'loginCount',
                                 'type' => [
-                                    'code' => ValueMapper::TYPE_INT64
+                                    'code' => Database::TYPE_INT64
                                 ]
                             ]
                         ]
@@ -126,7 +126,7 @@ class SnapshotTest extends SnippetTestCase
                             [
                                 'name' => 'loginCount',
                                 'type' => [
-                                    'code' => ValueMapper::TYPE_INT64
+                                    'code' => Database::TYPE_INT64
                                 ]
                             ]
                         ]

--- a/tests/snippets/Spanner/TimestampTest.php
+++ b/tests/snippets/Spanner/TimestampTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Tests\Snippets\Spanner;
 
 use Google\Cloud\Dev\Snippet\SnippetTestCase;
+use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\ValueMapper;
 
@@ -69,7 +70,7 @@ class TimestampTest extends SnippetTestCase
         $snippet->addLocal('timestamp', $this->timestamp);
 
         $res = $snippet->invoke('type');
-        $this->assertEquals(ValueMapper::TYPE_TIMESTAMP, $res->returnVal());
+        $this->assertEquals(Database::TYPE_TIMESTAMP, $res->returnVal());
     }
 
     public function testFormatAsString()

--- a/tests/snippets/Spanner/TransactionTest.php
+++ b/tests/snippets/Spanner/TransactionTest.php
@@ -316,7 +316,7 @@ class TransactionTest extends SnippetTestCase
                         [
                             'name' => 'loginCount',
                             'type' => [
-                                'code' => ValueMapper::TYPE_INT64
+                                'code' => Database::TYPE_INT64
                             ]
                         ]
                     ]

--- a/tests/system/Spanner/QueryTest.php
+++ b/tests/system/Spanner/QueryTest.php
@@ -19,9 +19,9 @@ namespace Google\Cloud\Tests\System\Spanner;
 
 use Google\Cloud\Core\Int64;
 use Google\Cloud\Spanner\Bytes;
+use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Date;
 use Google\Cloud\Spanner\Timestamp;
-use Google\Cloud\Spanner\ValueMapper;
 
 /**
  * @group spanner
@@ -105,7 +105,7 @@ class QueryTest extends SpannerTestCase
                 'param' => null
             ],
             'types' => [
-                'param' => ValueMapper::TYPE_BOOL
+                'param' => Database::TYPE_BOOL
             ]
         ]);
 
@@ -159,7 +159,7 @@ class QueryTest extends SpannerTestCase
                 'param' => null
             ],
             'types' => [
-                'param' => ValueMapper::TYPE_INT64
+                'param' => Database::TYPE_INT64
             ]
         ]);
 
@@ -197,7 +197,7 @@ class QueryTest extends SpannerTestCase
                 'param' => null
             ],
             'types' => [
-                'param' => ValueMapper::TYPE_FLOAT64
+                'param' => Database::TYPE_FLOAT64
             ]
         ]);
 
@@ -235,7 +235,7 @@ class QueryTest extends SpannerTestCase
                 'param' => null
             ],
             'types' => [
-                'param' => ValueMapper::TYPE_STRING
+                'param' => Database::TYPE_STRING
             ]
         ]);
 
@@ -276,7 +276,7 @@ class QueryTest extends SpannerTestCase
                 'param' => null
             ],
             'types' => [
-                'param' => ValueMapper::TYPE_BYTES
+                'param' => Database::TYPE_BYTES
             ]
         ]);
 
@@ -316,7 +316,7 @@ class QueryTest extends SpannerTestCase
                 'param' => null
             ],
             'types' => [
-                'param' => ValueMapper::TYPE_TIMESTAMP
+                'param' => Database::TYPE_TIMESTAMP
             ]
         ]);
 
@@ -356,7 +356,7 @@ class QueryTest extends SpannerTestCase
                 'param' => null
             ],
             'types' => [
-                'param' => ValueMapper::TYPE_DATE
+                'param' => Database::TYPE_DATE
             ]
         ]);
 
@@ -416,7 +416,7 @@ class QueryTest extends SpannerTestCase
                 'param' => []
             ],
             'types' => [
-                'param' => [ValueMapper::TYPE_ARRAY, $type]
+                'param' => [Database::TYPE_ARRAY, $type]
             ]
         ]);
 
@@ -444,7 +444,7 @@ class QueryTest extends SpannerTestCase
                 'param' => null
             ],
             'types' => [
-                'param' => [ValueMapper::TYPE_ARRAY, $type]
+                'param' => [Database::TYPE_ARRAY, $type]
             ]
         ]);
 
@@ -586,26 +586,26 @@ class QueryTest extends SpannerTestCase
     public function arrayTypesEmpty()
     {
         return [
-            [ValueMapper::TYPE_BOOL],
-            [ValueMapper::TYPE_INT64],
-            [ValueMapper::TYPE_FLOAT64],
-            [ValueMapper::TYPE_STRING],
-            [ValueMapper::TYPE_BYTES],
-            [ValueMapper::TYPE_TIMESTAMP],
-            [ValueMapper::TYPE_DATE],
+            [Database::TYPE_BOOL],
+            [Database::TYPE_INT64],
+            [Database::TYPE_FLOAT64],
+            [Database::TYPE_STRING],
+            [Database::TYPE_BYTES],
+            [Database::TYPE_TIMESTAMP],
+            [Database::TYPE_DATE],
         ];
     }
 
     public function arrayTypesNull()
     {
         return [
-            [ValueMapper::TYPE_BOOL],
-            [ValueMapper::TYPE_INT64],
-            [ValueMapper::TYPE_FLOAT64],
-            [ValueMapper::TYPE_STRING],
-            [ValueMapper::TYPE_BYTES],
-            [ValueMapper::TYPE_TIMESTAMP],
-            [ValueMapper::TYPE_DATE],
+            [Database::TYPE_BOOL],
+            [Database::TYPE_INT64],
+            [Database::TYPE_FLOAT64],
+            [Database::TYPE_STRING],
+            [Database::TYPE_BYTES],
+            [Database::TYPE_TIMESTAMP],
+            [Database::TYPE_DATE],
         ];
     }
 }

--- a/tests/unit/Spanner/DatabaseTest.php
+++ b/tests/unit/Spanner/DatabaseTest.php
@@ -658,7 +658,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
                         [
                             'name' => 'ID',
                             'type' => [
-                                'code' => ValueMapper::TYPE_INT64
+                                'code' => Database::TYPE_INT64
                             ]
                         ]
                     ]

--- a/tests/unit/Spanner/OperationTest.php
+++ b/tests/unit/Spanner/OperationTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Tests\Unit\Spanner;
 
 use Google\Cloud\Spanner\Connection\ConnectionInterface;
+use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\KeyRange;
 use Google\Cloud\Spanner\KeySet;
 use Google\Cloud\Spanner\Operation;
@@ -165,7 +166,7 @@ class OperationTest extends \PHPUnit_Framework_TestCase
             if ($arg['sql'] !== $sql) return false;
             if ($arg['session'] !== self::SESSION) return false;
             if ($arg['params'] !== ['id' => '10']) return false;
-            if ($arg['paramTypes']['id']['code'] !== ValueMapper::TYPE_INT64) return false;
+            if ($arg['paramTypes']['id']['code'] !== Database::TYPE_INT64) return false;
 
             return true;
         }))->shouldBeCalled()->willReturn($this->executeAndReadResponse());
@@ -311,7 +312,7 @@ class OperationTest extends \PHPUnit_Framework_TestCase
                         [
                             'name' => 'ID',
                             'type' => [
-                                'code' => ValueMapper::TYPE_INT64
+                                'code' => Database::TYPE_INT64
                             ]
                         ]
                     ]

--- a/tests/unit/Spanner/TransactionTest.php
+++ b/tests/unit/Spanner/TransactionTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Tests\Unit\Spanner;
 
 use Google\Cloud\Spanner\Connection\ConnectionInterface;
+use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Instance;
 use Google\Cloud\Spanner\KeySet;
 use Google\Cloud\Spanner\Operation;
@@ -313,7 +314,7 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
                         [
                             'name' => 'ID',
                             'type' => [
-                                'code' => ValueMapper::TYPE_INT64
+                                'code' => Database::TYPE_INT64
                             ]
                         ]
                     ]

--- a/tests/unit/Spanner/ValueMapperTest.php
+++ b/tests/unit/Spanner/ValueMapperTest.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Tests\Unit\Spanner;
 
 use Google\Cloud\Core\Int64;
 use Google\Cloud\Spanner\Bytes;
+use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Date;
 use Google\Cloud\Spanner\Result;
 use Google\Cloud\Spanner\Timestamp;
@@ -50,10 +51,10 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
         $res = $this->mapper->formatParamsForExecuteSql($params);
 
         $this->assertEquals($params, $res['params']);
-        $this->assertEquals(ValueMapper::TYPE_INT64, $res['paramTypes']['id']['code']);
-        $this->assertEquals(ValueMapper::TYPE_STRING, $res['paramTypes']['name']['code']);
-        $this->assertEquals(ValueMapper::TYPE_FLOAT64, $res['paramTypes']['pi']['code']);
-        $this->assertEquals(ValueMapper::TYPE_BOOL, $res['paramTypes']['isCool']['code']);
+        $this->assertEquals(Database::TYPE_INT64, $res['paramTypes']['id']['code']);
+        $this->assertEquals(Database::TYPE_STRING, $res['paramTypes']['name']['code']);
+        $this->assertEquals(Database::TYPE_FLOAT64, $res['paramTypes']['pi']['code']);
+        $this->assertEquals(Database::TYPE_BOOL, $res['paramTypes']['isCool']['code']);
     }
 
     public function testFormatParamsForExecuteSqlResource()
@@ -71,7 +72,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
         $res = $this->mapper->formatParamsForExecuteSql($params);
 
         $this->assertEquals($c, base64_decode($res['params']['resource']));
-        $this->assertEquals(ValueMapper::TYPE_BYTES, $res['paramTypes']['resource']['code']);
+        $this->assertEquals(Database::TYPE_BYTES, $res['paramTypes']['resource']['code']);
     }
 
     public function testFormatParamsForExecuteSqlArray()
@@ -84,8 +85,8 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('foo', $res['params']['array'][0]);
         $this->assertEquals('bar', $res['params']['array'][1]);
-        $this->assertEquals(ValueMapper::TYPE_ARRAY, $res['paramTypes']['array']['code']);
-        $this->assertEquals(ValueMapper::TYPE_STRING, $res['paramTypes']['array']['arrayElementType']['code']);
+        $this->assertEquals(Database::TYPE_ARRAY, $res['paramTypes']['array']['code']);
+        $this->assertEquals(Database::TYPE_STRING, $res['paramTypes']['array']['arrayElementType']['code']);
     }
 
     /**
@@ -116,7 +117,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
         $res = $this->mapper->formatParamsForExecuteSql($params);
 
         $this->assertEquals($val, $res['params']['int']);
-        $this->assertEquals(ValueMapper::TYPE_INT64, $res['paramTypes']['int']['code']);
+        $this->assertEquals(Database::TYPE_INT64, $res['paramTypes']['int']['code']);
     }
 
     public function testFormatParamsForExecuteSqlValueInterface()
@@ -128,7 +129,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
 
         $res = $this->mapper->formatParamsForExecuteSql($params);
         $this->assertEquals($val, base64_decode($res['params']['bytes']));
-        $this->assertEquals(ValueMapper::TYPE_BYTES, $res['paramTypes']['bytes']['code']);
+        $this->assertEquals(Database::TYPE_BYTES, $res['paramTypes']['bytes']['code']);
     }
 
     /**
@@ -180,7 +181,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
     public function testDecodeValuesThrowsExceptionWithInvalidFormat()
     {
         $res = $this->mapper->decodeValues(
-            $this->createField(ValueMapper::TYPE_STRING),
+            $this->createField(Database::TYPE_STRING),
             $this->createRow(self::FORMAT_TEST_VALUE),
             'Not a real format'
         );
@@ -192,7 +193,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
     public function testDecodeValuesReturnsVariedFormats($expectedOutput, $format)
     {
         $res = $this->mapper->decodeValues(
-            $this->createField(ValueMapper::TYPE_STRING),
+            $this->createField(Database::TYPE_STRING),
             $this->createRow(self::FORMAT_TEST_VALUE),
             $format
         );
@@ -228,7 +229,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
     public function testDecodeValuesBool()
     {
         $res = $this->mapper->decodeValues(
-            $this->createField(ValueMapper::TYPE_BOOL),
+            $this->createField(Database::TYPE_BOOL),
             $this->createRow(false),
             Result::RETURN_ASSOCIATIVE
         );
@@ -238,7 +239,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
     public function testDecodeValuesInt()
     {
         $res = $this->mapper->decodeValues(
-            $this->createField(ValueMapper::TYPE_INT64),
+            $this->createField(Database::TYPE_INT64),
             $this->createRow('555'),
             Result::RETURN_ASSOCIATIVE
         );
@@ -249,7 +250,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
     {
         $mapper = new ValueMapper(true);
         $res = $mapper->decodeValues(
-            $this->createField(ValueMapper::TYPE_INT64),
+            $this->createField(Database::TYPE_INT64),
             $this->createRow('555'),
             Result::RETURN_ASSOCIATIVE
         );
@@ -260,7 +261,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
     public function testDecodeValuesFloat()
     {
         $res = $this->mapper->decodeValues(
-            $this->createField(ValueMapper::TYPE_FLOAT64),
+            $this->createField(Database::TYPE_FLOAT64),
             $this->createRow(3.1415),
             Result::RETURN_ASSOCIATIVE
         );
@@ -270,7 +271,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
     public function testDecodeValuesFloatNaN()
     {
         $res = $this->mapper->decodeValues(
-            $this->createField(ValueMapper::TYPE_FLOAT64),
+            $this->createField(Database::TYPE_FLOAT64),
             $this->createRow('NaN'),
             Result::RETURN_ASSOCIATIVE
         );
@@ -280,7 +281,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
     public function testDecodeValuesFloatInfinity()
     {
         $res = $this->mapper->decodeValues(
-            $this->createField(ValueMapper::TYPE_FLOAT64),
+            $this->createField(Database::TYPE_FLOAT64),
             $this->createRow('Infinity'),
             Result::RETURN_ASSOCIATIVE
         );
@@ -292,7 +293,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
     public function testDecodeValuesFloatNegativeInfinity()
     {
         $res = $this->mapper->decodeValues(
-            $this->createField(ValueMapper::TYPE_FLOAT64),
+            $this->createField(Database::TYPE_FLOAT64),
             $this->createRow('-Infinity'),
             Result::RETURN_ASSOCIATIVE
         );
@@ -307,7 +308,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
     public function testDecodeValuesFloatError()
     {
         $res = $this->mapper->decodeValues(
-            $this->createField(ValueMapper::TYPE_FLOAT64),
+            $this->createField(Database::TYPE_FLOAT64),
             $this->createRow('foo'),
             Result::RETURN_ASSOCIATIVE
         );
@@ -316,7 +317,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
     public function testDecodeValuesString()
     {
         $res = $this->mapper->decodeValues(
-            $this->createField(ValueMapper::TYPE_STRING),
+            $this->createField(Database::TYPE_STRING),
             $this->createRow('foo'),
             Result::RETURN_ASSOCIATIVE
         );
@@ -327,7 +328,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
     {
         $dt = new \DateTime;
         $res = $this->mapper->decodeValues(
-            $this->createField(ValueMapper::TYPE_TIMESTAMP),
+            $this->createField(Database::TYPE_TIMESTAMP),
             $this->createRow($dt->format(Timestamp::FORMAT)),
             Result::RETURN_ASSOCIATIVE
         );
@@ -340,7 +341,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
     {
         $dt = new \DateTime;
         $res = $this->mapper->decodeValues(
-            $this->createField(ValueMapper::TYPE_DATE),
+            $this->createField(Database::TYPE_DATE),
             $this->createRow($dt->format(Date::FORMAT)),
             Result::RETURN_ASSOCIATIVE
         );
@@ -352,7 +353,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
     public function testDecodeValuesBytes()
     {
         $res = $this->mapper->decodeValues(
-            $this->createField(ValueMapper::TYPE_BYTES),
+            $this->createField(Database::TYPE_BYTES),
             $this->createRow(base64_encode('hello world')),
             Result::RETURN_ASSOCIATIVE
         );
@@ -364,8 +365,8 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
     public function testDecodeValuesArray()
     {
         $res = $this->mapper->decodeValues(
-            $this->createField(ValueMapper::TYPE_ARRAY, 'arrayElementType', [
-                'code' => ValueMapper::TYPE_STRING
+            $this->createField(Database::TYPE_ARRAY, 'arrayElementType', [
+                'code' => Database::TYPE_STRING
             ]),
             $this->createRow(['foo', 'bar']),
             Result::RETURN_ASSOCIATIVE
@@ -380,15 +381,15 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
         $field = [
             'name' => 'structTest',
             'type' => [
-                'code' => ValueMapper::TYPE_ARRAY,
+                'code' => Database::TYPE_ARRAY,
                 'arrayElementType' => [
-                    'code' => ValueMapper::TYPE_STRUCT,
+                    'code' => Database::TYPE_STRUCT,
                     'structType' => [
                         'fields' => [
                             [
                                 'name' => 'rowName',
                                 'type' => [
-                                    'code' => ValueMapper::TYPE_STRING
+                                    'code' => Database::TYPE_STRING
                                 ]
                             ]
                         ]
@@ -418,11 +419,11 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
             [
                 'name' => 'ID',
                 'type' => [
-                    'code' => ValueMapper::TYPE_INT64,
+                    'code' => Database::TYPE_INT64,
                 ]
             ], [
                 'type' => [
-                    'code' => ValueMapper::TYPE_STRING
+                    'code' => Database::TYPE_STRING
                 ]
             ]
         ];


### PR DESCRIPTION
`ValueMapper` is not visible to an end-user in any context besides the type constants, so it makes sense to move the types to a class which the user will already be interacting with.