### PR TITLE
Add options for entity calls in DatastoreSessionHandler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
   fast_finish: true
 
 before_script:
-  - pecl install grpc || echo 'Failed to install grpc'
+  - pecl install grpc-1.4.1 || echo 'Failed to install grpc'
   - composer install
   - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then composer --no-interaction --dev remove google/protobuf google/gax google/proto-client; fi
   - ./dev/sh/system-test-credentials

--- a/src/Datastore/DatastoreSessionHandler.php
+++ b/src/Datastore/DatastoreSessionHandler.php
@@ -167,7 +167,8 @@ class DatastoreSessionHandler implements SessionHandlerInterface
                 'Optional argument `entityOptions` must be an array, got ' .
                 (is_object($options['entityOptions'])
                     ? get_class($options['entityOptions'])
-                    : gettype($options['entityOptions'])));
+                    : gettype($options['entityOptions']))
+            );
         }
 
         $this->options = $options;

--- a/src/Datastore/DatastoreSessionHandler.php
+++ b/src/Datastore/DatastoreSessionHandler.php
@@ -224,7 +224,8 @@ class DatastoreSessionHandler implements SessionHandlerInterface
     /**
      * Write the session data to Cloud Datastore.
      *
-     * @param string $id Identifier used to construct a {@see \Google\Cloud\Datastore\Key} for the {@see \Google\Cloud\Datastore\Entity} to be written.
+     * @param string $id Identifier used to construct a {@see \Google\Cloud\Datastore\Key}
+     *        for the {@see \Google\Cloud\Datastore\Entity} to be written.
      * @param string $data The session data to write to the {@see \Google\Cloud\Datastore\Entity}.
      * @return bool
      */

--- a/src/Datastore/DatastoreSessionHandler.php
+++ b/src/Datastore/DatastoreSessionHandler.php
@@ -145,7 +145,7 @@ class DatastoreSessionHandler implements SessionHandlerInterface
      *
      *     @type array $entityOptions Default options to be passed to the
      *           {@see \Google\Cloud\Datastore\DatastoreClient::entity()} method when writing session data to Datastore.
-     *           If not specified, defaults to ['excludeFromIndexes' => ['data']].
+     *           If not specified, defaults to `['excludeFromIndexes' => ['data']]`.
      * }
      */
     public function __construct(
@@ -161,6 +161,13 @@ class DatastoreSessionHandler implements SessionHandlerInterface
             $options['entityOptions'] = [
                 'excludeFromIndexes' => ['data']
             ];
+        }
+        if (!is_array($options['entityOptions'])) {
+            throw new InvalidArgumentException(
+                'Optional argument `entityOptions` must be an array, got ' .
+                (is_object($options['entityOptions'])
+                    ? get_class($options['entityOptions'])
+                    : gettype($options['entityOptions'])));
         }
 
         $this->options = $options;

--- a/src/Datastore/DatastoreSessionHandler.php
+++ b/src/Datastore/DatastoreSessionHandler.php
@@ -144,7 +144,7 @@ class DatastoreSessionHandler implements SessionHandlerInterface
      *     Configuration Options
      *
      *     @type array $defaultEntityOptions Default options to be passed to the
-     *           {@see Datastore::entity} method when writing session data to Datastore.
+     *           {@see \Google\Cloud\Datastore\DatastoreClient::entity} method when writing session data to Datastore.
      *           If not specified, defaults to [].
      * }
      */
@@ -217,9 +217,9 @@ class DatastoreSessionHandler implements SessionHandlerInterface
     /**
      * Write the session data to Cloud Datastore.
      *
-     * @param string $id Identifier used to construct a {@see Key} for the {@see Entity} to be written.
-     * @param string $data The session data to write to the {@see Entity}.
-     * @param array $entityOptions Optional arguments that will be passed to the {@see DatastoreClient::entity} method
+     * @param string $id Identifier used to construct a {@see \Google\Cloud\Datastore\Key} for the {@see \Google\Cloud\Datastore\Entity} to be written.
+     * @param string $data The session data to write to the {@see \Google\Cloud\Datastore\Entity}.
+     * @param array $entityOptions Optional arguments that will be passed to the {@see \Google\Cloud\Datastore\DatastoreClient::entity} method
      * @return bool
      */
     public function write($id, $data, $entityOptions = null)

--- a/tests/unit/Datastore/DatastoreSessionHandlerTest.php
+++ b/tests/unit/Datastore/DatastoreSessionHandlerTest.php
@@ -348,6 +348,31 @@ class DatastoreSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, $ret);
     }
 
+    /**
+     * @dataProvider invalidEntityOptions
+     * @expectedException InvalidArgumentException
+     */
+    public function testInvalidEntityOptions($datastoreSessionHandlerOptions)
+    {
+        new DatastoreSessionHandler(
+            $this->datastore->reveal(),
+            DatastoreSessionHandler::DEFAULT_GC_LIMIT,
+            $datastoreSessionHandlerOptions
+        );
+    }
+
+    public function invalidEntityOptions()
+    {
+        return [
+            [
+                ['entityOptions' => 1]
+            ],
+            [
+                ['entityOptions' => new \stdClass()]
+            ],
+        ];
+    }
+
     public function testDestroy()
     {
         $key = new Key('projectid');


### PR DESCRIPTION
Fixes #506 

cc @tmatsuo @dwsupplee @jdpedrie 

Some notes:
- This is added as an option, not as the default behaviour, because that would be (I believe) a BC-break.
- It is slightly clumsy in the DatastoreSessionHandler because it is the second optional arg, so someone who wants to pass it will also need to set the $gcLimit parameter