### PR TITLE
add dlp to includes

### DIFF
--- a/docs/contents/google-cloud.json
+++ b/docs/contents/google-cloud.json
@@ -7,6 +7,7 @@
     "includes": [
         "cloud-bigquery",
         "cloud-datastore",
+        "cloud-dlp",
         "cloud-error-reporting",
         "cloud-logging",
         "cloud-monitoring",


### PR DESCRIPTION
This was missed when merging in DLP earlier and is required for content to show up in the nav bar on the doc site. I manually pushed the updates to the doc site, but we will want this for the future when generating new releases.