### PR TITLE
User defined configuration options are being lost. Issue #622

### DIFF
--- a/src/BigQuery/JobConfigurationTrait.php
+++ b/src/BigQuery/JobConfigurationTrait.php
@@ -39,11 +39,11 @@ trait JobConfigurationTrait
 
         unset($userDefinedOptions['jobConfig']);
 
-        return [
+        return array_merge_recursive([
             'projectId' => $projectId,
             'configuration' => [
                 $name => $config
             ]
-        ] + $userDefinedOptions;
+        ], $userDefinedOptions);
     }
 }


### PR DESCRIPTION
`+` does not do a recursive array merge so any user defined options that are supposed to be nested underneath the "configuration" key are being lost.