### PR TITLE
Run query and wait for it to complete

### DIFF
--- a/src/BigQuery/BigQueryClient.php
+++ b/src/BigQuery/BigQueryClient.php
@@ -203,6 +203,8 @@ class BigQueryClient
      *           named parameters will be used (`@name`).
      * }
      * @return QueryResults
+     * @throws \RuntimeException if the maximum number of retries while waiting
+     *         for query completion has been exceeded.
      */
     public function runQuery($query, array $options = [])
     {
@@ -237,7 +239,7 @@ class BigQueryClient
                 $results->reload($options);
 
                 if (!$results->isComplete()) {
-                    throw new \Exception('Job did not complete within the allowed number of retries.');
+                    throw new \RuntimeException('Job did not complete within the allowed number of retries.');
                 }
             };
 

--- a/src/BigQuery/BigQueryClient.php
+++ b/src/BigQuery/BigQueryClient.php
@@ -19,11 +19,13 @@ namespace Google\Cloud\BigQuery;
 
 use Google\Cloud\BigQuery\Connection\ConnectionInterface;
 use Google\Cloud\BigQuery\Connection\Rest;
+use Google\Cloud\BigQuery\Job;
 use Google\Cloud\Core\ArrayTrait;
+use Google\Cloud\Core\ClientTrait;
+use Google\Cloud\Core\ExponentialBackoff;
+use Google\Cloud\Core\Int64;
 use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Core\Iterator\PageIterator;
-use Google\Cloud\Core\ClientTrait;
-use Google\Cloud\Core\Int64;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\StreamInterface;
 
@@ -138,14 +140,6 @@ class BigQueryClient
      * ```
      * $queryResults = $bigQuery->runQuery('SELECT commit FROM [bigquery-public-data:github_repos.commits] LIMIT 100');
      *
-     * $isComplete = $queryResults->isComplete();
-     *
-     * while (!$isComplete) {
-     *     sleep(1); // let's wait for a moment...
-     *     $queryResults->reload(); // trigger a network request
-     *     $isComplete = $queryResults->isComplete(); // check the query's status
-     * }
-     *
      * foreach ($queryResults->rows() as $row) {
      *     echo $row['commit'];
      * }
@@ -162,14 +156,6 @@ class BigQueryClient
      *     ]
      * ]);
      *
-     * $isComplete = $queryResults->isComplete();
-     *
-     * while (!$isComplete) {
-     *     sleep(1); // let's wait for a moment...
-     *     $queryResults->reload(); // trigger a network request
-     *     $isComplete = $queryResults->isComplete(); // check the query's status
-     * }
-     *
      * foreach ($queryResults->rows() as $row) {
      *     echo $row['commit'];
      * }
@@ -181,14 +167,6 @@ class BigQueryClient
      * $queryResults = $bigQuery->runQuery($query, [
      *     'parameters' => ['A commit message.']
      * ]);
-     *
-     * $isComplete = $queryResults->isComplete();
-     *
-     * while (!$isComplete) {
-     *     sleep(1); // let's wait for a moment...
-     *     $queryResults->reload(); // trigger a network request
-     *     $isComplete = $queryResults->isComplete(); // check the query's status
-     * }
      *
      * foreach ($queryResults->rows() as $row) {
      *     echo $row['commit'];
@@ -211,6 +189,8 @@ class BigQueryClient
      *           qualified in the format 'datasetId.tableId'.
      *     @type int $timeoutMs How long to wait for the query to complete, in
      *           milliseconds. **Defaults to** `10000` milliseconds (10 seconds).
+     *     @type int $maxRetries The number of times to retry, checking if the
+     *           query has completed. **Defaults to** `100`.
      *     @type bool $useQueryCache Whether to look for the result in the query
      *           cache.
      *     @type bool $useLegacySql Specifies whether to use BigQuery's legacy
@@ -226,17 +206,24 @@ class BigQueryClient
      */
     public function runQuery($query, array $options = [])
     {
+        $options += [
+            'maxRetries' => 100
+        ];
+
         if (isset($options['parameters'])) {
             $options += $this->formatQueryParameters($options['parameters']);
             unset($options['parameters']);
         }
 
+        $queryOptions = $options;
+        unset($queryOptions['timeoutMs'], $queryOptions['maxRetries']);
+
         $response = $this->connection->query([
             'projectId' => $this->projectId,
             'query' => $query
-        ] + $options);
+        ] + $queryOptions);
 
-        return new QueryResults(
+        $results = new QueryResults(
             $this->connection,
             $response['jobReference']['jobId'],
             $this->projectId,
@@ -244,6 +231,21 @@ class BigQueryClient
             $options,
             $this->mapper
         );
+
+        if (!$results->isComplete()) {
+            $retryFn = function (QueryResults $results, array $options) {
+                $results->reload($options);
+
+                if (!$results->isComplete()) {
+                    throw new \Exception('Job did not complete within the allowed number of retries.');
+                }
+            };
+
+            $retry = new ExponentialBackoff($options['maxRetries']);
+            $retry->execute($retryFn, [$results, $options]);
+        }
+
+        return $results;
     }
 
     /**

--- a/tests/snippets/BigQuery/BigQueryClientTest.php
+++ b/tests/snippets/BigQuery/BigQueryClientTest.php
@@ -79,7 +79,6 @@ class BigQueryClientTest extends SnippetTestCase
     {
         $snippet = $this->snippetFromMethod(BigQueryClient::class, 'runQuery');
         $snippet->addLocal('bigQuery', $this->client);
-        $snippet->replace('sleep(1);', '');
         $this->connection->query(Argument::any())
             ->shouldBeCalled()
             ->willReturn([
@@ -102,7 +101,6 @@ class BigQueryClientTest extends SnippetTestCase
     {
         $snippet = $this->snippetFromMethod(BigQueryClient::class, 'runQuery', 1);
         $snippet->addLocal('bigQuery', $this->client);
-        $snippet->replace('sleep(1);', '');
         $this->connection
             ->query(Argument::withEntry('queryParameters', [
                 [
@@ -145,7 +143,6 @@ class BigQueryClientTest extends SnippetTestCase
     {
         $snippet = $this->snippetFromMethod(BigQueryClient::class, 'runQuery', 2);
         $snippet->addLocal('bigQuery', $this->client);
-        $snippet->replace('sleep(1);', '');
         $this->connection
             ->query(Argument::withEntry('queryParameters', [
                 [


### PR DESCRIPTION
This change modifies `BigQueryClient::runQuery()`. Rather than returning a `QueryResults` object which requires polling to retrieve a result, the poll will be executed within the method, and the return value will be an instance of `QueryResults` which is populated with result rows and can be immediately processed.

There's no BC break, though people currently using this method with the polling loops recommended in the past should consider removing extraneous polling operations.