### PR TITLE
[BC Break] Implement waitUntilComplete and block while waiting for query results

### DIFF
--- a/src/BigQuery/QueryResults.php
+++ b/src/BigQuery/QueryResults.php
@@ -223,7 +223,8 @@ class QueryResults implements \IteratorAggregate
 
     /**
      * @access private
-     * @return \Generator
+     * @return ItemIterator
+     * @throws GoogleException Thrown in the case of a malformed response.
      */
     public function getIterator()
     {

--- a/tests/snippets/BigQuery/JobTest.php
+++ b/tests/snippets/BigQuery/JobTest.php
@@ -82,7 +82,6 @@ class JobTest extends SnippetTestCase
             ]
         ]);
         $snippet = $this->snippetFromMethod(Job::class, 'cancel');
-        $snippet->replace('sleep(1);', '');
         $snippet->addLocal('job', $job);
         $snippet->invoke();
     }
@@ -91,13 +90,25 @@ class JobTest extends SnippetTestCase
     {
         $this->connection->getQueryResults(Argument::any())
             ->shouldBeCalledTimes(1)
-            ->willReturn([]);
+            ->willReturn(['jobComplete' => true]);
         $job = $this->getJob($this->connection);
         $snippet = $this->snippetFromMethod(Job::class, 'queryResults');
         $snippet->addLocal('job', $job);
         $res = $snippet->invoke('queryResults');
 
         $this->assertInstanceOf(QueryResults::class, $res->returnVal());
+    }
+
+    public function testWaitUntilComplete()
+    {
+        $job = $this->getJob($this->connection, [
+            'status' => [
+                'state' => 'DONE'
+            ]
+        ]);
+        $snippet = $this->snippetFromMethod(Job::class, 'waitUntilComplete');
+        $snippet->addLocal('job', $job);
+        $snippet->invoke();
     }
 
     public function testIsComplete()
@@ -116,7 +127,6 @@ class JobTest extends SnippetTestCase
         ]);
         $snippet = $this->snippetFromMethod(Job::class, 'isComplete');
         $snippet->addLocal('job', $job);
-        $snippet->replace('sleep(1);', '');
         $snippet->invoke();
     }
 
@@ -151,7 +161,6 @@ class JobTest extends SnippetTestCase
         ]);
         $snippet = $this->snippetFromMethod(Job::class, 'reload');
         $snippet->addLocal('job', $job);
-        $snippet->replace('sleep(1);', '');
         $snippet->invoke();
     }
 

--- a/tests/snippets/BigQuery/QueryResultsTest.php
+++ b/tests/snippets/BigQuery/QueryResultsTest.php
@@ -60,7 +60,6 @@ class QueryResultsTest extends SnippetTestCase
                 ]
             ]
         ];
-        $this->reload = [];
 
         $this->connection = $this->prophesize(ConnectionInterface::class);
         $this->qr = \Google\Cloud\Dev\stub(QueryResults::class, [
@@ -68,7 +67,6 @@ class QueryResultsTest extends SnippetTestCase
             self::JOB_ID,
             self::PROJECT,
             $this->info,
-            $this->reload,
             new ValueMapper(false)
         ]);
     }
@@ -88,21 +86,6 @@ class QueryResultsTest extends SnippetTestCase
 
         $res = $snippet->invoke();
         $this->assertEquals('abcd', trim($res->output()));
-    }
-
-    public function testIsComplete()
-    {
-        $snippet = $this->snippetFromMethod(QueryResults::class, 'isComplete');
-        $snippet->addLocal('queryResults', $this->qr);
-
-        $this->info['jobComplete'] = true;
-        $this->connection->getQueryResults(Argument::any())
-            ->willReturn($this->info);
-
-        $this->qr->___setProperty('connection', $this->connection->reveal());
-
-        $res = $snippet->invoke();
-        $this->assertEquals('Query complete!', $res->output());
     }
 
     public function testIdentity()
@@ -133,9 +116,7 @@ class QueryResultsTest extends SnippetTestCase
 
         $snippet = $this->snippetFromMethod(QueryResults::class, 'reload');
         $snippet->addLocal('queryResults', $this->qr);
