### PR TITLE
Only emit debug information when debugOutput is enabled

### DIFF
--- a/src/Core/Batch/BatchTrait.php
+++ b/src/Core/Batch/BatchTrait.php
@@ -92,10 +92,12 @@ trait BatchTrait
         try {
             call_user_func_array($this->getCallback(), [$items]);
         } catch (\Exception $e) {
-            fwrite(
-                $this->debugOutputResource ?: STDERR,
-                $e->getMessage() . PHP_EOL
-            );
+            if ($this->debugOutput) {
+                fwrite(
+                    $this->debugOutputResource ?: STDERR,
+                    $e->getMessage() . PHP_EOL
+                );
+            }
 
             return false;
         }
@@ -137,7 +139,8 @@ trait BatchTrait
      *     @type resource $debugOutputResource A resource to output debug output
      *           to.
      *     @type bool $debugOutput Whether or not to output debug information.
-     *           **Defaults to** false.
+     *           Please note debug output currently only applies in CLI based
+     *           applications. **Defaults to** `false`.
      *     @type array $batchOptions A set of options for a BatchJob.
      *           {@see \Google\Cloud\Core\Batch\BatchJob::__construct()} for
      *           more details.

--- a/src/Logging/LoggingClient.php
+++ b/src/Logging/LoggingClient.php
@@ -107,7 +107,8 @@ class LoggingClient
      *           automatically chosen provider, based on detected environment
      *           settings.
      *     @type bool $debugOutput Whether or not to output debug information.
-     *           **Defaults to** false.
+     *           Please note debug output currently only applies in CLI based
+     *           applications. **Defaults to** `false`.
      *     @type array $batchOptions A set of options for a BatchJob.
      *           {@see \Google\Cloud\Core\Batch\BatchJob::__construct()} for
      *           more details.
@@ -502,8 +503,9 @@ class LoggingClient
      *     @type bool $batchEnabled Determines whether or not to use background
      *           batching. **Defaults to** `false`.
      *     @type bool $debugOutput Whether or not to output debug information.
-     *           **Defaults to** false. Applies only when `batchEnabled` is set
-     *           to `true`.
+     *           Please note debug output currently only applies in CLI based
+     *           applications. **Defaults to** `false`. Applies only when
+     *           `batchEnabled` is set to `true`.
      *     @type array $batchOptions A set of options for a BatchJob.
      *           {@see \Google\Cloud\Core\Batch\BatchJob::__construct()} for
      *           more details.

--- a/src/Logging/PsrLogger.php
+++ b/src/Logging/PsrLogger.php
@@ -95,8 +95,9 @@ class PsrLogger implements LoggerInterface, \Serializable
      *           batching. **Defaults to** `false`. Note that this option is
      *           currently considered **experimental** and is subject to change.
      *     @type bool $debugOutput Whether or not to output debug information.
-     *           **Defaults to** false. Applies only when `batchEnabled` is set
-     *           to `true`.
+     *           Please note debug output currently only applies in CLI based
+     *           applications. **Defaults to** `false`. Applies only when
+     *           `batchEnabled` is set to `true`.
      *     @type array $batchOptions A set of options for a BatchJob.
      *           {@see \Google\Cloud\Core\Batch\BatchJob::__construct()} for
      *           more details.

--- a/src/PubSub/Topic.php
+++ b/src/PubSub/Topic.php
@@ -362,7 +362,8 @@ class Topic
      *     Configuration options.
      *
      *     @type bool $debugOutput Whether or not to output debug information.
-     *           **Defaults to** `false`.
+     *           Please note debug output currently only applies in CLI based
+     *           applications. **Defaults to** `false`.
      *     @type array $batchOptions A set of options for a BatchJob.
      *           {@see \Google\Cloud\Core\Batch\BatchJob::__construct()} for
      *           more details.

--- a/src/Trace/Reporter/AsyncReporter.php
+++ b/src/Trace/Reporter/AsyncReporter.php
@@ -49,7 +49,8 @@ class AsyncReporter implements ReporterInterface
      *     @type TraceClient $client A trace client used to instantiate traces
      *           to be delivered to the batch queue.
      *     @type bool $debugOutput Whether or not to output debug information.
-     *           **Defaults to** `false`.
+     *           Please note debug output currently only applies in CLI based
+     *           applications. **Defaults to** `false`.
      *     @type array $batchOptions A set of options for a BatchJob.
      *           {@see \Google\Cloud\Core\Batch\BatchJob::__construct()} for
      *           more details.


### PR DESCRIPTION
Closes: https://github.com/GoogleCloudPlatform/google-cloud-php/issues/584

cc @tmatsuo 

How does this solution sound for right now?

As a future item, we could replace these fwrite calls with a generalized logging mechanism that could also be utilized elsewhere throughout the library for emitting debug information.

Let me know what you think! :)