### PR TITLE
Add support for etags on bigquery tables and datasets

### DIFF
--- a/src/Core/ConcurrencyControlTrait.php
+++ b/src/Core/ConcurrencyControlTrait.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core;
+
+/**
+ * Methods to control concurrent updates.
+ */
+trait ConcurrencyControlTrait
+{
+    /**
+     * Apply the If-Match header to requests requiring concurrency control.
+     *
+     * @param array $options
+     * @param string $argName
+     * @return array
+     */
+    private function applyEtagHeader(array $options, $argName = 'etag')
+    {
+        if (isset($options[$argName])) {
+            if (!isset($options['restOptions'])) {
+                $options['restOptions'] = [];
+            }
+
+            if (!isset($options['restOptions']['headers'])) {
+                $options['restOptions']['headers'] = [];
+            }
+
+            $options['restOptions']['headers']['If-Match'] = $options[$argName];
+        }
+
+        return $options;
+    }
+}

--- a/tests/system/BigQuery/ManageDatasetsTest.php
+++ b/tests/system/BigQuery/ManageDatasetsTest.php
@@ -75,6 +75,19 @@ class ManageDatasetsTest extends BigQueryTestCase
         $this->assertEquals($metadata['friendlyName'], $info['friendlyName']);
     }
 
+    /**
+     * @expectedException Google\Cloud\Core\Exception\FailedPreconditionException
+     */
+    public function testUpdateDatasetConcurrentUpdateFails()
+    {
+        $data = [
+            'friendlyName' => 'foo',
+            'etag' => 'blah'
+        ];
+
+        self::$dataset->update($data);
+    }
+
     public function testReloadsDataset()
     {
         $this->assertEquals('bigquery#dataset', self::$dataset->reload()['kind']);

--- a/tests/system/BigQuery/ManageTablesTest.php
+++ b/tests/system/BigQuery/ManageTablesTest.php
@@ -129,6 +129,19 @@ class ManageTablesTest extends BigQueryTestCase
         $this->assertEquals($metadata['friendlyName'], $info['friendlyName']);
     }
 
+    /**
+     * @expectedException Google\Cloud\Core\Exception\FailedPreconditionException
+     */
+    public function testUpdateTableConcurrentUpdateFails()
+    {
+        $data = [
+            'friendlyName' => 'foo',
+            'etag' => 'blah'
+        ];
+
+        self::$table->update($data);
+    }
+
     public function testReloadsTable()
     {
         $this->assertEquals('bigquery#table', self::$table->reload()['kind']);

--- a/tests/unit/BigQuery/DatasetTest.php
+++ b/tests/unit/BigQuery/DatasetTest.php
@@ -94,6 +94,22 @@ class DatasetTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($updateData['friendlyName'], $dataset->info()['friendlyName']);
     }
 
+    public function testUpdatesDataWithEtag()
+    {
+        $updateData = ['friendlyName' => 'wow a name', 'etag' => 'foo'];
+        $this->connection->patchDataset(Argument::that(function ($args) {
+            if ($args['restOptions']['headers']['If-Match'] !== 'foo') return false;
+
+            return true;
+        }))
+            ->willReturn($updateData)
+            ->shouldBeCalledTimes(1);
+        $dataset = $this->getDataset($this->connection, ['friendlyName' => 'another name']);
+        $dataset->update($updateData);
+
+        $this->assertEquals($updateData['friendlyName'], $dataset->info()['friendlyName']);
+    }
+
     public function testGetsTable()
     {
         $dataset = $this->getDataset($this->connection);

--- a/tests/unit/BigQuery/TableTest.php
+++ b/tests/unit/BigQuery/TableTest.php
@@ -122,6 +122,22 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
     public function testUpdatesData()
     {
+        $updateData = ['friendlyName' => 'wow a name', 'etag' => 'foo'];
+        $this->connection->patchTable(Argument::that(function ($args) {
+            if ($args['restOptions']['headers']['If-Match'] !== 'foo') return false;
+
+            return true;
+        }))
+            ->willReturn($updateData)
+            ->shouldBeCalledTimes(1);
+        $table = $this->getTable($this->connection, ['friendlyName' => 'another name']);
+        $table->update($updateData);
+
+        $this->assertEquals($updateData['friendlyName'], $table->info()['friendlyName']);
+    }
+
+    public function testUpdatesDataWithEtag()
+    {
         $updateData = ['friendlyName' => 'wow a name'];
         $this->connection->patchTable(Argument::any())
             ->willReturn($updateData)

--- a/tests/unit/Core/ConcurrencyControlTraitTest.php
+++ b/tests/unit/Core/ConcurrencyControlTraitTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Core;
+
+use Google\Cloud\Core\ConcurrencyControlTrait;
+
+/**
+ * @group core
+ */
+class ConcurrencyControlTraitTest extends \PHPUnit_Framework_TestCase
+{
+    const ETAG = 'foobar';
+
+    private $trait;
+
+    public function setUp()
+    {
+        $this->trait = \Google\Cloud\Dev\impl(ConcurrencyControlTrait::class);
+    }
+
+    public function testApplyEtagHeader()
+    {
+        $input = ['etag' => self::ETAG];
+
+        $res = $this->trait->call('applyEtagHeader', [$input]);
+
+        $this->assertEquals(self::ETAG, $res['restOptions']['headers']['If-Match']);
+    }
+
+    public function testApplyEtagHeaderCustomName()
+    {
+        $input = ['test' => self::ETAG];
+
+        $res = $this->trait->call('applyEtagHeader', [$input, 'test']);
+
+        $this->assertEquals(self::ETAG, $res['restOptions']['headers']['If-Match']);
+    }
+}


### PR DESCRIPTION
I put the new trait in Core thinking it could be used elsewhere in the future. If you think it should be in BigQuery, I'm open to that too.