-        $snippet->replace('sleep(1);', '');
 
         $res = $snippet->invoke();
-        $this->assertEquals('Query complete!', $res->output());
     }
 }

--- a/tests/unit/BigQuery/BigQueryClientTest.php
+++ b/tests/unit/BigQuery/BigQueryClientTest.php
@@ -51,7 +51,19 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testRunsQuery($query, $options, $expected)
     {
-        $this->connection->query($expected)
+        $projectId = $expected['projectId'];
+        unset($expected['projectId']);
+        $this->connection->insertJob([
+            'projectId' => $projectId,
+            'configuration' => [
+                'query' => $expected
+            ]
+        ])
+            ->willReturn([
+                'jobReference' => ['jobId' => $this->jobId]
+            ])
+            ->shouldBeCalledTimes(1);
+        $this->connection->getQueryResults(Argument::any())
             ->willReturn([
                 'jobReference' => [
                     'jobId' => $this->jobId
@@ -71,15 +83,18 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testRunsQueryWithRetry($query, $options, $expected)
     {
-        $this->connection->query($expected)
+        $projectId = $expected['projectId'];
+        unset($expected['projectId']);
+        $this->connection->insertJob([
+            'projectId' => $projectId,
+            'configuration' => [
+                'query' => $expected
+            ]
+        ])
             ->willReturn([
-                'jobReference' => [
-                    'jobId' => $this->jobId
-                ],
-                'jobComplete' => false
+                'jobReference' => ['jobId' => $this->jobId]
             ])
             ->shouldBeCalledTimes(1);
-
         $this->connection->getQueryResults(Argument::any())
             ->willReturn([
                 'jobReference' => [

--- a/tests/unit/BigQuery/QueryResultsTest.php
+++ b/tests/unit/BigQuery/QueryResultsTest.php
@@ -57,21 +57,8 @@ class QueryResultsTest extends \PHPUnit_Framework_TestCase
             $this->jobId,
             $this->projectId,
             $data,
-            [],
             new ValueMapper(false)
         );
-    }
-
-    /**
-     * @expectedException \Google\Cloud\Core\Exception\GoogleException
-     */
-    public function testGetsRowsThrowsExceptionWhenQueryNotComplete()
-    {
-        $this->queryData['jobComplete'] = false;
-        unset($this->queryData['rows']);
-        $this->connection->getQueryResults()->shouldNotBeCalled();
-        $queryResults = $this->getQueryResults($this->connection, $this->queryData);
-        $queryResults->rows()->next();
     }
 
     public function testGetsRowsWithNoResults()
@@ -105,6 +92,16 @@ class QueryResultsTest extends \PHPUnit_Framework_TestCase
         $rows = iterator_to_array($queryResults->rows());
 
         $this->assertEquals('Alton', $rows[1]['first_name']);
+    }
+
+    public function testGetIterator()
+    {
+        $this->connection->getQueryResults()->shouldNotBeCalled();
+        unset($this->queryData['rows']);
+        $queryResults = $this->getQueryResults($this->connection, $this->queryData);
+        $rows = iterator_to_array($queryResults);
+
+        $this->assertEmpty($rows);
     }
 
     public function testIsCompleteTrue()


### PR DESCRIPTION
Introduced by this PR:

- It's no longer necessary to manually poll jobs for completion. `Google\Cloud\BigQuery\Job::waitUntilComplete()` has been added to help simplify the process. Closes https://github.com/GoogleCloudPlatform/google-cloud-php/issues/89.
- `Google\Cloud\BigQuery\QueryResults` no longer inherits reload options.
- `Google\Cloud\BigQuery\Job::queryResults()` now blocks until the query is complete.
- `Google\Cloud\BigQuery\QueryResults::isComplete()` has been marked internal, as by the time 
 `QueryResults` are passed back to the user rows are now guaranteed to be loaded.
- `Google\Cloud\BigQuery\QueryResults` now implements `IteratorAggregate`, allowing users to iterate directly over the `QueryResults`.
- `Google\Cloud\BigQuery\BigQueryClient::runQuery()` now implements [jobs.insert](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert) instead of [jobs.query](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query) and calls `Google\Cloud\BigQuery\Job::queryResults()` under the hood.