### PR TITLE
Change RequestWrapper to use constant

### DIFF
--- a/src/Core/RequestWrapper.php
+++ b/src/Core/RequestWrapper.php
@@ -161,7 +161,7 @@ class RequestWrapper
     {
         $headers = [
             'User-Agent' => 'gcloud-php/' . $this->componentVersion,
-            'x-goog-api-client' => 'gl-php/' . phpversion() . ' gccl/' . $this->componentVersion,
+            'x-goog-api-client' => 'gl-php/' . PHP_VERSION . ' gccl/' . $this->componentVersion,
         ];
 
         if ($this->shouldSignRequest) {


### PR DESCRIPTION
In the default Google App Engine environment, the phpversion function is disabled and requires fiddling around to get it to work (currently overriding ini config, suhosin config and whitelist env do not work as intended). This change moves to using PHP_VERSION which is a constant available in PHP since 5.2.7 and provides the same information as the implementation of phpversion here.