### PR TITLE
CI: Temporarily require grpc-1.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
   fast_finish: true
 
 before_script:
-  - pecl install grpc || echo 'Failed to install grpc'
+  - pecl install grpc-1.4.1 || echo 'Failed to install grpc'
   - composer install
   - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then composer --no-interaction --dev remove google/protobuf google/gax google/proto-client; fi
   - ./dev/sh/system-test-credentials


### PR DESCRIPTION
Until https://github.com/grpc/grpc/issues/12123 is resolved we will need to rely on an older version of gRPC for builds to pass.