### PR TITLE
Iterator / PubSub Updates

### DIFF
--- a/src/Core/Iterator/ItemIteratorTrait.php
+++ b/src/Core/Iterator/ItemIteratorTrait.php
@@ -113,7 +113,7 @@ trait ItemIteratorTrait
         $this->pageIndex++;
         $this->position++;
 
-        if (count($this->pageIterator->current()) <= $this->pageIndex && $this->pageIterator->nextResultToken()) {
+        if (count($this->pageIterator->current()) <= $this->pageIndex && $this->nextResultToken()) {
             $this->pageIterator->next();
             $this->pageIndex = 0;
         }
@@ -126,8 +126,21 @@ trait ItemIteratorTrait
      */
     public function valid()
     {
-        if (isset($this->pageIterator->current()[$this->pageIndex])) {
+        $page = $this->pageIterator->current();
+
+        if (isset($page[$this->pageIndex])) {
             return true;
+        }
+
+        // If there are no results, but a token for the next page
+        // exists let's continue paging until there are results.
+        while ($this->nextResultToken()) {
+            $this->pageIterator->next();
+            $page = $this->pageIterator->current();
+
+            if (isset($page[$this->pageIndex])) {
+                return true;
+            }
         }
 
         return false;

--- a/src/Core/Iterator/PageIteratorTrait.php
+++ b/src/Core/Iterator/PageIteratorTrait.php
@@ -171,11 +171,17 @@ trait PageIteratorTrait
      */
     public function current()
     {
-        if (!$this->page) {
+        if ($this->page === null) {
             $this->page = $this->executeCall();
         }
 
-        return $this->get($this->itemsPath, $this->page);
+        $page = $this->get($this->itemsPath, $this->page);
+
+        if ($this->nextResultToken()) {
+            return $page ?: [];
+        }
+
+        return $page;
     }
 
     /**
@@ -196,12 +202,9 @@ trait PageIteratorTrait
     public function next()
     {
         $this->position++;
-
-        if ($this->nextResultToken()) {
-            $this->page = $this->executeCall();
-        } else {
-            $this->page = null;
-        }
+        $this->page = $this->nextResultToken()
+            ? $this->executeCall()
+            : null;
     }
 
     /**

--- a/tests/system/Logging/WriteAndListEntryTest.php
+++ b/tests/system/Logging/WriteAndListEntryTest.php
@@ -41,7 +41,7 @@ class WriteAndListEntryTest extends LoggingTestCase
             $entries = iterator_to_array($logger->entries());
 
             if (count($entries) === 0) {
-                throw new \Exception();
+                throw new \Exception('Entries not found in the allotted number of attempts.');
             }
 
             return $entries;
@@ -64,7 +64,6 @@ class WriteAndListEntryTest extends LoggingTestCase
                 'data'
             ]
         ];
-
         $entry = $logger->entry($data);
 
         $logger->write($entry);
@@ -74,7 +73,7 @@ class WriteAndListEntryTest extends LoggingTestCase
             $entries = iterator_to_array($logger->entries());
 
             if (count($entries) === 0) {
-                throw new \Exception();
+                throw new \Exception('Entries not found in the allotted number of attempts.');
             }
 
             return $entries;
@@ -103,7 +102,7 @@ class WriteAndListEntryTest extends LoggingTestCase
             $entries = iterator_to_array($logger->entries());
 
             if (count($entries) !== count($entriesToWrite)) {
-                throw new \Exception();
+                throw new \Exception('Entries not found in the allotted number of attempts.');
             }
 
             return $entries;
@@ -130,7 +129,6 @@ class WriteAndListEntryTest extends LoggingTestCase
             'test' => 'label'
         ];
         $severity = 'INFO';
-
         $entry = $logger->entry($data, [
             'httpRequest' => $httpRequest,
             'labels' => $labels,
@@ -144,7 +142,7 @@ class WriteAndListEntryTest extends LoggingTestCase
             $entries = iterator_to_array($logger->entries());
 
             if (count($entries) === 0) {
-                throw new \Exception();
+                throw new \Exception('Entries not found in the allotted number of attempts.');
             }
 
             return $entries;
@@ -245,7 +243,7 @@ class WriteAndListEntryTest extends LoggingTestCase
             $entries = iterator_to_array($logger->entries());
 
             if (count($entries) === 0) {
-                throw new \Exception();
+                throw new \Exception('Entries not found in the allotted number of attempts.');
             }
 
             return $entries;

--- a/tests/system/PubSub/ManageTopicsTest.php
+++ b/tests/system/PubSub/ManageTopicsTest.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Tests\System\PubSub;
 
+use Google\Cloud\Core\ExponentialBackoff;
+
 /**
  * @group pubsub
  * @group pubsub-topic
@@ -28,7 +30,6 @@ class ManageTopicsTest extends PubSubTestCase
      */
     public function testCreateAndListTopics($client)
     {
-        $foundTopics = [];
         $topicsToCreate = [
             uniqid(self::TESTING_PREFIX),
             uniqid(self::TESTING_PREFIX)
@@ -38,19 +39,29 @@ class ManageTopicsTest extends PubSubTestCase
             self::$deletionQueue->add($client->createTopic($topicToCreate));
         }
 
-        $topics = $client->topics();
+        $backoff = new ExponentialBackoff(8);
+        $hasFoundTopics = $backoff->execute(function () use ($client, $topicsToCreate) {
+            $foundTopics = [];
+            $topics = $client->topics();
 
-        foreach ($topics as $topic) {
-            $nameParts = explode('/', $topic->name());
-            $tName = end($nameParts);
-            foreach ($topicsToCreate as $key => $topicToCreate) {
-                if ($tName === $topicToCreate) {
-                    $foundTopics[$key] = $tName;
+            foreach ($topics as $topic) {
+                $nameParts = explode('/', $topic->name());
+                $sName = end($nameParts);
+                foreach ($topicsToCreate as $key => $topicToCreate) {
+                    if ($sName === $topicToCreate) {
+                        $foundTopics[$key] = $sName;
+                    }
                 }
             }
-        }
 
-        $this->assertEquals($topicsToCreate, $foundTopics);
+            if (sort($foundTopics) === sort($topicsToCreate)) {
+                return true;
+            }
+
+            throw new \Exception('Items not found in the allotted number of attempts.');
+        });
+
+        $this->assertTrue($hasFoundTopics);
     }
 
     /**

--- a/tests/unit/Core/Iterator/ItemIteratorTest.php
+++ b/tests/unit/Core/Iterator/ItemIteratorTest.php
@@ -22,6 +22,7 @@ use Google\Cloud\Core\Iterator\PageIterator;
 
 /**
  * @group core
+ * @group iterator
  */
 class ItemIteratorTest extends \PHPUnit_Framework_TestCase
 {
@@ -35,7 +36,7 @@ class ItemIteratorTest extends \PHPUnit_Framework_TestCase
             ->shouldBeCalledTimes(1);
         $pageIterator->nextResultToken()
             ->willReturn('abc', null)
-            ->shouldBeCalledTimes(2);
+            ->shouldBeCalledTimes(3);
         $pageIterator->current()
             ->willReturn($page1)
             ->shouldBeCalledTimes(19);

--- a/tests/unit/Core/Iterator/PageIteratorTest.php
+++ b/tests/unit/Core/Iterator/PageIteratorTest.php
@@ -22,6 +22,7 @@ use Google\Cloud\Core\Iterator\PageIterator;
 
 /**
  * @group core
+ * @group iterator
  */
 class PageIteratorTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
This PR addresses a few concerns in the system tests:

- Some of the logging write tests have intermittently been failing due to some concerns related to eventually consistency. To resolve this, iterators have been updated to make sure we continue paging as long a `nextResultToken` is set.
- A few pubsub tests were failing intermittently due to results not coming back in the same order they were created. To resolve this, the expected and actual results are now sorted using the same algorithm.