### PR TITLE
upgrade to google/auth ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "erusev/parsedown": "^1.6",
         "vierbergenlars/php-semver": "^3.0",
         "google/proto-client-php": "^0.13",
-        "google/gax": "^0.9",
+        "google/gax": "^0.10",
         "symfony/lock": "3.3.x-dev#1ba6ac9"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "require": {
         "php": ">=5.5",
         "rize/uri-template": "~0.3",
-        "google/auth": "^0.11",
+        "google/auth": "^1.0",
         "guzzlehttp/guzzle": "^5.3|^6.0",
         "guzzlehttp/psr7": "^1.2",
         "monolog/monolog": "~1",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.5",
         "rize/uri-template": "~0.3",
-        "google/auth": "^0.11",
+        "google/auth": "^1.0",
         "guzzlehttp/guzzle": "^5.3|^6.0",
         "guzzlehttp/psr7": "^1.2",
         "monolog/monolog": "~1",

--- a/src/ErrorReporting/composer.json
+++ b/src/ErrorReporting/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "ext-grpc": "*",
         "google/proto-client-php": "^0.13",
-        "google/gax": "^0.9"
+        "google/gax": "^0.10"
     },
     "extra": {
         "component": {

--- a/src/Monitoring/composer.json
+++ b/src/Monitoring/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "ext-grpc": "*",
         "google/proto-client-php": "^0.13",
-        "google/gax": "^0.9"
+        "google/gax": "^0.10"
     },
     "extra": {
         "component": {

--- a/src/Spanner/composer.json
+++ b/src/Spanner/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "ext-grpc": "*",
         "google/cloud-core": "^1.4",
-        "google/gax": "^0.9",
+        "google/gax": "^0.10",
         "google/proto-client-php": "^0.13"
     },
     "suggest": {

--- a/src/VideoIntelligence/composer.json
+++ b/src/VideoIntelligence/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "ext-grpc": "*",
         "google/proto-client-php": "^0.13",
-        "google/gax": "^0.9"
+        "google/gax": "^0.10"
     },
     "extra": {
         "component": {


### PR DESCRIPTION
A new version of `google/auth` was tagged. There haven't been any important changes since `v0.11`, just the fact that we are finally calling it stable, which is nice.