### PR TITLE
Updates documentation to use selfLink instead of friendlyName

### DIFF
--- a/src/BigQuery/Dataset.php
+++ b/src/BigQuery/Dataset.php
@@ -266,7 +266,7 @@ class Dataset
      * Example:
      * ```
      * $info = $dataset->info();
-     * echo $info['friendlyName'];
+     * echo $info['selfLink'];
      * ```
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/datasets#resource Datasets resource documentation.
@@ -290,7 +290,7 @@ class Dataset
      * ```
      * $dataset->reload();
      * $info = $dataset->info();
-     * echo $info['friendlyName'];
+     * echo $info['selfLink'];
      * ```
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/datasets/get Datasets get API documentation.

--- a/src/BigQuery/Table.php
+++ b/src/BigQuery/Table.php
@@ -539,7 +539,7 @@ class Table
      * Example:
      * ```
      * $info = $table->info();
-     * echo $info['friendlyName'];
+     * echo $info['selfLink'];
      * ```
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/tables#resource Tables resource documentation.
@@ -563,7 +563,7 @@ class Table
      * ```
      * $table->reload();
      * $info = $table->info();
-     * echo $info['friendlyName'];
+     * echo $info['selfLink'];
      * ```
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/tables/get Tables get API documentation.

--- a/tests/snippets/BigQuery/DatasetTest.php
+++ b/tests/snippets/BigQuery/DatasetTest.php
@@ -136,27 +136,27 @@ class DatasetTest extends SnippetTestCase
 
     public function testInfo()
     {
-        $friendlyName = 'Friendly.';
-        $dataset = $this->getDataset($this->connection, ['friendlyName' => $friendlyName]);
+        $selfLink = 'https://www.googleapis.com/bigquery/v2/projects/my-project/datasets/mynewdataset';
+        $dataset = $this->getDataset($this->connection, ['selfLink' => $selfLink]);
         $snippet = $this->snippetFromMethod(Dataset::class, 'info');
         $snippet->addLocal('dataset', $dataset);
         $res = $snippet->invoke();
 
-        $this->assertEquals($friendlyName, $res->output());
+        $this->assertEquals($selfLink, $res->output());
     }
 
     public function testReload()
     {
-        $friendlyName = 'Friendly.';
+        $selfLink = 'https://www.googleapis.com/bigquery/v2/projects/my-project/datasets/mynewdataset';
         $this->connection->getDataset(Argument::any())
             ->shouldBeCalledTimes(1)
-            ->willReturn(['friendlyName' => $friendlyName]);
+            ->willReturn(['selfLink' => $selfLink]);
         $dataset = $this->getDataset($this->connection);
         $snippet = $this->snippetFromMethod(Dataset::class, 'reload');
         $snippet->addLocal('dataset', $dataset);
         $res = $snippet->invoke();
 
-        $this->assertEquals($friendlyName, $res->output());
+        $this->assertEquals($selfLink, $res->output());
     }
 
     public function testId()

--- a/tests/snippets/BigQuery/TableTest.php
+++ b/tests/snippets/BigQuery/TableTest.php
@@ -62,7 +62,8 @@ class TableTest extends SnippetTestCase
                     ]
                 ]
             ],
-            'friendlyName' => 'Jeffrey'
+            'friendlyName' => 'Jeffrey',
+            'selfLink' => 'https://www.googleapis.com/bigquery/v2/projects/my-project/datasets/mynewdataset',
         ];
 
         $this->mapper = new ValueMapper(false);
@@ -274,7 +275,7 @@ class TableTest extends SnippetTestCase
         $snippet->addLocal('table', $this->table);
 
         $res = $snippet->invoke();
-        $this->assertEquals('Jeffrey', $res->output());
+        $this->assertEquals('https://www.googleapis.com/bigquery/v2/projects/my-project/datasets/mynewdataset', $res->output());
     }
 
     public function testReload()
@@ -285,13 +286,13 @@ class TableTest extends SnippetTestCase
         $this->connection->getTable(Argument::any())
             ->shouldBeCalled()
             ->willReturn([
-                'friendlyName' => 'El Jefe'
+                'selfLink' => 'https://www.googleapis.com/bigquery/v2/projects/my-project/datasets/myupdateddataset'
             ]);
 
         $this->table->___setProperty('connection', $this->connection->reveal());
 
         $res = $snippet->invoke();
-        $this->assertEquals('El Jefe', $res->output());
+        $this->assertEquals('https://www.googleapis.com/bigquery/v2/projects/my-project/datasets/myupdateddataset', $res->output());
     }
 
     public function testId()


### PR DESCRIPTION
Fixes #525 

This changes instances in docs of fetching the friendlyName to selfLink. It leaves calls that set the friendlyName (e.g. https://github.com/GoogleCloudPlatform/google-cloud-php/blob/master/src/BigQuery/Dataset.php#L127)