### PR TITLE
Update documentation generation

### DIFF
--- a/dev/src/DocGenerator/DocGenerator.php
+++ b/dev/src/DocGenerator/DocGenerator.php
@@ -78,11 +78,9 @@ class DocGenerator
             $isPhp = strrpos($file, '.php') == strlen($file) - strlen('.php');
 
             if ($isPhp) {
-                $fileReflector = $fileReflectorRegister->getFileReflector($file);
                 $parser = new CodeParser(
                     $file,
                     $currentFile,
-                    $fileReflector,
                     $fileReflectorRegister,
                     dirname($this->executionPath),
                     $this->componentId,

--- a/dev/src/DocGenerator/DocGenerator.php
+++ b/dev/src/DocGenerator/DocGenerator.php
@@ -19,8 +19,6 @@ namespace Google\Cloud\Dev\DocGenerator;
 
 use Google\Cloud\Dev\DocGenerator\Parser\CodeParser;
 use Google\Cloud\Dev\DocGenerator\Parser\MarkdownParser;
-use phpDocumentor\Reflection\DocBlock\Description;
-use phpDocumentor\Reflection\DocBlock\Tag\SeeTag;
 use phpDocumentor\Reflection\FileReflector;
 
 /**
@@ -88,6 +86,7 @@ class DocGenerator
                     $this->componentId,
                     $this->manifestPath,
                     $this->release,
+                    $basePath,
                     $this->isComponent
                 );
             } else {

--- a/dev/src/DocGenerator/DocGenerator.php
+++ b/dev/src/DocGenerator/DocGenerator.php
@@ -65,6 +65,7 @@ class DocGenerator
      */
     public function generate($basePath, $pretty)
     {
+        $fileReflectorRegister = new ReflectorRegister();
         foreach ($this->files as $file) {
 
             if ($basePath) {
@@ -77,11 +78,12 @@ class DocGenerator
             $isPhp = strrpos($file, '.php') == strlen($file) - strlen('.php');
 
             if ($isPhp) {
-                $fileReflector = new FileReflector($file);
+                $fileReflector = $fileReflectorRegister->getFileReflector($file);
                 $parser = new CodeParser(
                     $file,
                     $currentFile,
                     $fileReflector,
+                    $fileReflectorRegister,
                     dirname($this->executionPath),
                     $this->componentId,
                     $this->manifestPath,

--- a/dev/src/DocGenerator/Parser/CodeParser.php
+++ b/dev/src/DocGenerator/Parser/CodeParser.php
@@ -268,26 +268,34 @@ class CodeParser implements ParserInterface
     {
         $content = '';
         if (method_exists($reflector, 'getParentClass')) {
-            $parentClass = $reflector->getParentClass();
-            if (isset($parentClass)) {
-                $content .= "\nExtends " . $this->buildReference($parentClass);
-            }
+            $content .= $this->buildInheritDocContent([$reflector->getParentClass()], "Extends");
         } elseif (method_exists($reflector, 'getParentInterfaces')) {
-            foreach($reflector->getParentInterfaces() as $trait) {
-                $content .= "\nExtends " . $this->buildReference($trait);
-            }
+            $content .= $this->buildInheritDocContent($reflector->getParentInterfaces(), "Extends");
         }
 
         if (method_exists($reflector, 'getTraits')) {
-            foreach($reflector->getTraits() as $trait) {
-                $content .= "\nUses " . $this->buildReference($trait);
-            }
+            $content .= $this->buildInheritDocContent($reflector->getTraits(), "Uses");
         }
 
         if (method_exists($reflector, 'getInterfaces')) {
-            foreach($reflector->getInterfaces() as $trait) {
-                $content .= "\nImplements " . $this->buildReference($trait);
+            $content .= $this->buildInheritDocContent($reflector->getInterfaces(), "Implements");
+        }
+
+        return $content;
+    }
+
+    private function buildInheritDocContent($items, $prefix)
+    {
+        $refs = [];
+        foreach($items as $item) {
+            if (!empty($item)) {
+                $refs[] = $this->buildReference($item);
             }
+        }
+        if (count($refs) > 0) {
+            return "\n\n$prefix " . implode(", ", $refs);
+        } else {
+            return "";
         }
     }
 

--- a/dev/src/DocGenerator/ReflectorRegister.php
+++ b/dev/src/DocGenerator/ReflectorRegister.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\DocGenerator;
+
+use Google\Cloud\Dev\DocGenerator\Parser\CodeParser;
+use Google\Cloud\Dev\DocGenerator\Parser\MarkdownParser;
+use phpDocumentor\Reflection\FileReflector;
+
+class ReflectorRegister
+{
+    private $reflectors = [];
+    private $fileReflectors = [];
+    private $nameFileMap = [];
+
+    public function getFileReflector($fileName)
+    {
+        if (!isset($this->fileReflectors[$fileName])) {
+            $this->fileReflectors[$fileName] = new FileReflector($fileName);
+            $this->fileReflectors[$fileName]->process();
+        }
+        return $this->fileReflectors[$fileName];
+    }
+
+    public function getReflector($name)
+    {
+        if (!isset($this->reflectors[$name])) {
+            $fileName = $this->getFileForName($name);
+            if (empty($fileName)) {
+                return null;
+            }
+            $fileReflector = $this->getFileReflector($fileName);
+            $reflector = $this->getReflectorFromFileReflector($fileReflector);
+            $this->reflectors[$name] = $reflector;
+        }
+        return $this->reflectors[$name];
+    }
+
+    public function getReflectorFromFileReflector($fileReflector)
+    {
+        if (isset($fileReflector->getClasses()[0])) {
+            return $fileReflector->getClasses()[0];
+        }
+
+        if (isset($fileReflector->getInterfaces()[0])) {
+            return $fileReflector->getInterfaces()[0];
+        }
+
+        if (isset($fileReflector->getTraits()[0])) {
+            return $fileReflector->getTraits()[0];
+        }
+
+        return null;
+    }
+
+    public function getFileForName($name)
+    {
+        // FIXME: handle nulls correctly
+        if (!isset($this->nameFileMap[$name])) {
+            if (!(class_exists($name) || interface_exists($name) || trait_exists($name))) {
+                echo "Could not find class, trait or interface for $name\n";
+                return null;
+            }
+            $refClass = new \ReflectionClass((string)$name);
+            $fileName = $refClass->getFileName();
+            if (empty($fileName)) {
+                echo "Could not find file for $name\n";
+            }
+            $this->nameFileMap[$name] = $fileName;
+        }
+        return $this->nameFileMap[$name];
+    }
+}

--- a/docs/external-classes.json
+++ b/docs/external-classes.json
@@ -1,4 +1,61 @@
 [{
+  "name": "array",
+  "uri": "http://php.net/manual/en/language.types.array.php"
+}, {
+  "name": "bool",
+  "uri": "http://php.net/manual/en/language.types.boolean.php"
+}, {
+  "name": "Boolean",
+  "uri": "http://php.net/manual/en/language.types.boolean.php"
+}, {
+  "name": "callable",
+  "uri": "http://php.net/manual/en/language.types.callable.php"
+}, {
+  "name": "float",
+  "uri": "http://php.net/manual/en/language.types.float.php"
+}, {
+  "name": "int",
+  "uri": "http://php.net/manual/en/language.types.integer.php"
+}, {
+  "name": "mixed",
+  "uri": "http://php.net/manual/en/language.pseudo-types.php#language.types.mixed"
+}, {
+  "name": "null",
+  "uri": "http://php.net/manual/en/language.types.null.php"
+}, {
+  "name": "resource",
+  "uri": "http://php.net/manual/en/language.types.resource.php"
+}, {
+  "name": "string",
+  "uri": "http://php.net/manual/en/language.types.string.php"
+}, {
+  "name": "void",
+  "uri": "http://php.net/manual/en/language.pseudo-types.php#language.types.void"
+}, {
+  "name": "DateTimeInterface",
+  "uri": "http://php.net/manual/en/class.datetimeinterface.php"
+}, {
+  "name": "Exception",
+  "uri": "http://php.net/manual/en/class.exception.php"
+}, {
+  "name": "Generator",
+  "uri": "http://php.net/manual/en/class.generator.php"
+}, {
+  "name": "Iterator",
+  "uri": "http://php.net/manual/en/class.iterator.php"
+}, {
+  "name": "JsonSerializable",
+  "uri": "http://php.net/manual/en/class.jsonserializable.php"
+}, {
+  "name": "Psr\\Cache\\",
+  "uri": "https://github.com/php-fig/cache/blob/master/src/%s.php"
+}, {
+  "name": "Psr\\Log\\",
+  "uri": "https://github.com/php-fig/log/blob/master/Psr/Log/%s.php"
+}, {
+  "name": "Psr\\Http\\Message\\",
+  "uri": "https://github.com/php-fig/http-message/blob/master/src/%s.php"
+}, {
   "name": "Google\\Auth\\",
   "uri": "https://github.com/google/google-auth-library-php/blob/master/src/%s.php"
 }, {


### PR DESCRIPTION
Explore what this looks like here: https://michaelbausor.github.io/gcloud-php/#/docs/google-cloud/master/core/upload/streamableuploader

Points to note:
- Classes now list superclasses and interfaces
- Classes include methods from superclasses and traits *inside Google\Cloud*
- Methods defined on **external** superclasses and traits are **NOT** included. This is because we cannot be sure they will have a docblock. We may want to consider including them anyway?
- Added a link the implementing class/trait on relevant methods
- Included links to build-in types and PSR classes/interfaces

Existing problem that isn't fixed: we don't link correctly when the docs specify a relative class name. See e.g. the param documentation in the existing docs (Duration and Timestamp): https://googlecloudplatform.github.io/google-cloud-php/#/docs/google-cloud/v0.34.1/spanner/database?method=execute
I am not sure what we should do about this - maybe nothing in this PR, but think about a future fix? The easiest thing is to change our docs so that we use FQNs everywhere, but that is ugly for someone reading the code.