### PR TITLE
Prevent nested transactions

### DIFF
--- a/src/Spanner/Database.php
+++ b/src/Spanner/Database.php
@@ -144,6 +144,11 @@ class Database
     private $sessionPool;
 
     /**
+     * @var bool
+     */
+    private $isRunningTransaction = false;
+
+    /**
      * Create an object representing a Database.
      *
      * @param ConnectionInterface $connection The connection to the
@@ -593,6 +598,10 @@ class Database
      * it is important that every transaction commits or rolls back as early as
      * possible. Do not hold transactions open longer than necessary.
      *
+     * Please also note that nested transactions are NOT supported by this client.
+     * Attempting to call `runTransaction` inside a transaction callable will
+     * raise a `BadMethodCallException`.
+     *
      * If a callable finishes executing without invoking
      * {@see Google\Cloud\Spanner\Transaction::commit()} or
      * {@see Google\Cloud\Spanner\Transaction::rollback()}, the transaction will
@@ -643,10 +652,15 @@ class Database
      *           `false`.
      * }
      * @return mixed The return value of `$operation`.
-     * @throws \RuntimeException
+     * @throws \RuntimeException If a transaction is not committed or rolled back.
+     * @throws \BadMethodCallException If a nested transaction is created.
      */
     public function runTransaction(callable $operation, array $options = [])
     {
+        if ($this->isRunningTransaction) {
+            throw new \BadMethodCallException('Nested transactions are not supported by this client.');
+        }
+
         $options += [
             'maxRetries' => self::MAX_RETRIES,
         ];
@@ -683,7 +697,13 @@ class Database
                 $options
             ]);
 
-            $res = call_user_func($operation, $transaction);
+            // Prevent nested transactions.
+            $this->isRunningTransaction = true;
+            try {
+                $res = call_user_func($operation, $transaction);
+            } finally {
+                $this->isRunningTransaction = false;
+            }
 
             $active = $transaction->state() === Transaction::STATE_ACTIVE;
             $singleUse = $transaction->type() === Transaction::TYPE_SINGLE_USE;

--- a/src/Spanner/Database.php
+++ b/src/Spanner/Database.php
@@ -512,6 +512,8 @@ class Database
      *           **Defaults to** `false`.
      * }
      * @return Snapshot
+     * @throws \BadMethodCallException If attempting to call this method within
+     *         an existing transaction.
      * @codingStandardsIgnoreEnd
      */
     public function snapshot(array $options = [])
@@ -569,6 +571,8 @@ class Database
      *           **Defaults to** `false`.
      * }
      * @return Transaction
+     * @throws \BadMethodCallException If attempting to call this method within
+     *         an existing transaction.
      */
     public function transaction(array $options = [])
     {
@@ -661,7 +665,8 @@ class Database
      * }
      * @return mixed The return value of `$operation`.
      * @throws \RuntimeException If a transaction is not committed or rolled back.
-     * @throws \BadMethodCallException If a nested transaction is created.
+     * @throws \BadMethodCallException If attempting to call this method within
+     *         an existing transaction.
      */
     public function runTransaction(callable $operation, array $options = [])
     {

--- a/src/Spanner/Database.php
+++ b/src/Spanner/Database.php
@@ -516,6 +516,10 @@ class Database
      */
     public function snapshot(array $options = [])
     {
+        if ($this->isRunningTransaction) {
+            throw new \BadMethodCallException('Nested transactions are not supported by this client.');
+        }
+
         $options += [
             'singleUse' => false
         ];
@@ -568,6 +572,10 @@ class Database
      */
     public function transaction(array $options = [])
     {
+        if ($this->isRunningTransaction) {
+            throw new \BadMethodCallException('Nested transactions are not supported by this client.');
+        }
+
         // There isn't anything configurable here.
         $options['transactionOptions'] = $this->configureTransactionOptions();
 

--- a/tests/unit/Spanner/DatabaseTest.php
+++ b/tests/unit/Spanner/DatabaseTest.php
@@ -340,6 +340,25 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
         $this->database->runTransaction(function (Transaction $t) {});
     }
 
+    /**
+     * @expectedException BadMethodCallException
+     */
+    public function testRunTransactionNestedTransaction()
+    {
+        $this->connection->beginTransaction(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn(['id' => self::TRANSACTION]);
+
+        $this->connection->rollback(Argument::any())
+            ->shouldNotBeCalled();
+
+        $this->refreshOperation();
+
+        $this->database->runTransaction(function ($t) {
+            $this->database->runTransaction(function ($t) {});
+        });
+    }
+
     public function testRunTransactionRetry()
     {
         $abort = new AbortedException('foo', 409, null, [

--- a/tests/unit/Spanner/DatabaseTest.php
+++ b/tests/unit/Spanner/DatabaseTest.php
@@ -300,6 +300,25 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
         $this->database->snapshot(['maxStaleness' => 'foo']);
     }
 
+    /**
+     * @expectedException BadMethodCallException
+     */
+    public function testSnapshotNestedTransaction()
+    {
+        $this->connection->beginTransaction(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn(['id' => self::TRANSACTION]);
+
+        $this->connection->rollback(Argument::any())
+            ->shouldNotBeCalled();
+
+        $this->refreshOperation();
+
+        $this->database->runTransaction(function ($t) {
+            $this->database->snapshot();
+        });
+    }
+
     public function testRunTransaction()
     {
         $this->connection->beginTransaction(Argument::any())
@@ -444,6 +463,25 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
 
         $t = $this->database->transaction();
         $this->assertInstanceOf(Transaction::class, $t);
+    }
+
+    /**
+     * @expectedException BadMethodCallException
+     */
+    public function testTransactionNestedTransaction()
+    {
+        $this->connection->beginTransaction(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn(['id' => self::TRANSACTION]);
+
+        $this->connection->rollback(Argument::any())
+            ->shouldNotBeCalled();
+
+        $this->refreshOperation();
+
+        $this->database->runTransaction(function ($t) {
+            $this->database->transaction();
+        });
     }
 
     public function testInsert()


### PR DESCRIPTION
Closes #528.

Please note that while this change prevents calling `Database::runTransaction()` inside `Database::runTransaction()`, it only works *on a single `Database` instance*. There is no protection against a user creating a new instance of the client and injecting it into the runTransaction callback. If we must protect against this, it will require additional discussion and work, and would be much more challenging.

/cc @vkedia.

edit: Examples of what I explained above:

```php
use Google\Cloud\Spanner\SpannerClient;

$spanner = new SpannerClient();
$db = $spanner->connect('instance', 'database');

$db->runTransaction(function ($t) use ($db) {
    // Exception thrown here.
    $db->runTransaction(function (){});
});
```

```php
use Google\Cloud\Spanner\SpannerClient;

$spanner = new SpannerClient();
$db = $spanner->connect('instance', 'database');
$db2 = $spanner->connect('instance', 'database');

$db->runTransaction(function ($t) use ($db2) {
    // No exception will be thrown.
    $db2->runTransaction(function () {});
});
```