### PR TITLE
Bump gax version, fix for resource streaming

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,8 +57,8 @@
         "league/json-guard": "^0.3",
         "erusev/parsedown": "^1.6",
         "vierbergenlars/php-semver": "^3.0",
-        "google/proto-client": "^0.20.0",
-        "google/gax": "^0.20.0",
+        "google/proto-client": "^0.20.1",
+        "google/gax": "^0.20.1",
         "symfony/lock": "3.3.x-dev#1ba6ac9"
     },
     "suggest": {

--- a/src/ErrorReporting/composer.json
+++ b/src/ErrorReporting/composer.json
@@ -5,8 +5,8 @@
     "minimum-stability": "stable",
     "require": {
         "ext-grpc": "*",
-        "google/proto-client": "^0.20.0",
-        "google/gax": "^0.20.0"
+        "google/proto-client": "^0.20.1",
+        "google/gax": "^0.20.1"
     },
     "extra": {
         "component": {

--- a/src/Monitoring/composer.json
+++ b/src/Monitoring/composer.json
@@ -5,8 +5,8 @@
     "minimum-stability": "stable",
     "require": {
         "ext-grpc": "*",
-        "google/proto-client": "^0.20",
-        "google/gax": "^0.20"
+        "google/proto-client": "^0.20.1",
+        "google/gax": "^0.20.1"
     },
     "extra": {
         "component": {

--- a/src/PubSub/V1/SubscriberClient.php
+++ b/src/PubSub/V1/SubscriberClient.php
@@ -368,7 +368,7 @@ class SubscriberClient
         return [
             'streamingPull' => [
                 'grpcStreamingType' => 'BidiStreaming',
-                'resourcesField' => 'getReceivedMessages',
+                'resourcesGetMethod' => 'getReceivedMessages',
             ],
         ];
     }

--- a/src/Spanner/composer.json
+++ b/src/Spanner/composer.json
@@ -6,8 +6,8 @@
     "require": {
         "ext-grpc": "*",
         "google/cloud-core": "^1.5",
-        "google/gax": "^0.20.0",
-        "google/proto-client": "^0.20.0"
+        "google/gax": "^0.20.1",
+        "google/proto-client": "^0.20.1"
     },
     "suggest": {
         "symfony/lock": "Required for the default session handler. Should be included as follows: 3.3.x-dev#1ba6ac9"

--- a/src/VideoIntelligence/composer.json
+++ b/src/VideoIntelligence/composer.json
@@ -5,8 +5,8 @@
     "minimum-stability": "stable",
     "require": {
         "ext-grpc": "*",
-        "google/proto-client": "^0.20",
-        "google/gax": "^0.20"
+        "google/proto-client": "^0.20.1",
+        "google/gax": "^0.20.1"
     },
     "extra": {
         "component": {


### PR DESCRIPTION
- Bump gax version for 0.20.1 release, which contains bug fixes and updates the ApiException message format to match REST
- Bugfix renaming resourcesField->resourcesGetMethod