### PR TITLE
Introduce flock/semaphore locking mechanisms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
     },
     "suggest": {
         "google/gax": "Required to support gRPC",
-        "google/proto-client-php": "Required to support gRPC",
+        "google/proto-client": "Required to support gRPC",
         "phpseclib/phpseclib": "May be used in place of OpenSSL for creating signed Cloud Storage URLs. Please require version ^2."
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,6 @@
     "suggest": {
         "google/gax": "Required to support gRPC",
         "google/proto-client-php": "Required to support gRPC",
-        "symfony/lock": "Required for the Spanner cached based session pool. Please require the following commit: 3.3.x-dev#1ba6ac9",
         "phpseclib/phpseclib": "May be used in place of OpenSSL for creating signed Cloud Storage URLs. Please require version ^2."
     },
     "autoload": {

--- a/src/Core/Batch/BatchDaemon.php
+++ b/src/Core/Batch/BatchDaemon.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Core\Batch;
 
+use Google\Cloud\Core\SysvTrait;
+
 /**
  * An external daemon script for executing the batch jobs.
  *
@@ -32,8 +34,9 @@ namespace Google\Cloud\Core\Batch;
  */
 class BatchDaemon
 {
-    use SysvTrait;
+    use BatchDaemonTrait;
     use HandleFailureTrait;
+    use SysvTrait;
 
     /* @var BatchRunner */
     private $runner;
@@ -51,6 +54,7 @@ class BatchDaemon
      * Prepare the descriptor spec and install signal handlers.
      *
      * @param string $entrypoint Daemon's entrypoint script.
+     * @throws \RuntimeException
      */
     public function __construct($entrypoint)
     {

--- a/src/Core/Batch/BatchDaemonTrait.php
+++ b/src/Core/Batch/BatchDaemonTrait.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Batch;
+
+/**
+ * A utility trait related to BatchDaemon functionality.
+ *
+ * @experimental The experimental flag means that while we believe this method
+ *      or class is ready for use, it may change before release in backwards-
+ *      incompatible ways. Please use with caution, and test thoroughly when
+ *      upgrading.
+ */
+trait BatchDaemonTrait
+{
+    private static $typeDirect = 1;
+    private static $typeFile = 2;
+
+    /**
+     * Returns whether or not the BatchDaemon is running.
+     *
+     * @return bool
+     */
+    private function isDaemonRunning()
+    {
+        $isDaemonRunning = filter_var(
+            getenv('IS_BATCH_DAEMON_RUNNING'),
+            FILTER_VALIDATE_BOOLEAN
+        );
+
+        return $isDaemonRunning !== false;
+    }
+}

--- a/src/Core/Batch/BatchRunner.php
+++ b/src/Core/Batch/BatchRunner.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Core\Batch;
 
+use Google\Cloud\Core\SysvTrait;
+
 /**
  * A class for executing jobs in batch.
  *
@@ -27,6 +29,7 @@ namespace Google\Cloud\Core\Batch;
  */
 class BatchRunner
 {
+    use BatchDaemonTrait;
     use SysvTrait;
 
     /**

--- a/src/Core/Batch/SysvProcessor.php
+++ b/src/Core/Batch/SysvProcessor.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Core\Batch;
 
+use Google\Cloud\Core\SysvTrait;
+
 /**
  * ProcessItemInterface implementation with SysV IPC message queue.
  *
@@ -27,6 +29,7 @@ namespace Google\Cloud\Core\Batch;
  */
 class SysvProcessor implements ProcessItemInterface
 {
+    use BatchDaemonTrait;
     use SysvTrait;
 
     /* @var array */

--- a/src/Core/Lock/FlockLock.php
+++ b/src/Core/Lock/FlockLock.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Lock;
+
+/**
+ * Flock based lock implementation.
+ *
+ * @see http://php.net/manual/en/function.flock.php
+ * @experimental The experimental flag means that while we believe this method
+ *      or class is ready for use, it may change before release in backwards-
+ *      incompatible ways. Please use with caution, and test thoroughly when
+ *      upgrading.
+ */
+class FlockLock implements LockInterface
+{
+    use LockTrait;
+
+    const FILE_PATH_TEMPLATE = '%s/%s.lock';
+
+    /**
+     * @var string
+     */
+    private $filePath;
+
+    /**
+     * @var resource|null
+     */
+    private $handle;
+
+    /**
+     * @param string $fileName The name of the file to use as a lock.
+     * @throws \InvalidArgumentException If an invalid fileName is provided.
+     */
+    public function __construct($fileName)
+    {
+        if (!is_string($fileName)) {
+            throw new \InvalidArgumentException('$fileName must be a string.');
+        }
+
+        $this->filePath = sprintf(
+            self::FILE_PATH_TEMPLATE,
+            sys_get_temp_dir(),
+            $fileName
+        );
+    }
+
+    /**
+     * Acquires a lock that will block until released.
+     *
+     * @return bool
+     * @throws \RuntimeException If the lock fails to be acquired.
+     */
+    public function acquire()
+    {
+        if ($this->handle) {
+            return true;
+        }
+
+        $this->handle = $this->initializeHandle();
+
+        if (!flock($this->handle, LOCK_EX)) {
+            fclose($this->handle);
+            $this->handle = null;
+
+            throw new \RuntimeException('Failed to acquire lock.');
+        }
+
+        return true;
+    }
+
+    /**
+     * Releases the lock.
+     *
+     * @throws \RuntimeException If the lock fails to release.
+     */
+    public function release()
+    {
+        if ($this->handle) {
+            $released = flock($this->handle, LOCK_UN);
+            fclose($this->handle);
+            $this->handle = null;
+
+            if (!$released) {
+                throw new \RuntimeException('Failed to release lock.');
+            }
+        }
+    }
+
+    /**
+     * Initializes the handle.
+     *
+     * @return resource
+     * @throws \RuntimeException If the lock file fails to open.
+     */
+    private function initializeHandle()
+    {
+        $handle = @fopen($this->filePath, 'c');
+
+        if (!$handle) {
+            throw new \RuntimeException('Failed to open lock file.');
+        }
+
+        return $handle;
+    }
+}

--- a/src/Core/Lock/SemaphoreLock.php
+++ b/src/Core/Lock/SemaphoreLock.php
@@ -50,12 +50,12 @@ class SemaphoreLock implements LockInterface
      */
     public function __construct($key)
     {
-        if (!is_int($key)) {
-            throw new \InvalidArgumentException('The provided key must be an integer.');
-        }
-
         if (!$this->isSysvIPCLoaded()) {
             throw new \RuntimeException('SystemV IPC extensions are required.');
+        }
+
+        if (!is_int($key)) {
+            throw new \InvalidArgumentException('The provided key must be an integer.');
         }
 
         $this->key = $key;

--- a/src/Core/Lock/SemaphoreLock.php
+++ b/src/Core/Lock/SemaphoreLock.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Lock;
+
+use Google\Cloud\Core\SysvTrait;
+
+/**
+ * Semaphore based lock implementation.
+ *
+ * @see http://php.net/manual/en/book.sem.php
+ * @experimental The experimental flag means that while we believe this method
+ *      or class is ready for use, it may change before release in backwards-
+ *      incompatible ways. Please use with caution, and test thoroughly when
+ *      upgrading.
+ */
+class SemaphoreLock implements LockInterface
+{
+    use LockTrait;
+    use SysvTrait;
+
+    /**
+     * @var int
+     */
+    private $key;
+
+    /**
+     * @var resource|null
+     */
+    private $semaphoreId;
+
+    /**
+     * @param int $key A key.
+     * @throws \InvalidArgumentException If an invalid key is provided.
+     * @throws \RuntimeException If the System V IPC extensions are missing.
+     */
+    public function __construct($key)
+    {
+        if (!is_int($key)) {
+            throw new \InvalidArgumentException('The provided key must be an integer.');
+        }
+
+        if (!$this->isSysvIPCLoaded()) {
+            throw new \RuntimeException('SystemV IPC extensions are required.');
+        }
+
+        $this->key = $key;
+    }
+
+    /**
+     * Acquires a lock that will block until released.
+     *
+     * @return bool
+     * @throws \RuntimeException If the lock fails to be acquired.
+     */
+    public function acquire()
+    {
+        if ($this->semaphoreId) {
+            return true;
+        }
+
+        $this->semaphoreId = $this->initializeId();
+
+        if (!sem_acquire($this->semaphoreId)) {
+            $this->semaphoreId = null;
+
+            throw new \RuntimeException('Failed to acquire lock.');
+        }
+
+        return true;
+    }
+
+    /**
+     * Releases the lock.
+     *
+     * @throws \RuntimeException If the lock fails to release.
+     */
+    public function release()
+    {
+        if ($this->semaphoreId) {
+            $released = sem_release($this->semaphoreId);
+            $this->semaphoreId = null;
+
+            if (!$released) {
+                throw new \RuntimeException('Failed to release lock.');
+            }
+        }
+    }
+
+    /**
+     * Initializes the semaphore ID.
+     *
+     * @return resource
+     * @throws \RuntimeException If semaphore ID fails to generate.
+     */
+    private function initializeId()
+    {
+        $semaphoreId = sem_get($this->key);
+
+        if (!$semaphoreId) {
+            throw new \RuntimeException('Failed to generate semaphore ID.');
+        }
+
+        return $semaphoreId;
+    }
+}

--- a/src/Core/Lock/SymfonyLockAdapter.php
+++ b/src/Core/Lock/SymfonyLockAdapter.php
@@ -24,6 +24,8 @@ use Symfony\Component\Lock\LockInterface as SymfonyLockInterface;
  */
 class SymfonyLockAdapter implements LockInterface
 {
+    use LockTrait;
+
     /**
      * @var SymfonyLockInterface
      */
@@ -64,32 +66,5 @@ class SymfonyLockAdapter implements LockInterface
         } catch (\Exception $ex) {
             throw new \RunTimeException($ex->getMessage());
         }
-    }
-
-    /**
-     * Execute a callable within a lock.
-     *
-     * @return mixed
-     * @throws \RuntimeException
-     */
-    public function synchronize(callable $func)
-    {
-        $result = null;
-        $exception = null;
-
-        if ($this->acquire()) {
-            try {
-                $result = $func();
-            } catch (\Exception $ex) {
-                $exception = $ex;
-            }
-            $this->release();
-        }
-
-        if ($exception) {
-            throw $exception;
-        }
-
-        return $result;
     }
 }

--- a/src/Core/SysvTrait.php
+++ b/src/Core/SysvTrait.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Core\Batch;
+namespace Google\Cloud\Core;
 
 /**
  * A utility trait related to System V IPC.
@@ -27,8 +27,6 @@ namespace Google\Cloud\Core\Batch;
  */
 trait SysvTrait
 {
-    private static $typeDirect = 1;
-    private static $typeFile = 2;
     private static $productionKey = 'P';
 
     /**
@@ -36,8 +34,7 @@ trait SysvTrait
      *
      * Set GOOGLE_CLOUD_SYSV_ID envvar to change the base id.
      *
-     * @param int $idNum An id number of the job
-     *
+     * @param int $idNum An id number.
      * @return int
      */
     private function getSysvKey($idNum)
@@ -60,20 +57,5 @@ trait SysvTrait
         return extension_loaded('sysvmsg')
             && extension_loaded('sysvsem')
             && extension_loaded('sysvshm');
-    }
-
-    /**
-     * Returns if the BatchDaemon is supposed running.
-     *
-     * @return bool
-     */
-    private function isDaemonRunning()
-    {
-        $isDaemonRunning = filter_var(
-            getenv('IS_BATCH_DAEMON_RUNNING'),
-            FILTER_VALIDATE_BOOLEAN
-        );
-
-        return $isDaemonRunning !== false;
     }
 }

--- a/src/Spanner/composer.json
+++ b/src/Spanner/composer.json
@@ -9,9 +9,6 @@
         "google/gax": "^0.21.0",
         "google/proto-client": "^0.21.0"
     },
-    "suggest": {
-        "symfony/lock": "Required for the default session handler. Should be included as follows: 3.3.x-dev#1ba6ac9"
-    },
     "extra": {
         "component": {
             "id": "cloud-spanner",

--- a/tests/unit/Core/Batch/BatchDaemonTraitTest.php
+++ b/tests/unit/Core/Batch/BatchDaemonTraitTest.php
@@ -17,36 +17,17 @@
 
 namespace Google\Cloud\Tests\Unit\Core\Batch;
 
-use Google\Cloud\Core\Batch\SysvTrait;
+use Google\Cloud\Core\Batch\BatchDaemonTrait;
 
 /**
  * @group core
  * @group batch
  */
-class SysvTraitTest extends \PHPUnit_Framework_TestCase
+class BatchDaemonTraitTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->impl = new MySysvClass();
-    }
-
-    public function testGetSysvKey()
-    {
-        if (! $this->impl->isSysvIPCLoaded()) {
-            $this->markTestSkipped(
-                'SysV IPC extensions are not available, skipped');
-        }
-        $key1 = $this->impl->getSysvKey(1);
-        $key2 = $this->impl->getSysvKey(2);
-        $this->assertEquals(1, $key2 - $key1);
-    }
-
-    public function testIsSysvIPCLoaded()
-    {
-        $expected = extension_loaded('sysvmsg')
-            && extension_loaded('sysvsem')
-            && extension_loaded('sysvshm');
-        $this->assertEquals($expected, $this->impl->isSysvIPCLoaded());
+        $this->impl = new MyBatchDaemonTraitClass();
     }
 
     public function testIsDaemonRunning()
@@ -68,26 +49,14 @@ class SysvTraitTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class MySysvClass
+class MyBatchDaemonTraitClass
 {
-    use SysvTrait {
+    use BatchDaemonTrait {
         isDaemonRunning as privateIsDaemonRunning;
-        isSysvIPCLoaded as privateIsSysvIPCLoaded;
-        getSysvKey as privateGetSysvKey;
     }
 
     function isDaemonRunning()
     {
         return $this->privateIsDaemonRunning();
-    }
-
-    function isSysvIPCLoaded()
-    {
-        return $this->privateIsSysvIPCLoaded();
-    }
-
-    function getSysvKey($id)
-    {
-        return $this->privateGetSysvKey($id);
     }
 }

--- a/tests/unit/Core/Batch/SysvConfigStorageTest.php
+++ b/tests/unit/Core/Batch/SysvConfigStorageTest.php
@@ -18,8 +18,8 @@
 namespace Google\Cloud\Tests\Unit\Core\Batch;
 
 use Google\Cloud\Core\Batch\BatchConfig;
-use Google\Cloud\Core\Batch\SysvTrait;
 use Google\Cloud\Core\Batch\SysvConfigStorage;
+use Google\Cloud\Core\SysvTrait;
 
 /**
  * @group core

--- a/tests/unit/Core/Batch/SysvProcessorTest.php
+++ b/tests/unit/Core/Batch/SysvProcessorTest.php
@@ -17,8 +17,9 @@
 
 namespace Google\Cloud\Tests\Unit\Core\Batch;
 
+use Google\Cloud\Core\Batch\BatchDaemonTrait;
 use Google\Cloud\Core\Batch\SysvProcessor;
-use Google\Cloud\Core\Batch\SysvTrait;
+use Google\Cloud\Core\SysvTrait;
 
 /**
  * @group core
@@ -26,6 +27,7 @@ use Google\Cloud\Core\Batch\SysvTrait;
  */
 class SysvProcessorTest extends \PHPUnit_Framework_TestCase
 {
+    use BatchDaemonTrait;
     use SysvTrait;
 
     private $submitter;

--- a/tests/unit/Core/Lock/CommonLockTrait.php
+++ b/tests/unit/Core/Lock/CommonLockTrait.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Core\Lock;
+
+require_once __DIR__ . '/MockGlobals.php';
+
+use Google\Cloud\Core\Lock\MockValues;
+use Google\Cloud\Core\Lock\SemaphoreLock;
+use Google\Cloud\Core\SysvTrait;;
+
+/**
+ * @group core
+ * @group lock
+ */
+trait CommonLockTrait
+{
+    private $lock;
+
+    private function setLock($lock)
+    {
+        $this->lock = $lock;
+    }
+
+    public function testAcquireAndReleaseLock()
+    {
+        $this->assertTrue($this->lock->acquire());
+        $this->lock->release();
+    }
+
+    public function testAcquireSameLockBeforeRelease()
+    {
+        $this->assertTrue($this->lock->acquire());
+        $this->assertTrue($this->lock->acquire());
+
+        $this->lock->release();
+    }
+
+    public function testSynchronizeLock()
+    {
+        $return = $this->lock->synchronize(function () {
+            return true;
+        });
+
+        $this->assertTrue($return);
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testSynchronizeLockThrowsException()
+    {
+        $this->lock->synchronize(function () {
+            throw new \Exception();
+        });
+    }
+}
+

--- a/tests/unit/Core/Lock/FlockLockTest.php
+++ b/tests/unit/Core/Lock/FlockLockTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Core\Lock;
+
+require_once __DIR__ . '/MockGlobals.php';
+
+use Google\Cloud\Core\Lock\FlockLock;
+use Google\Cloud\Core\Lock\MockValues;
+
+/**
+ * @group core
+ * @group lock
+ */
+class FlockLockTest extends \PHPUnit_Framework_TestCase
+{
+    use CommonLockTrait;
+
+    const LOCK_NAME = 'test';
+
+    public function setUp()
+    {
+        MockValues::initialize();
+        $this->setLock(new FlockLock(self::LOCK_NAME));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowsExceptionWithInvalidFileName()
+    {
+        new FlockLock(123);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Failed to acquire lock.
+     */
+    public function testThrowsExceptionWhenFlockFailsOnAcquire()
+    {
+        MockValues::$flockReturnValue = false;
+        $this->lock->acquire();
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Failed to release lock.
+     */
+    public function testThrowsExceptionWhenFlockFailsOnRelease()
+    {
+        $this->lock->acquire();
+        MockValues::$flockReturnValue = false;
+        $this->lock->release();
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Failed to open lock file.
+     */
+    public function testThrowsExceptionWhenFopenFails()
+    {
+        MockValues::$fopenReturnValue = false;
+        $this->lock->acquire();
+    }
+}
+

--- a/tests/unit/Core/Lock/MockGlobals.php
+++ b/tests/unit/Core/Lock/MockGlobals.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Google\Cloud\Core\Lock {
+    class MockValues
+    {
+        public static $flockReturnValue;
+        public static $fopenReturnValue;
+        public static $sem_acquireReturnValue;
+        public static $sem_releaseReturnValue;
+        public static $sem_getReturnValue;
+
+        public static function initialize()
+        {
+            self::$flockReturnValue = true;
+            self::$fopenReturnValue = function($file, $mode) {
+                return \fopen($file, $mode);
+            };
+            self::$sem_acquireReturnValue = true;
+            self::$sem_releaseReturnValue = true;
+            self::$sem_getReturnValue = function($key) {
+                return \sem_get($key);
+            };
+        }
+    }
+
+    function flock($handle, $type)
+    {
+        return MockValues::$flockReturnValue;
+    }
+
+    function fopen($file, $mode)
+    {
+        $val = MockValues::$fopenReturnValue;
+
+        if (is_callable($val)) {
+            return $val($file, $mode);
+        }
+
+        return $val;
+    }
+
+    function sem_acquire($id)
+    {
+        return MockValues::$sem_acquireReturnValue;
+    }
+
+    function sem_release($id)
+    {
+        return MockValues::$sem_releaseReturnValue;
+    }
+
+    function sem_get($key)
+    {
+        $val = MockValues::$sem_getReturnValue;
+
+        if (is_callable($val)) {
+            return $val($key);
+        }
+
+        return $val;
+    }
+}

--- a/tests/unit/Core/Lock/SemaphoreLockTest.php
+++ b/tests/unit/Core/Lock/SemaphoreLockTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Core\Lock;
+
+require_once __DIR__ . '/MockGlobals.php';
+
+use Google\Cloud\Core\Lock\MockValues;
+use Google\Cloud\Core\Lock\SemaphoreLock;
+use Google\Cloud\Core\SysvTrait;;
+
+/**
+ * @group core
+ * @group lock
+ */
+class SemaphoreLockTest extends \PHPUnit_Framework_TestCase
+{
+    use CommonLockTrait;
+    use SysvTrait;
+
+    const LOCK_NAME = 'test';
+
+    public function setUp()
+    {
+        if (!$this->isSysvIPCLoaded()) {
+            $this->markTestSkipped(
+                'Skipping because SystemV IPC extensions are not loaded'
+            );
+        }
+
+        $this->setLock(new SemaphoreLock(1));
+        MockValues::initialize();
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowsExceptionWithInvalidKey()
+    {
+        new SemaphoreLock('abc');
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Failed to acquire lock.
+     */
+    public function testThrowsExceptionWhenSemAcquireFailsOnAcquire()
+    {
+        MockValues::$sem_acquireReturnValue = false;
+        $this->lock->acquire();
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Failed to release lock.
+     */
+    public function testThrowsExceptionWhenSemReleaseFailsOnRelease()
+    {
+        $this->lock->acquire();
+        MockValues::$sem_releaseReturnValue = false;
+        $this->lock->release();
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Failed to generate semaphore ID.
+     */
+    public function testThrowsExceptionWhenSemGetFails()
+    {
+        MockValues::$sem_getReturnValue = false;
+        $this->lock->acquire();
+    }
+}
+

--- a/tests/unit/Core/SysvTraitTest.php
+++ b/tests/unit/Core/SysvTraitTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Core;
+
+use Google\Cloud\Core\SysvTrait;
+
+/**
+ * @group core
+ */
+class SysvTraitTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->impl = new MySysvClass();
+    }
+
+    public function testGetSysvKey()
+    {
+        if (!$this->impl->isSysvIPCLoaded()) {
+            $this->markTestSkipped(
+                'SysV IPC extensions are not available, skipped'
+            );
+        }
+        $key1 = $this->impl->getSysvKey(1);
+        $key2 = $this->impl->getSysvKey(2);
+        $this->assertEquals(1, $key2 - $key1);
+    }
+
+    public function testIsSysvIPCLoaded()
+    {
+        $expected = extension_loaded('sysvmsg')
+            && extension_loaded('sysvsem')
+            && extension_loaded('sysvshm');
+        $this->assertEquals($expected, $this->impl->isSysvIPCLoaded());
+    }
+}
+
+class MySysvClass
+{
+    use SysvTrait {
+        isSysvIPCLoaded as privateIsSysvIPCLoaded;
+        getSysvKey as privateGetSysvKey;
+    }
+
+    function isSysvIPCLoaded()
+    {
+        return $this->privateIsSysvIPCLoaded();
+    }
+
+    function getSysvKey($id)
+    {
+        return $this->privateGetSysvKey($id);
+    }
+}

--- a/tests/unit/Spanner/Session/CacheSessionPoolTest.php
+++ b/tests/unit/Spanner/Session/CacheSessionPoolTest.php
@@ -44,6 +44,7 @@ class CacheSessionPoolTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->checkAndSkipGrpcTests();
+        putenv('GOOGLE_CLOUD_SYSV_ID=U');
         $this->time = time();
     }
 


### PR DESCRIPTION
Closes: https://github.com/GoogleCloudPlatform/google-cloud-php/issues/564

Included in this PR:

- Flock based lock
- Semaphore based lock
- Updates to Spanner to remove references to symfony/lock
- There were some useful methods in `Google\Cloud\Core\Batch\SysvTrait` that could be used outside of the context of batching, so it has been split out into two traits