### PR TITLE
Fix errors in doc generator, add servicebuilder test

### DIFF
--- a/dev/src/DocGenerator/Parser/CodeParser.php
+++ b/dev/src/DocGenerator/Parser/CodeParser.php
@@ -180,8 +180,12 @@ class CodeParser implements ParserInterface
 
     private function getPath($fileReflector)
     {
-        $fileSplit = explode($this->basePath, trim($fileReflector->getFileName(), '/'));
-        return 'src/' . trim($fileSplit[1], '/');
+        if (strpos($fileReflector->getFileName(), $this->basePath) !== false) {
+            $fileSplit = explode($this->basePath, trim($fileReflector->getFileName(), '/'));
+            return 'src/' . trim($fileSplit[1], '/');
+        } else {
+            return 'src/'. trim(explode('src', $fileReflector->getFileName())[1]);
+        }
     }
 
     private function buildDocument($fileReflector, $reflector)
@@ -324,7 +328,7 @@ class CodeParser implements ParserInterface
     {
         $content = '';
         if (count($classInfo['parents']) > 0) {
-            $content .= $this->implodeInheritDocLinks(" > ", $classInfo['parents'], "Extends");
+            $content .= $this->implodeInheritDocLinks(" &raquo; ", $classInfo['parents'], "Extends");
         }
         if (count($classInfo['interfaces']) > 0) {
             $content .= $this->implodeInheritDocLinks(", ", $classInfo['interfaces'], "Implements");

--- a/tests/unit/ServiceBuilderTest.php
+++ b/tests/unit/ServiceBuilderTest.php
@@ -19,12 +19,14 @@ namespace Google\Cloud\Tests\Unit;
 
 use Google\Cloud\BigQuery\BigQueryClient;
 use Google\Cloud\Datastore\DatastoreClient;
-use Google\Cloud\Logging\LoggingClient;
 use Google\Cloud\Language\LanguageClient;
+use Google\Cloud\Logging\LoggingClient;
 use Google\Cloud\PubSub\PubSubClient;
 use Google\Cloud\ServiceBuilder;
+use Google\Cloud\Spanner\SpannerClient;
 use Google\Cloud\Speech\SpeechClient;
 use Google\Cloud\Storage\StorageClient;
+use Google\Cloud\Tests\GrpcTestTrait;
 use Google\Cloud\Translate\TranslateClient;
 use Google\Cloud\Vision\VisionClient;
 
@@ -33,11 +35,17 @@ use Google\Cloud\Vision\VisionClient;
  */
 class ServiceBuilderTest extends \PHPUnit_Framework_TestCase
 {
+    use GrpcTestTrait;
+
     /**
      * @dataProvider serviceProvider
      */
-    public function testBuildsClients($serviceName, $expectedClient, array $args = [])
+    public function testBuildsClients($serviceName, $expectedClient, array $args = [], callable $beforeCallable = null)
     {
+        if ($beforeCallable) {
+            call_user_func($beforeCallable);
+        }
+
         $serviceBuilder = new ServiceBuilder(['projectId' => 'myProject']);
         $config = [
             'projectId' => 'myProject',
@@ -79,6 +87,11 @@ class ServiceBuilderTest extends \PHPUnit_Framework_TestCase
             ], [
                 'pubsub',
                 PubSubClient::class
+            ], [
+                'spanner',
+                SpannerClient::class,
+                [],
+                [$this, 'checkAndSkipGrpcTests']
             ], [
                 'speech',
                 SpeechClient::class,


### PR DESCRIPTION
@michaelbausor, building off your last doc generator change, this resolves some php warnings which it was causing. I searched through the generated docs site a fair bit and couldn't find it causing problems with the error or with my fix, but if you could take a look to verify that I'm not going against your intent, I'd appreciate it!

Error example is below:

```
Warning: trim() expects parameter 1 to be string, array given in /google-cloud-php/dev/src/DocGenerator/Parser/CodeParser.php on line 187

Call Stack:
    0.0002     368592   1. {main}() /google-cloud-php/dev/google-cloud:0
    0.0148    2309824   2. Symfony\Component\Console\Application->run() /google-cloud-php/dev/google-cloud:38
    0.0228    2631144   3. Symfony\Component\Console\Application->doRun() /google-cloud-php/vendor/symfony/console/Application.php:130
    0.0229    2631144   4. Symfony\Component\Console\Application->doRunCommand() /google-cloud-php/vendor/symfony/console/Application.php:223
    0.0229    2631144   5. Google\Cloud\Dev\DocGenerator\Command\Docs->run() /google-cloud-php/vendor/symfony/console/Application.php:869
    0.0231    2633720   6. Google\Cloud\Dev\DocGenerator\Command\Docs->execute() /google-cloud-php/vendor/symfony/console/Command/Command.php:264
    6.8046    9209656   7. Google\Cloud\Dev\DocGenerator\Command\Docs->generateComponentDocumentation() /google-cloud-php/dev/src/DocGenerator/Command/Docs.php:95
    6.8048    9210040   8. Google\Cloud\Dev\DocGenerator\DocGenerator->generate() /google-cloud-php/dev/src/DocGenerator/Command/Docs.php:151
    7.0171   10916784   9. Google\Cloud\Dev\DocGenerator\Parser\CodeParser->parse() /google-cloud-php/dev/src/DocGenerator/DocGenerator.php:98
    7.0219   10968224  10. Google\Cloud\Dev\DocGenerator\Parser\CodeParser->buildDocument() /google-cloud-php/dev/src/DocGenerator/Parser/CodeParser.php:81
    7.0220   10969800  11. Google\Cloud\Dev\DocGenerator\Parser\CodeParser->buildInfo() /google-cloud-php/dev/src/DocGenerator/Parser/CodeParser.php:223
    7.0220   10970200  12. Google\Cloud\Dev\DocGenerator\Parser\CodeParser->buildClassInfoRecursive() /google-cloud-php/dev/src/DocGenerator/Parser/CodeParser.php:95
    7.0537   11275208  13. Google\Cloud\Dev\DocGenerator\Parser\CodeParser->buildClassInfoRecursive() /google-cloud-php/dev/src/DocGenerator/Parser/CodeParser.php:115
    7.0537   11275208  14. Google\Cloud\Dev\DocGenerator\Parser\CodeParser->buildMethodInfo() /google-cloud-php/dev/src/DocGenerator/Parser/CodeParser.php:106
    7.0541   11276424  15. Google\Cloud\Dev\DocGenerator\Parser\CodeParser->getPath() /google-cloud-php/dev/src/DocGenerator/Parser/CodeParser.php:174
    7.0541   11276832  16. trim() /google-cloud-php/dev/src/DocGenerator/Parser/CodeParser.php:187
```