### PR TITLE
Support inheritdoc tag in class docs

### DIFF
--- a/dev/src/DocGenerator/Parser/CodeParser.php
+++ b/dev/src/DocGenerator/Parser/CodeParser.php
@@ -273,7 +273,7 @@ class CodeParser implements ParserInterface
                 if ($part instanceof SeeTag) {
                     $part = $this->buildReference($part->getReference(), $part);
                 } elseif ($this->isInheritDocTag($part)) {
-                    if (empty($reflector)) {
+                    if ($reflector === null) {
                         throw new \Exception(sprintf(
                             "Inherit Doc tag ({@inheritdoc}) is only supported when \$reflector is not null.\nContext:\n%s",
                             $content));


### PR DESCRIPTION
Notes:
- Inheritdocs are only supported in class docblocks, not method docblocks.
- Two formats are supported: `{@inheritdoc}` and `{@inheritDoc}`. This is because those two are supported by [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer), and php-cs-fixer will convert from `inheritDoc` to `inheritdoc`