### PR TITLE
adds has to CallTrait

### DIFF
--- a/src/Core/CallTrait.php
+++ b/src/Core/CallTrait.php
@@ -23,6 +23,24 @@ namespace Google\Cloud\Core;
 trait CallTrait
 {
     /**
+     * Determine if a property exists for this object.
+     *
+     * Example:
+     * ```
+     * if ($annotation->has('sentiment')) {
+     *     $sentiment = $annotation->sentiment();
+     * }
+     * ```
+     *
+     * @param $name the property name
+     * @return bool
+     */
+    public function has($name)
+    {
+        return isset($this->info()[$name]);
+    }
+
+    /**
      * @access private
      */
     public function __call($name, array $args)

--- a/tests/unit/Core/CallTraitTest.php
+++ b/tests/unit/Core/CallTraitTest.php
@@ -31,6 +31,14 @@ class CallTraitTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $t->foo());
     }
 
+    public function testHas()
+    {
+        $t = new CallTraitStub(['foo' => 'bar']);
+
+        $this->assertTrue($t->has('foo'));
+        $this->assertFalse($t->has('bar'));
+    }
+
     /**
      * @expectedException PHPUnit_Framework_Error
      */


### PR DESCRIPTION
Not required, but it would be nice for some samples where we have to do this to avoid an exception being thrown:

```php
$info = $annotation->info();
if (isset($info['sentiment'])) {
    print($annotation->sentiment());
}
```

This is fine, but it would be cleaner to do 

```php
if ($annotation->has('sentiment')) {
    print($annotation->sentiment());
}
```