### PR TITLE
Fixing a documentation comment in SpannerClient class construct

### DIFF
--- a/src/Spanner/SpannerClient.php
+++ b/src/Spanner/SpannerClient.php
@@ -91,7 +91,7 @@ class SpannerClient
      *     @type callable $authHttpHandler A handler used to deliver Psr7
      *           requests specifically for authentication.
      *     @type callable $httpHandler A handler used to deliver Psr7 requests.
-     *     @type string $keyFile The contents of the service account
+     *     @type array $keyFile The json decoded contents of the service account
      *           credentials .json file retrieved from the Google Developers
      *           Console.
      *     @type string $keyFilePath The full path to your service account


### PR DESCRIPTION
According to https://github.com/google/google-auth-library-php/blob/master/src/CredentialsLoader.php#L115 this should actually be the json-decoded array of the service credentials passed through, not the raw string. This is also mentioned here: https://github.com/GoogleCloudPlatform/google-cloud-php/blob/master/src/Core/RequestWrapperTrait.php#L80