### PR TITLE
Add Speech wordTimeOffset support

### DIFF
--- a/src/Speech/Result.php
+++ b/src/Speech/Result.php
@@ -72,7 +72,9 @@ class Result
      *         a `transcript` key which holds the transcribed text. Optionally
      *         a `confidence` key holding the confidence estimate ranging from
      *         0.0 to 1.0 may be present. `confidence` is typically provided
-     *         only for the top hypothesis.
+     *         only for the top hypothesis. If the `enableWordTimeOffsets`
+     *         option was set in the request, the top hypothesis will also
+     *         contain a list of `wordTimeOffsets`.
      */
     public function alternatives()
     {
@@ -93,6 +95,8 @@ class Result
      * @return array The top alternative. Contains a `transcript` key which
      *         holds the transcribed text. Optionally a `confidence` key holding
      *         the confidence estimate ranging from 0.0 to 1.0 may be present.
+     *         If the `enableWordTimeOffsets` option was set in the request, this
+     *         will also contain a list of `wordTimeOffsets`.
      */
     public function topAlternative()
     {

--- a/src/Speech/SpeechClient.php
+++ b/src/Speech/SpeechClient.php
@@ -188,6 +188,13 @@ class SpeechClient
      *           to favor specific words and phrases in the results. Please see
      *           [SpeechContext](https://cloud.google.com/speech/reference/rest/v1/RecognitionConfig#SpeechContext)
      *           for more information.
+     *     @type bool $enableWordTimeOffsets If set to `true`, a list of
+     *           `word_time_offsets` are returned with the top alternative. If
+     *           `false` or omitted, no `word_time_offsets` are returned.
+     *           **Defaults to** `false`.
+     *           **Whitelist Warning:** At the time of publication, this argument
+     *           is subject to a feature whitelist and may not be available in
+     *           your project.
      * }
      * @return array Result[]
      * @throws \InvalidArgumentException
@@ -313,6 +320,13 @@ class SpeechClient
      *           to favor specific words and phrases in the results. Please see
      *           [SpeechContext](https://cloud.google.com/speech/reference/rest/v1/RecognitionConfig#SpeechContext)
      *           for more information.
+     *     @type bool $enableWordTimeOffsets If set to `true`, a list of
+     *           `word_time_offsets` are returned with the top alternative. If
+     *           `false` or omitted, no `word_time_offsets` are returned.
+     *           **Defaults to** `false`.
+     *           **Whitelist Warning:** At the time of publication, this argument
+     *           is subject to a feature whitelist and may not be available in
+     *           your project.
      * }
      * @return Operation
      * @throws \InvalidArgumentException
@@ -370,7 +384,8 @@ class SpeechClient
             'languageCode',
             'maxAlternatives',
             'profanityFilter',
-            'speechContexts'
+            'speechContexts',
+            'enableWordTimeOffsets'
         ];
 
         if ($audio instanceof StorageObject) {

--- a/src/Speech/SpeechClient.php
+++ b/src/Speech/SpeechClient.php
@@ -189,8 +189,8 @@ class SpeechClient
      *           [SpeechContext](https://cloud.google.com/speech/reference/rest/v1/RecognitionConfig#SpeechContext)
      *           for more information.
      *     @type bool $enableWordTimeOffsets If set to `true`, a list of
-     *           `word_time_offsets` are returned with the top alternative. If
-     *           `false` or omitted, no `word_time_offsets` are returned.
+     *           `wordTimeOffsets` are returned with the top alternative. If
+     *           `false` or omitted, no `wordTimeOffsets` are returned.
      *           **Defaults to** `false`.
      *           **Whitelist Warning:** At the time of publication, this argument
      *           is subject to a feature whitelist and may not be available in
@@ -321,8 +321,8 @@ class SpeechClient
      *           [SpeechContext](https://cloud.google.com/speech/reference/rest/v1/RecognitionConfig#SpeechContext)
      *           for more information.
      *     @type bool $enableWordTimeOffsets If set to `true`, a list of
-     *           `word_time_offsets` are returned with the top alternative. If
-     *           `false` or omitted, no `word_time_offsets` are returned.
+     *           `wordTimeOffsets` are returned with the top alternative. If
+     *           `false` or omitted, no `wordTimeOffsets` are returned.
      *           **Defaults to** `false`.
      *           **Whitelist Warning:** At the time of publication, this argument
      *           is subject to a feature whitelist and may not be available in

--- a/tests/unit/Speech/SpeechClientTest.php
+++ b/tests/unit/Speech/SpeechClientTest.php
@@ -125,7 +125,8 @@ class SpeechClientTest extends \PHPUnit_Framework_TestCase
                         [
                             'phrases' => ['Test']
                         ]
-                    ]
+                    ],
+                    'enableWordTimeOffsets' => false
                 ],
                 [
                     'audio' => [
@@ -139,7 +140,8 @@ class SpeechClientTest extends \PHPUnit_Framework_TestCase
                             [
                                 'phrases' => ['Test']
                             ]
-                        ]
+                        ],
+                        'enableWordTimeOffsets' => false
                     ]
                 ]
             ],


### PR DESCRIPTION
cc @shinfan 

This PR adds support for the new wordTimeOffset feature in Speech.

Currently there are no system tests for the Speech API, but I have manually verified the change against our test project, which is whitelisted for this feature.