### PR TITLE
Batch daemon clear config

### DIFF
--- a/src/Core/Batch/BatchRunner.php
+++ b/src/Core/Batch/BatchRunner.php
@@ -112,7 +112,7 @@ class BatchRunner
         } finally {
             $this->configStorage->unlock();
         }
-        return true;
+        return $result;
     }
 
     /**

--- a/src/Core/Batch/BatchRunner.php
+++ b/src/Core/Batch/BatchRunner.php
@@ -182,11 +182,15 @@ class BatchRunner
         if ($result === false) {
             throw new \RuntimeException('Failed to lock the configStorage');
         }
-        $result = $this->configStorage->load();
-        $this->configStorage->unlock();
-        if ($result === false) {
-            throw new \RuntimeException('Failed to load the BatchConfig');
+        try {
+            $result = $this->configStorage->load();
+        } catch (\RuntimeException $e) {
+            $this->configStorage->clear();
+            return false;
+        } finally {
+            $this->configStorage->unlock();
         }
+
         $this->config = $result;
         return true;
     }

--- a/src/Core/Batch/BatchRunner.php
+++ b/src/Core/Batch/BatchRunner.php
@@ -107,11 +107,14 @@ class BatchRunner
         $this->config = $this->configStorage->load();
         $this->config->registerJob($identifier, $func, $options);
 
-        $result = $this->configStorage->save($this->config);
-        if ($result === false) {
-            return false;
+        try {
+            $result = $this->configStorage->save($this->config);
+        } catch (\Exception $e) {
+            $this->configStorage->clear();
+            throw $e;
+        } finally {
+            $this->configStorage->unlock();
         }
-        $this->configStorage->unlock();
         return true;
     }
 

--- a/src/Core/Batch/BatchRunner.php
+++ b/src/Core/Batch/BatchRunner.php
@@ -109,9 +109,6 @@ class BatchRunner
 
         try {
             $result = $this->configStorage->save($this->config);
-        } catch (\Exception $e) {
-            $this->configStorage->clear();
-            throw $e;
         } finally {
             $this->configStorage->unlock();
         }
@@ -189,7 +186,7 @@ class BatchRunner
             $result = $this->configStorage->load();
         } catch (\RuntimeException $e) {
             $this->configStorage->clear();
-            return false;
+            throw $e;
         } finally {
             $this->configStorage->unlock();
         }

--- a/src/Core/Batch/ConfigStorageInterface.php
+++ b/src/Core/Batch/ConfigStorageInterface.php
@@ -55,4 +55,9 @@ interface ConfigStorageInterface
      * @throws \RuntimeException when failed to load the BatchConfig.
      */
     public function load();
+
+    /**
+     * Clear the BatchConfig from storage.
+     */
+    public function clear();
 }

--- a/src/Core/Batch/InMemoryConfigStorage.php
+++ b/src/Core/Batch/InMemoryConfigStorage.php
@@ -137,6 +137,14 @@ final class InMemoryConfigStorage implements
     }
 
     /**
+     * Clear the BatchConfig from storage.
+     */
+    public function clear()
+    {
+        $this->config = new BatchConfig();
+    }
+
+    /**
      * Hold the items in memory and run the job in the same process when it
      * meets the condition.
      *

--- a/src/Core/Batch/SysvConfigStorage.php
+++ b/src/Core/Batch/SysvConfigStorage.php
@@ -70,6 +70,7 @@ class SysvConfigStorage implements ConfigStorageInterface
      * @param BatchConfig $config A BatchConfig to save.
      * @return bool
      * @throws \RuntimeException when failed to attach to the shared memory.
+     * @throws \Exception when serialization of the BatchConfig fails
      */
     public function save(BatchConfig $config)
     {
@@ -102,11 +103,13 @@ class SysvConfigStorage implements ConfigStorageInterface
             $result = new BatchConfig();
         } else {
             $result = shm_get_var($shmid, self::VAR_KEY);
-            if ($result === false) {
-                throw new \RuntimeException(
-                    'Failed to deserialize data from shared memory'
-                );
-            }
+        }
+        shm_detach($shmid);
+
+        if ($result === false) {
+            throw new \RuntimeException(
+                'Failed to deserialize data from shared memory'
+            );
         }
         return $result;
     }

--- a/src/Core/Batch/SysvConfigStorage.php
+++ b/src/Core/Batch/SysvConfigStorage.php
@@ -102,7 +102,21 @@ class SysvConfigStorage implements ConfigStorageInterface
             $result = new BatchConfig();
         } else {
             $result = shm_get_var($shmid, self::VAR_KEY);
+            if ($result === false) {
+                throw new \RuntimeException(
+                    'Failed to deserialize data from shared memory'
+                );
+            }
         }
         return $result;
+    }
+
+    /**
+     * Clear the BatchConfig from storage.
+     */
+    public function clear()
+    {
+        $shmid = shm_attach($this->sysvKey);
+        shm_remove_var($shmid, self::VAR_KEY);
     }
 }

--- a/tests/unit/Core/Batch/SysvConfigStorageTest.php
+++ b/tests/unit/Core/Batch/SysvConfigStorageTest.php
@@ -52,4 +52,35 @@ class SysvConfigStorageTest extends \PHPUnit_Framework_TestCase
         $this->storage->save($config);
         $this->assertEquals($config, $this->storage->load());
     }
+
+    public function testSaveBadConfig()
+    {
+        $object = new TestSerializableObjectWithClosure();
+        $config = new BatchConfig();
+        $config->registerJob('badConfig', [$object, 'callback']);
+
+        try {
+            $this->storage->save($config);
+        } catch (\RuntimeException $e) {
+            // verify we didn't corrupt memory
+            $this->storage->load();
+            return;
+        }
+
+        $this->assertTrue(false, 'should have thrown an exception');
+    }
+}
+
+class TestSerializableObjectWithClosure
+{
+    public $closure;
+
+    public function __construct()
+    {
+        $this->closure = function () {};
+    }
+
+    public function callback()
+    {
+    }
 }


### PR DESCRIPTION
If you attempt to store a closure into shared memory, it will error out
and leave corrupt data in shared memory. When the daemon tries to read
the corrupt data, it crashes, but currently does not clear the config.
Thus, the batch daemon will continue to crash until the shared memory is
manually cleared.

When we write data and serialization fails, we will clear the corrupt data from
shared memory. When we read data and deserialization fails, we will also clear the 
corrupt data from shared memory.

On the daemon side, the daemon will continue to poll for new config without crashing.