### PR TITLE
The Road to GA - BigQuery Updates

### DIFF
--- a/src/BigQuery/BigQueryClient.php
+++ b/src/BigQuery/BigQueryClient.php
@@ -20,7 +20,6 @@ namespace Google\Cloud\BigQuery;
 use Google\Cloud\BigQuery\Connection\ConnectionInterface;
 use Google\Cloud\BigQuery\Connection\Rest;
 use Google\Cloud\BigQuery\Job;
-use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\ClientTrait;
 use Google\Cloud\Core\ExponentialBackoff;
 use Google\Cloud\Core\Int64;
@@ -43,7 +42,6 @@ use Psr\Http\Message\StreamInterface;
  */
 class BigQueryClient
 {
-    use ArrayTrait;
     use ClientTrait;
     use JobConfigurationTrait;
 
@@ -254,6 +252,8 @@ class BigQueryClient
      *           If not provided default settings will be used, with the exception
      *           of `configuration.query.useLegacySql`, which defaults to `false`
      *           in this client.
+     *     @type string $jobIdPrefix If given, the returned job ID will be of
+     *           format `{$jobIdPrefix-}{jobId}`. **Defaults to** `null`.
      * }
      * @return Job
      */

--- a/src/BigQuery/BigQueryClient.php
+++ b/src/BigQuery/BigQueryClient.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\BigQuery;
 
 use Google\Cloud\BigQuery\Connection\ConnectionInterface;
 use Google\Cloud\BigQuery\Connection\Rest;
+use Google\Cloud\BigQuery\Exception\JobException;
 use Google\Cloud\BigQuery\Job;
 use Google\Cloud\Core\ClientTrait;
 use Google\Cloud\Core\ExponentialBackoff;
@@ -197,8 +198,8 @@ class BigQueryClient
      *           in this client.
      * }
      * @return QueryResults
-     * @throws \RuntimeException If the maximum number of retries while waiting
-     *         for query completion has been exceeded.
+     * @throws JobException If the maximum number of retries while waiting for
+     *         query completion has been exceeded.
      */
     public function runQuery($query, array $options = [])
     {

--- a/src/BigQuery/BigQueryClient.php
+++ b/src/BigQuery/BigQueryClient.php
@@ -21,11 +21,12 @@ use Google\Cloud\BigQuery\Connection\ConnectionInterface;
 use Google\Cloud\BigQuery\Connection\Rest;
 use Google\Cloud\BigQuery\Exception\JobException;
 use Google\Cloud\BigQuery\Job;
+use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\ClientTrait;
-use Google\Cloud\Core\ExponentialBackoff;
 use Google\Cloud\Core\Int64;
 use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Core\Iterator\PageIterator;
+use Google\Cloud\Core\RetryDeciderTrait;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\StreamInterface;
 
@@ -43,10 +44,13 @@ use Psr\Http\Message\StreamInterface;
  */
 class BigQueryClient
 {
+    use ArrayTrait;
     use ClientTrait;
-    use JobConfigurationTrait;
+    use RetryDeciderTrait;
 
     const VERSION = '0.2.4';
+
+    const MAX_DELAY_MICROSECONDS = 32000000;
 
     const SCOPE = 'https://www.googleapis.com/auth/bigquery';
     const INSERT_SCOPE = 'https://www.googleapis.com/auth/bigquery.insertdata';
@@ -57,7 +61,7 @@ class BigQueryClient
     protected $connection;
 
     /**
-     * @var ValueMapper $mapper Maps values between PHP and BigQuery.
+     * @var ValueMapper Maps values between PHP and BigQuery.
      */
     private $mapper;
 
@@ -96,13 +100,83 @@ class BigQueryClient
      */
     public function __construct(array $config = [])
     {
+        $this->setHttpRetryCodes([]);
+        $this->setHttpRetryMessages([
+            'rateLimitExceeded',
+            'backendError'
+        ]);
         $config += [
             'scopes' => [self::SCOPE],
-            'returnInt64AsObject' => false
+            'returnInt64AsObject' => false,
+            'restRetryFunction' => $this->getRetryFunction(),
+            'restDelayFunction' => function ($attempt) {
+                return min(
+                    mt_rand(0, 1000000) + (pow(2, $attempt) * 1000000),
+                    self::MAX_DELAY_MICROSECONDS
+                );
+            }
         ];
 
         $this->connection = new Rest($this->configureAuthentication($config));
         $this->mapper = new ValueMapper($config['returnInt64AsObject']);
+    }
+
+    /**
+     * Returns a job configuration to be passed to either
+     * {@see Google\Cloud\BigQuery\BigQueryClient::runQuery()} or
+     * {@see Google\Cloud\BigQuery\BigQueryClient::startQuery()}. A
+     * configuration can be built using fluent setters or by providing a full
+     * set of options at once.
+     *
+     * Unless otherwise specified, all configuration options will default based
+     * on the [Jobs configuration API documentation]
+     * (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
+     * except for `configuration.query.useLegacySql`, which defaults to `false`
+     * in this client.
+     *
+     * Example:
+     * ```
+     * $queryJobConfig = $bigQuery->query(
+     *     'SELECT commit FROM `bigquery-public-data.github_repos.commits` LIMIT 100'
+     * );
+     * ```
+     *
+     * ```
+     * // Set create disposition using fluent setters.
+     * $queryJobConfig = $bigQuery->query(
+     *     'SELECT commit FROM `bigquery-public-data.github_repos.commits` LIMIT 100'
+     * )->createDisposition('CREATE_NEVER');
+     * ```
+     *
+     * ```
+     * // This is equivalent to the above example, using array configuration
+     * // instead of fluent setters.
+     * $queryJobConfig = $bigQuery->query(
+     *     'SELECT commit FROM `bigquery-public-data.github_repos.commits` LIMIT 100',
+     *     [
+     *         'configuration' => [
+     *             'query' => [
+     *                 'createDisposition' => 'CREATE_NEVER'
+     *             ]
+     *         ]
+     *     ]
+     * );
+     * ```
+     *
+     * @param string $query A BigQuery SQL query.
+     * @param array $options [optional] Please see the
+     *        [API documentation for Job configuration]
+     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
+     *        for the available options.
+     * @return QueryJobConfiguration
+     */
+    public function query($query, array $options = [])
+    {
+        return (new QueryJobConfiguration(
+            $this->mapper,
+            $this->projectId,
+            $options
+        ))->query($query);
     }
 
     /**
@@ -137,7 +211,10 @@ class BigQueryClient
      *
      * Example:
      * ```
-     * $queryResults = $bigQuery->runQuery('SELECT commit FROM `bigquery-public-data.github_repos.commits` LIMIT 100');
+     * $queryJobConfig = $bigQuery->query(
+     *     'SELECT commit FROM `bigquery-public-data.github_repos.commits` LIMIT 100'
+     * );
+     * $queryResults = $bigQuery->runQuery($queryJobConfig);
      *
      * foreach ($queryResults as $row) {
      *     echo $row['commit'];
@@ -148,12 +225,12 @@ class BigQueryClient
      * // Construct a query utilizing named parameters.
      * $query = 'SELECT commit FROM `bigquery-public-data.github_repos.commits`' .
      *          'WHERE author.date < @date AND message = @message LIMIT 100';
-     * $queryResults = $bigQuery->runQuery($query, [
-     *     'parameters' => [
+     * $queryJobConfig = $bigQuery->query($query)
+     *     ->parameters([
      *         'date' => $bigQuery->timestamp(new \DateTime('1980-01-01 12:15:00Z')),
      *         'message' => 'A commit message.'
-     *     ]
-     * ]);
+     *     ]);
+     * $queryResults = $bigQuery->runQuery($queryJobConfig);
      *
      * foreach ($queryResults as $row) {
      *     echo $row['commit'];
@@ -163,9 +240,9 @@ class BigQueryClient
      * ```
      * // Construct a query utilizing positional parameters.
      * $query = 'SELECT commit FROM `bigquery-public-data.github_repos.commits` WHERE message = ? LIMIT 100';
-     * $queryResults = $bigQuery->runQuery($query, [
-     *     'parameters' => ['A commit message.']
-     * ]);
+     * $queryJobConfig = $bigQuery->query($query)
+     *     ->parameters(['A commit message.']);
+     * $queryResults = $bigQuery->runQuery($queryJobConfig);
      *
      * foreach ($queryResults as $row) {
      *     echo $row['commit'];
@@ -174,7 +251,7 @@ class BigQueryClient
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs/query Query API documentation.
      *
-     * @param string $query A BigQuery SQL query.
+     * @param QueryJobConfiguration $query A BigQuery SQL query configuration.
      * @param array $options [optional] {
      *     Configuration options.
      *
@@ -187,26 +264,13 @@ class BigQueryClient
      *           milliseconds. **Defaults to** `10000` milliseconds (10 seconds).
      *     @type int $maxRetries The number of times to retry, checking if the
      *           query has completed. **Defaults to** `100`.
-     *     @type array $parameters Only available for standard SQL queries.
-     *           When providing a non-associative array positional parameters
-     *           (`?`) will be used. When providing an associative array
-     *           named parameters will be used (`@name`).
-     *     @type array $jobConfig Configuration settings for a query job are
-     *           outlined in the [API Docs for `configuration.query`](https://goo.gl/PuRa3I).
-     *           If not provided default settings will be used, with the exception
-     *           of `configuration.query.useLegacySql`, which defaults to `false`
-     *           in this client.
      * }
      * @return QueryResults
      * @throws JobException If the maximum number of retries while waiting for
      *         query completion has been exceeded.
      */
-    public function runQuery($query, array $options = [])
+    public function runQuery(JobConfigurationInterface $query, array $options = [])
     {
-        $jobOptions = $this->pluckArray([
-            'parameters',
-            'jobConfig'
-        ], $options);
         $queryResultsOptions = $this->pluckArray([
             'maxResults',
             'startIndex',
@@ -214,9 +278,9 @@ class BigQueryClient
             'maxRetries'
         ], $options);
 
-        return $this->runQueryAsJob(
+        return $this->startQuery(
             $query,
-            $jobOptions + $options
+            $options
         )->queryResults($queryResultsOptions + $options);
     }
 
@@ -230,7 +294,10 @@ class BigQueryClient
      *
      * Example:
      * ```
-     * $job = $bigQuery->runQueryAsJob('SELECT commit FROM `bigquery-public-data.github_repos.commits` LIMIT 100');
+     * $queryJobConfig = $bigQuery->query(
+     *     'SELECT commit FROM `bigquery-public-data.github_repos.commits` LIMIT 100'
+     * );
+     * $job = $bigQuery->startQuery($queryJobConfig);
      * $queryResults = $job->queryResults();
      *
      * foreach ($queryResults as $row) {
@@ -240,52 +307,18 @@ class BigQueryClient
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs/insert Jobs insert API documentation.
      *
-     * @param string $query A BigQuery SQL query.
-     * @param array $options [optional] {
-     *     Configuration options.
-     *
-     *     @type array $parameters Only available for standard SQL queries.
-     *           When providing a non-associative array positional parameters
-     *           (`?`) will be used. When providing an associative array
-     *           named parameters will be used (`@name`).
-     *     @type array $jobConfig Configuration settings for a query job are
-     *           outlined in the [API Docs for `configuration.query`](https://goo.gl/PuRa3I).
-     *           If not provided default settings will be used, with the exception
-     *           of `configuration.query.useLegacySql`, which defaults to `false`
-     *           in this client.
-     *     @type string $jobIdPrefix If given, the returned job ID will be of
-     *           format `{$jobIdPrefix-}{jobId}`. **Defaults to** `null`.
-     * }
+     * @param QueryJobConfiguration $query A BigQuery SQL query configuration.
+     * @param array $options [optional] Configuration options.
      * @return Job
      */
-    public function runQueryAsJob($query, array $options = [])
+    public function startQuery(JobConfigurationInterface $query, array $options = [])
     {
-        $options += [
-            'jobConfig' => []
-        ];
-
-        if (isset($options['parameters'])) {
-            $options['jobConfig'] += $this->formatQueryParameters($options['parameters']);
-
-            unset($options['parameters']);
-        }
-
-        $options['jobConfig'] += [
-            'useLegacySql' => false
-        ];
-
-        $config = $this->buildJobConfig(
-            'query',
-            $this->projectId,
-            ['query' => $query],
-            $options
-        );
-
-        $response = $this->connection->insertJob($config);
+        $config = $query->toArray();
+        $response = $this->connection->insertJob($config + $options);
 
         return new Job(
             $this->connection,
-            $response['jobReference']['jobId'],
+            $config['jobReference']['jobId'],
             $this->projectId,
             $this->mapper,
             $response
@@ -302,7 +335,7 @@ class BigQueryClient
      * $job = $bigQuery->job('myJobId');
      * ```
      *
-     * @param string $id The id of the job to request.
+     * @param string $id The id of the already run or running job to request.
      * @return Job
      */
     public function job($id)
@@ -445,6 +478,9 @@ class BigQueryClient
     /**
      * Creates a dataset.
      *
+     * Please note that by default the library will not attempt to retry this
+     * call on your behalf.
+     *
      * Example:
      * ```
      * $dataset = $bigQuery->createDataset('aDataset');
@@ -469,12 +505,16 @@ class BigQueryClient
             unset($options['metadata']);
         }
 
-        $response = $this->connection->insertDataset([
-            'projectId' => $this->projectId,
-            'datasetReference' => [
-                'datasetId' => $id
+        $response = $this->connection->insertDataset(
+            [
+                'projectId' => $this->projectId,
+                'datasetReference' => [
+                    'datasetId' => $id
+                ]
             ]
-        ] + $options);
+            + $options
+            + ['retries' => 0]
+        );
 
         return new Dataset(
             $this->connection,
@@ -564,31 +604,5 @@ class BigQueryClient
     public function timestamp(\DateTimeInterface $value)
     {
         return new Timestamp($value);
-    }
-
-    /**
-     * Formats query parameters for the API.
-     *
-     * @param array $parameters The parameters to format.
-     * @return array
-     */
-    private function formatQueryParameters(array $parameters)
-    {
-        $options = [
-            'parameterMode' => $this->isAssoc($parameters) ? 'named' : 'positional',
-            'useLegacySql' => false
-        ];
-
-        foreach ($parameters as $name => $value) {
-            $param = $this->mapper->toParameter($value);
-
-            if ($options['parameterMode'] === 'named') {
-                $param += ['name' => $name];
-            }
-
-            $options['queryParameters'][] = $param;
-        }
-
-        return $options;
     }
 }

--- a/src/BigQuery/Connection/Rest.php
+++ b/src/BigQuery/Connection/Rest.php
@@ -246,12 +246,19 @@ class Rest implements ConnectionInterface
         $args += [
             'projectId' => null,
             'data' => null,
-            'configuration' => []
+            'configuration' => [],
+            'labels' => [],
+            'dryRun' => false,
+            'jobReference' => []
         ];
 
         $args['data'] = Psr7\stream_for($args['data']);
-        $args['metadata']['configuration'] = $args['configuration'];
-        unset($args['configuration']);
+        $args['metadata'] = $this->pluckArray([
+            'labels',
+            'dryRun',
+            'jobReference',
+            'configuration'
+        ], $args);
 
         $uploaderOptionKeys = [
             'restOptions',

--- a/src/BigQuery/CopyJobConfiguration.php
+++ b/src/BigQuery/CopyJobConfiguration.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+/**
+ * Represents a configuration for a copy job. For more information on the
+ * available settings please see the
+ * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration).
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\BigQuery\BigQueryClient;
+ *
+ * $bigQuery = new BigQueryClient();
+ * $sourceTable = $bigQuery->dataset('my_dataset')
+ *     ->table('my_source_table');
+ * $destinationTable = $bigQuery->dataset('my_dataset')
+ *     ->table('my_destination_table');
+ *
+ * $copyJobConfig = $sourceTable->copy($destinationTable);
+ * ```
+ */
+class CopyJobConfiguration implements JobConfigurationInterface
+{
+    use JobConfigurationTrait;
+
+    /**
+     * @param string $projectId The project's ID.
+     * @param array $config A set of configuration options for a job.
+     */
+    public function __construct($projectId, array $config)
+    {
+        $this->jobConfigurationProperties($projectId, $config);
+    }
+
+    /**
+     * Set whether the job is allowed to create new tables. Creation, truncation
+     * and append actions occur as one atomic update upon job completion.
+     *
+     * Example:
+     * ```
+     * $copyJobConfig->createDisposition('CREATE_NEVER');
+     * ```
+     *
+     * @param string $createDisposition The create disposition. Acceptable
+     *        values include `"CREATED_IF_NEEDED"`, `"CREATE_NEVER"`. **Defaults
+     *        to** `"CREATE_IF_NEEDED"`.
+     * @return CopyJobConfiguration
+     */
+    public function createDisposition($createDisposition)
+    {
+        $this->config['configuration']['copy']['createDisposition'] = $createDisposition;
+
+        return $this;
+    }
+
+    /**
+     * Sets the custom encryption configuration (e.g., Cloud KMS keys).
+     *
+     * Example:
+     * ```
+     * $copyJobConfig->destinationEncryptionConfiguration([
+     *     'kmsKeyName' => 'my_key'
+     * ]);
+     * ```
+     *
+     * @param array $configuration Custom encryption configuration.
+     * @return CopyJobConfiguration
+     */
+    public function destinationEncryptionConfiguration(array $configuration)
+    {
+        $this->config['configuration']['copy']['destinationEncryptionConfiguration'] = $configuration;
+
+        return $this;
+    }
+
+    /**
+     * Sets the destination table.
+     *
+     * Example:
+     * ```
+     * $table = $bigQuery->dataset('my_dataset')
+     *     ->table('my_table');
+     * $copyJobConfig->destinationTable($table);
+     * ```
+     *
+     * @param Table $destinationTable The destination table.
+     * @return CopyJobConfiguration
+     */
+    public function destinationTable(Table $destinationTable)
+    {
+        $this->config['configuration']['copy']['destinationTable'] = $destinationTable->identity();
+
+        return $this;
+    }
+
+    /**
+     * Sets the source table to copy.
+     *
+     * Example:
+     * ```
+     * $table = $bigQuery->dataset('my_dataset')
+     *     ->table('source_table');
+     * $copyJobConfig->sourceTable($table);
+     * ```
+     *
+     * @param Table $sourceTable The destination table.
+     * @return CopyJobConfiguration
+     */
+    public function sourceTable(Table $sourceTable)
+    {
+        $this->config['configuration']['copy']['sourceTable'] = $sourceTable->identity();
+
+        return $this;
+    }
+
+    /**
+     * Sets the action that occurs if the destination table already exists. Each
+     * action is atomic and only occurs if BigQuery is able to complete the job
+     * successfully. Creation, truncation and append actions occur as one atomic
+     * update upon job completion.
+     *
+     * Example:
+     * ```
+     * $copyJobConfig->writeDisposition('WRITE_TRUNCATE');
+     * ```
+     *
+     * @param string $writeDisposition The write disposition. Acceptable values
+     *        include `"WRITE_TRUNCATE"`, `"WRITE_APPEND"`, `"WRITE_EMPTY"`.
+     *        **Defaults to** `"WRITE_EMPTY"`.
+     * @return CopyJobConfiguration
+     */
+    public function writeDisposition($writeDisposition)
+    {
+        $this->config['configuration']['copy']['writeDisposition'] = $writeDisposition;
+
+        return $this;
+    }
+}

--- a/src/BigQuery/Exception/JobException.php
+++ b/src/BigQuery/Exception/JobException.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery\Exception;
+
+use Google\Cloud\BigQuery\Job;
+
+/**
+ * Exception thrown when a job fails to complete.
+ */
+class JobException extends \RuntimeException
+{
+    /**
+     * @param string $message
+     * @param Job $job
+     */
+    public function __construct($message, Job $job)
+    {
+        $this->job = $job;
+        parent::__construct($message, 0);
+    }
+
+    /**
+     * Returns the job instance associated with the failure.
+     *
+     * @return Job
+     */
+    public function getJob()
+    {
+        return $this->job;
+    }
+}

--- a/src/BigQuery/ExtractJobConfiguration.php
+++ b/src/BigQuery/ExtractJobConfiguration.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+/**
+ * Represents a configuration for an extract job. For more information on the
+ * available settings please see the
+ * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration).
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\BigQuery\BigQueryClient;
+ *
+ * $bigQuery = new BigQueryClient();
+ * $table = $bigQuery->dataset('my_dataset')
+ *     ->table('my_table');
+ * $extractJobConfig = $table->extract('gs://my_bucket/target.csv');
+ * ```
+ */
+class ExtractJobConfiguration implements JobConfigurationInterface
+{
+    use JobConfigurationTrait;
+
+    /**
+     * @param string $projectId The project's ID.
+     * @param array $config A set of configuration options for a job.
+     */
+    public function __construct($projectId, array $config)
+    {
+        $this->jobConfigurationProperties($projectId, $config);
+    }
+
+    /**
+     * Sets the compression type to use for exported files.
+     *
+     * Example:
+     * ```
+     * $extractJobConfig->compression('GZIP');
+     * ```
+     *
+     * @param string $compression The compression type. Acceptable values
+     *        include `"GZIP"`, `"NONE"`. **Defaults to** `"NONE"`.
+     * @return ExtractJobConfiguration
+     */
+    public function compression($compression)
+    {
+        $this->config['configuration']['extract']['compression'] = $compression;
+
+        return $this;
+    }
+
+    /**
+     * Sets the exported file format. Tables with nested or repeated fields
+     * cannot be exported as CSV.
+     *
+     * Example:
+     * ```
+     * $extractJobConfig->destinationFormat('NEWLINE_DELIMITED_JSON');
+     * ```
+     *
+     * @param string $destinationFormat The exported file format. Acceptable
+     *        values include `"CSV"`, `"NEWLINE_DELIMITED_JSON"`, `"AVRO"`.
+     *        **Defaults to** `"CSV"`.
+     * @return ExtractJobConfiguration
+     */
+    public function destinationFormat($destinationFormat)
+    {
+        $this->config['configuration']['extract']['destinationFormat'] = $destinationFormat;
+
+        return $this;
+    }
+
+    /**
+     * Sets a list of fully-qualified Google Cloud Storage URIs where the
+     * extracted table should be written.
+     *
+     * Example:
+     * ```
+     * $extractJobConfig->destinationUris([
+     *     'gs://my_bucket/destination.csv'
+     * ]);
+     * ```
+     *
+     * @param array $destinationUris The destination URIs.
+     * @return ExtractJobConfiguration
+     */
+    public function destinationUris(array $destinationUris)
+    {
+        $this->config['configuration']['extract']['destinationUris'] = $destinationUris;
+
+        return $this;
+    }
+
+    /**
+     * Sets the delimiter to use between fields in the exported data.
+     *
+     * Example:
+     * ```
+     * $extractJobConfig->fieldDelimiter(',');
+     * ```
+     *
+     * @param string $fieldDelimiter The field delimiter. **Defaults to** `","`.
+     * @return ExtractJobConfiguration
+     */
+    public function fieldDelimiter($fieldDelimiter)
+    {
+        $this->config['configuration']['extract']['fieldDelimiter'] = $fieldDelimiter;
+
+        return $this;
+    }
+
+    /**
+     * Sets whether or not to print out a header row in the results.
+     *
+     * Example:
+     * ```
+     * $extractJobConfig->printHeader(false);
+     * ```
+     *
+     * @param bool $printHeader Whether or not to print out a header row.
+     *        **Defaults to** `true`.
+     * @return ExtractJobConfiguration
+     */
+    public function printHeader($printHeader)
+    {
+        $this->config['configuration']['extract']['printHeader'] = $printHeader;
+
+        return $this;
+    }
+
+    /**
+     * Sets a reference to the table being exported.
+     *
+     * Example:
+     * ```
+     * $table = $bigQuery->dataset('my_dataset')
+     *     ->table('my_table');
+     * $extractJobConfig->sourceTable($table);
+     * ```
+     *
+     * @param Table $sourceTable
+     * @return ExtractJobConfiguration
+     */
+    public function sourceTable(Table $sourceTable)
+    {
+        $this->config['configuration']['extract']['sourceTable'] = $sourceTable->identity();
+
+        return $this;
+    }
+}

--- a/src/BigQuery/Job.php
+++ b/src/BigQuery/Job.php
@@ -103,6 +103,9 @@ class Job
      * Requests that a job be cancelled. You will need to poll the job to ensure
      * the cancel request successfully goes through.
      *
+     * Please note that by default the library will not attempt to retry this
+     * call on your behalf.
+     *
      * Example:
      * ```
      * $job->cancel();
@@ -124,7 +127,11 @@ class Job
      */
     public function cancel(array $options = [])
     {
-        $this->connection->cancelJob($options + $this->identity);
+        $this->connection->cancelJob(
+            $options
+            + ['retries' => 0]
+            + $this->identity
+        );
     }
 
     /**
@@ -172,7 +179,7 @@ class Job
      *     Configuration options.
      *
      *     @type int $maxRetries The number of times to retry, checking if the
-     *           query has completed. **Defaults to** `100`.
+     *           job has completed. **Defaults to** `100`.
      * }
      * @throws JobException If the maximum number of retries while waiting for
      *         job completion has been exceeded.

--- a/src/BigQuery/JobConfigurationInterface.php
+++ b/src/BigQuery/JobConfigurationInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+/**
+ * A contract to be implemented by job configurations.
+ */
+interface JobConfigurationInterface
+{
+    /**
+     * Returns the job config as an array.
+     *
+     * @return array
+     */
+    public function toArray();
+}

--- a/src/BigQuery/JobConfigurationTrait.php
+++ b/src/BigQuery/JobConfigurationTrait.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,58 +21,109 @@ use Google\Cloud\Core\ArrayTrait;
 use Ramsey\Uuid\Uuid;
 
 /**
- * A trait used to build out configuration for jobs.
+ * A utility trait implementing shared behavior between job configurations.
  */
 trait JobConfigurationTrait
 {
     use ArrayTrait;
 
     /**
-     * Builds a configuration for a job.
-     *
-     * @param string $name
-     * @param string $projectId
-     * @param array $config
-     * @param array $userDefinedOptions
-     * @return array
+     * @var string $jobIdPrefix
      */
-    public function buildJobConfig($name, $projectId, array $config, array $userDefinedOptions)
+    private $jobIdPrefix;
+
+    /**
+     * @var array $config
+     */
+    private $config = [];
+
+    /**
+     * Sets shared job configuration properties.
+     *
+     * @access private
+     * @param string $projectId The project's ID.
+     * @param array $config A set of configuration options for a job.
+     */
+    public function jobConfigurationProperties($projectId, array $config)
     {
-        $jobIdPrefix = $this->pluck('jobIdPrefix', $userDefinedOptions, false);
-
-        if (isset($userDefinedOptions['jobConfig'])) {
-            $config = $userDefinedOptions['jobConfig'] + $config;
-        }
-
-        unset($userDefinedOptions['jobConfig']);
-
-        return [
+        $this->config = array_replace_recursive([
             'projectId' => $projectId,
-            'jobReference' => [
-                'projectId' => $projectId,
-                'jobId' => $this->generateJobId($jobIdPrefix)
-            ],
-            'configuration' => [
-                $name => $config
-            ]
-        ] + $userDefinedOptions;
+            'jobReference' => ['projectId' => $projectId]
+        ], $config);
+
+        if (!isset($this->config['jobReference']['jobId'])) {
+            $this->config['jobReference']['jobId'] = $this->generateJobId();
+        }
     }
 
     /**
-     * Generate a Job ID with an optional user-defined prefix.
+     * Specifies the default dataset to use for unqualified table names in the
+     * query.
      *
-     * @param string $jobIdPrefix [optional] If given, the returned job ID will
-     *        be of format `{$jobIdPrefix-}{jobId}`. **Defaults to** `null`.
-     * @return string
+     * @param bool $dryRun
+     * @return JobConfigInterface
      */
-    protected function generateJobId($jobIdPrefix = null)
+    public function dryRun($dryRun)
     {
-        $jobId = '';
+        $this->config['configuration']['dryRun'] = $dryRun;
 
-        if ($jobIdPrefix) {
-            $jobId = $jobIdPrefix . '-';
+        return $this;
+    }
+
+    /**
+     * Sets a prefix for the job ID.
+     *
+     * @param string $jobIdPrefix If provided, the job ID will be of format
+     *        `{$jobIdPrefix}-{jobId}`.
+     * @return JobConfigInterface
+     */
+    public function jobIdPrefix($jobIdPrefix)
+    {
+        $this->jobIdPrefix = $jobIdPrefix;
+
+        return $this;
+    }
+
+    /**
+     * Specifies the default dataset to use for unqualified table names in the
+     * query.
+     *
+     * @param array $labels
+     * @return JobConfigInterface
+     */
+    public function labels(array $labels)
+    {
+        $this->config['configuration']['labels'] = $labels;
+
+        return $this;
+    }
+
+    /**
+     * Returns the job config as an array.
+     *
+     * @access private
+     * @return array
+     */
+    public function toArray()
+    {
+        if ($this->jobIdPrefix) {
+            $this->config['jobReference']['jobId'] = sprintf(
+                '%s-%s',
+                $this->jobIdPrefix,
+                $this->config['jobReference']['jobId']
+            );
         }
 
-        return $jobId . Uuid::uuid4();
+        return $this->config;
+    }
+
+    /**
+     * Generate a Job ID.
+     *
+     * @return string
+     */
+    protected function generateJobId()
+    {
+        return (string) Uuid::uuid4();
     }
 }

--- a/src/BigQuery/JobConfigurationTrait.php
+++ b/src/BigQuery/JobConfigurationTrait.php
@@ -17,11 +17,16 @@
 
 namespace Google\Cloud\BigQuery;
 
+use Google\Cloud\Core\ArrayTrait;
+use Ramsey\Uuid\Uuid;
+
 /**
  * A trait used to build out configuration for jobs.
  */
 trait JobConfigurationTrait
 {
+    use ArrayTrait;
+
     /**
      * Builds a configuration for a job.
      *
@@ -33,6 +38,8 @@ trait JobConfigurationTrait
      */
     public function buildJobConfig($name, $projectId, array $config, array $userDefinedOptions)
     {
+        $jobIdPrefix = $this->pluck('jobIdPrefix', $userDefinedOptions, false);
+
         if (isset($userDefinedOptions['jobConfig'])) {
             $config = $userDefinedOptions['jobConfig'] + $config;
         }
@@ -41,9 +48,31 @@ trait JobConfigurationTrait
 
         return [
             'projectId' => $projectId,
+            'jobReference' => [
+                'projectId' => $projectId,
+                'jobId' => $this->generateJobId($jobIdPrefix)
+            ],
             'configuration' => [
                 $name => $config
             ]
         ] + $userDefinedOptions;
+    }
+
+    /**
+     * Generate a Job ID with an optional user-defined prefix.
+     *
+     * @param string $jobIdPrefix [optional] If given, the returned job ID will
+     *        be of format `{$jobIdPrefix-}{jobId}`. **Defaults to** `null`.
+     * @return string
+     */
+    protected function generateJobId($jobIdPrefix = null)
+    {
+        $jobId = '';
+
+        if ($jobIdPrefix) {
+            $jobId = $jobIdPrefix . '-';
+        }
+
+        return $jobId . Uuid::uuid4();
     }
 }

--- a/src/BigQuery/JobWaitTrait.php
+++ b/src/BigQuery/JobWaitTrait.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+use Google\Cloud\BigQuery\Exception\JobException;
+use Google\Cloud\BigQuery\Job;
+use Google\Cloud\Core\ExponentialBackoff;
+
+/**
+ * A utility trait which utilizes exponential backoff to wait until an operation
+ * is complete.
+ */
+trait JobWaitTrait
+{
+    /**
+     * Waits for an operation to complete.
+     *
+     * @param callable $isCompleteFn
+     * @param callable $reloadFn
+     * @param Job $job
+     * @param int $maxRetries
+     * @throws JobException
+     */
+    private function wait(
+        callable $isCompleteFn,
+        callable $reloadFn,
+        Job $job,
+        $maxRetries
+    ) {
+        if (!$isCompleteFn()) {
+            if ($maxRetries === null) {
+                $maxRetries = Job::MAX_RETRIES;
+            }
+
+            $retryFn = function () use ($isCompleteFn, $reloadFn, $job) {
+                $reloadFn();
+
+                if (!$isCompleteFn()) {
+                    throw new JobException('Job did not complete within the allowed number of retries.', $job);
+                }
+            };
+
+            (new ExponentialBackoff($maxRetries))
+                ->execute($retryFn);
+        }
+    }
+}

--- a/src/BigQuery/LoadJobConfiguration.php
+++ b/src/BigQuery/LoadJobConfiguration.php
@@ -1,0 +1,526 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+/**
+ * Represents a configuration for a load job. For more information on the
+ * available settings please see the
+ * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration).
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\BigQuery\BigQueryClient;
+ *
+ * $bigQuery = new BigQueryClient();
+ * $table = $bigQuery->dataset('my_dataset')
+ *     ->table('my_table');
+ * $loadJobConfig = $table->load(fopen('/path/to/my/data.csv', 'r'));
+ * ```
+ */
+class LoadJobConfiguration implements JobConfigurationInterface
+{
+    use JobConfigurationTrait;
+
+    /**
+     * @param string $projectId The project's ID.
+     * @param array $config A set of configuration options for a job.
+     */
+    public function __construct($projectId, array $config)
+    {
+        $this->jobConfigurationProperties($projectId, $config);
+    }
+
+    /**
+     * Sets whether to accept rows that are missing trailing optional columns.
+     * The missing values are treated as nulls. If false, records with missing
+     * trailing columns are treated as bad records, and if there are too many
+     * bad records, an invalid error is returned in the job result. Only
+     * applicable to CSV, ignored for other formats.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->allowJaggedRows(true);
+     * ```
+     *
+     * @param bool $allowJaggedRows Whether or not to allow jagged rows.
+     *        **Defaults to** `false`.
+     * @return LoadJobConfiguration
+     */
+    public function allowJaggedRows($allowJaggedRows)
+    {
+        $this->config['configuration']['load']['allowJaggedRows'] = $allowJaggedRows;
+
+        return $this;
+    }
+
+    /**
+     * Sets whether quoted data sections that contain newline characters in a
+     * CSV file are allowed.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->allowQuotedNewlines(true);
+     * ```
+     *
+     * @param bool $allowQuotedNewlines Whether or not to allow quoted new
+     *        lines. **Defaults to** `false`.
+     * @return LoadJobConfiguration
+     */
+    public function allowQuotedNewlines($allowQuotedNewlines)
+    {
+        $this->config['configuration']['load']['allowQuotedNewlines'] = $allowQuotedNewlines;
+
+        return $this;
+    }
+
+    /**
+     * Sets whether we should automatically infer the options and schema for CSV
+     * and JSON sources.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->autodetect(true);
+     * ```
+     *
+     * @param bool $autodetect Whether or not to autodetect options and schema.
+     * @return LoadJobConfiguration
+     */
+    public function autodetect($autodetect)
+    {
+        $this->config['configuration']['load']['autodetect'] = $autodetect;
+
+        return $this;
+    }
+
+    /**
+     * Set whether the job is allowed to create new tables. Creation, truncation
+     * and append actions occur as one atomic update upon job completion.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->createDisposition('CREATE_NEVER');
+     * ```
+     *
+     * @param string $createDisposition The create disposition. Acceptable
+     *        values include `"CREATED_IF_NEEDED"`, `"CREATE_NEVER"`. **Defaults
+     *        to** `"CREATE_IF_NEEDED"`.
+     * @return LoadJobConfiguration
+     */
+    public function createDisposition($createDisposition)
+    {
+        $this->config['configuration']['load']['createDisposition'] = $createDisposition;
+
+        return $this;
+    }
+
+    /**
+     * Sets the custom encryption configuration (e.g., Cloud KMS keys).
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->destinationEncryptionConfiguration([
+     *     'kmsKeyName' => 'my_key'
+     * ]);
+     * ```
+     *
+     * @param array $configuration Custom encryption configuration.
+     * @return LoadJobConfiguration
+     */
+    public function destinationEncryptionConfiguration(array $configuration)
+    {
+        $this->config['configuration']['load']['destinationEncryptionConfiguration'] = $configuration;
+
+        return $this;
+    }
+
+    /**
+     * The data to be loaded into the table.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->data(fopen('/path/to/my/data.csv', 'r'));
+     * ```
+     *
+     * @param string|resource|StreamInterface $data The data to be loaded into
+     *        the table.
+     * @return LoadJobConfiguration
+     */
+    public function data($data)
+    {
+        $this->config['data'] = $data;
+
+        return $this;
+    }
+
+    /**
+     * Sets the destination table to load the data into.
+     *
+     * Example:
+     * ```
+     * $table = $bigQuery->dataset('my_dataset')
+     *     ->table('my_table');
+     * $loadJobConfig->destinationTable($table);
+     * ```
+     *
+     * @param Table $destinationTable The destination table.
+     * @return LoadJobConfiguration
+     */
+    public function destinationTable(Table $destinationTable)
+    {
+        $this->config['configuration']['load']['destinationTable'] = $destinationTable->identity();
+
+        return $this;
+    }
+
+    /**
+     * Sets the character encoding of the data. BigQuery decodes the data after
+     * the raw, binary data has been split using the values of the quote and
+     * fieldDelimiter properties.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->encoding('UTF-8');
+     * ```
+     *
+     * @param string $encoding The encoding type. Acceptable values include
+     *        `"UTF-8"`, `"ISO-8859-1"`. **Defaults to** `"UTF-8"`.
+     * @return LoadJobConfiguration
+     */
+    public function encoding($encoding)
+    {
+        $this->config['configuration']['load']['encoding'] = $encoding;
+
+        return $this;
+    }
+
+    /**
+     * Sets the separator for fields in a CSV file. The separator can be any
+     * ISO-8859-1 single-byte character. To use a character in the range
+     * 128-255, you must encode the character as UTF8. BigQuery converts the
+     * string to ISO-8859-1 encoding, and then uses the first byte of the
+     * encoded string to split the data in its raw, binary state. BigQuery also
+     * supports the escape sequence "\t" to specify a tab separator.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->fieldDelimiter('\t');
+     * ```
+     *
+     * @param string $fieldDelimiter The field delimiter. **Defaults to** `","`.
+     * @return LoadJobConfiguration
+     */
+    public function fieldDelimiter($fieldDelimiter)
+    {
+        $this->config['configuration']['load']['fieldDelimiter'] = $fieldDelimiter;
+
+        return $this;
+    }
+
+    /**
+     * Sets whether values that are not represented in the table schema should
+     * be allowed. If true, the extra values are ignored. If false, records with
+     * extra columns are treated as bad records, and if there are too many bad
+     * records, an invalid error is returned in the job result.
+     *
+     * The sourceFormat property determines what BigQuery treats as an extra
+     * value:
+     *
+     * - CSV: Trailing columns.
+     * - JSON: Named values that don't match any column names.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->ignoreUnknownValues(true);
+     * ```
+     *
+     * @param bool $ignoreUnknownValues Whether or not to ignore unknown values.
+     *        **Defaults to** `false`.
+     * @return LoadJobConfiguration
+     */
+    public function ignoreUnknownValues($ignoreUnknownValues)
+    {
+        $this->config['configuration']['load']['ignoreUnknownValues'] = $ignoreUnknownValues;
+
+        return $this;
+    }
+
+    /**
+     * Sets the maximum number of bad records that BigQuery can ignore when
+     * running the job. If the number of bad records exceeds this value, an
+     * invalid error is returned in the job result.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->maxBadRecords(10);
+     * ```
+     *
+     * @param int $maxBadRecords The maximum number of bad records.
+     *        **Defaults to** `0` (requires all records to be valid).
+     * @return LoadJobConfiguration
+     */
+    public function maxBadRecords($maxBadRecords)
+    {
+        $this->config['configuration']['load']['maxBadRecords'] = $maxBadRecords;
+
+        return $this;
+    }
+
+    /**
+     * Sets a string that represents a null value in a CSV file. For example,
+     * if you specify "\N", BigQuery interprets "\N" as a null value when
+     * loading a CSV file. The default value is the empty string. If you set
+     * this property to a custom value, BigQuery throws an error if an empty
+     * string is present for all data types except for STRING and BYTE. For
+     * STRING and BYTE columns, BigQuery interprets the empty string as an
+     * empty value.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->nullMarker('\N');
+     * ```
+     *
+     * @param string $nullMarker The null marker.
+     * @return LoadJobConfiguration
+     */
+    public function nullMarker($nullMarker)
+    {
+        $this->config['configuration']['load']['nullMarker'] = $nullMarker;
+
+        return $this;
+    }
+
+    /**
+     * Sets a list of projection fields. If sourceFormat is set to
+     * "DATASTORE_BACKUP", indicates which entity properties to load into
+     * BigQuery from a Cloud Datastore backup. Property names are case sensitive
+     * and must be top-level properties. If no properties are specified,
+     * BigQuery loads all properties. If any named property isn't found in the
+     * Cloud Datastore backup, an invalid error is returned in the job result.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->projectionFields([
+     *     'field_name'
+     * ]);
+     * ```
+     *
+     * @param array $projectionFields The projection fields.
+     * @return LoadJobConfiguration
+     */
+    public function projectionFields(array $projectionFields)
+    {
+        $this->config['configuration']['load']['projectionFields'] = $projectionFields;
+
+        return $this;
+    }
+
+    /**
+     * Sets the value that is used to quote data sections in a CSV file.
+     * BigQuery converts the string to ISO-8859-1 encoding, and then uses the
+     * first byte of the encoded string to split the data in its raw, binary
+     * state. If your data does not contain quoted sections, set the property
+     * value to an empty string. If your data contains quoted newline
+     * characters, you must also set the allowQuotedNewlines property to true.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->quote('"');
+     * ```
+     *
+     * @param string $quote The quote value. **Defaults to** `"""`
+     *        (double quotes).
+     * @return LoadJobConfiguration
+     */
+    public function quote($quote)
+    {
+        $this->config['configuration']['load']['quote'] = $quote;
+
+        return $this;
+    }
+
+    /**
+     * Sets the schema for the destination table. The schema can be omitted if
+     * the destination table already exists, or if you're loading data from
+     * Google Cloud Datastore.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->schema([
+     *     'fields' => [
+     *         [
+     *             'name' => 'col1',
+     *             'type' => 'STRING',
+     *         ],
+     *         [
+     *             'name' => 'col2',
+     *             'type' => 'BOOL',
+     *         ]
+     *     ]
+     * ]);
+     * ```
+     *
+     * @param array $schema The table schema.
+     * @return LoadJobConfiguration
+     */
+    public function schema(array $schema)
+    {
+        $this->config['configuration']['load']['schema'] = $schema;
+
+        return $this;
+    }
+
+    /**
+     * Sets options to allow the schema of the destination table to be updated
+     * as a side effect of the query job. Schema update options are supported
+     * in two cases: when writeDisposition is `"WRITE_APPEND"`; when
+     * writeDisposition is `"WRITE_TRUNCATE"` and the destination table is a
+     * partition of a table, specified by partition decorators. For normal
+     * tables, `"WRITE_TRUNCATE"` will always overwrite the schema.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->schemaUpdateOptions([
+     *     'ALLOW_FIELD_ADDITION'
+     * ]);
+     * ```
+     *
+     * @param array $schemaUpdateOptions Schema update options. Acceptable
+     *        values include `"ALLOW_FIELD_ADDITION"` (allow adding a nullable
+     *        field to the schema),  `"ALLOW_FIELD_RELAXATION"` (allow relaxing
+     *        a required field in the original schema to nullable).
+     * @return LoadJobConfiguration
+     */
+    public function schemaUpdateOptions(array $schemaUpdateOptions)
+    {
+        $this->config['configuration']['load']['schemaUpdateOptions'] = $schemaUpdateOptions;
+
+        return $this;
+    }
+
+    /**
+     * Sets the number of rows at the top of a CSV file that BigQuery will skip
+     * when loading the data. This property is useful if you have header rows in
+     * the file that should be skipped.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->skipLeadingRows(10);
+     * ```
+     *
+     * @param int $skipLeadingRows The number of rows to skip.
+     *        **Defaults to** `0`.
+     * @return LoadJobConfiguration
+     */
+    public function skipLeadingRows($skipLeadingRows)
+    {
+        $this->config['configuration']['load']['skipLeadingRows'] = $skipLeadingRows;
+
+        return $this;
+    }
+
+    /**
+     * Sets the format of the data files.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->sourceFormat('NEWLINE_DELIMITED_JSON');
+     * ```
+     *
+     * @param string $sourceFormat The source format. Acceptable values include
+     *        `"CSV"`, `"DATASTORE_BACKUP"`. `"NEWLINE_DELIMITED_JSON"`,
+     *        `"AVRO"`. **Defaults to** `"CSV"`.
+     * @return LoadJobConfiguration
+     */
+    public function sourceFormat($sourceFormat)
+    {
+        $this->config['configuration']['load']['sourceFormat'] = $sourceFormat;
+
+        return $this;
+    }
+
+    /**
+     * Sets the fully-qualified URIs that point to your data in Google Cloud.
+     *
+     * - For Google Cloud Storage URIs: Each URI can contain one '*' wildcard
+     *   character and it must come after the 'bucket' name.
+     * - For Google Cloud Bigtable URIs: Exactly one URI can be specified and it
+     *   has be a fully specified and valid HTTPS URL for a Google Cloud Bigtable
+     *   table.
+     * - For Google Cloud Datastore backups: Exactly one URI can be specified.
+     *   Also, the '*' wildcard character is not allowed.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->sourceUris([
+     *     'gs://my_bucket/source.csv'
+     * ]);
+     * ```
+     *
+     * @param array $sourceUris The source URIs.
+     * @return LoadJobConfiguration
+     */
+    public function sourceUris(array $sourceUris)
+    {
+        $this->config['configuration']['load']['sourceUris'] = $sourceUris;
+
+        return $this;
+    }
+
+    /**
+     * Sets time-based partitioning for the destination table.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->timePartitioning([
+     *     'type' => 'DAY'
+     * ]);
+     * ```
+     *
+     * @param array $timePartitioning Time-based partitioning configuration.
+     * @return LoadJobConfiguration
+     */
+    public function timePartitioning(array $timePartitioning)
+    {
+        $this->config['configuration']['load']['timePartitioning'] = $timePartitioning;
+
+        return $this;
+    }
+
+    /**
+     * Sets the action that occurs if the destination table already exists. Each
+     * action is atomic and only occurs if BigQuery is able to complete the job
+     * successfully. Creation, truncation and append actions occur as one atomic
+     * update upon job completion.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->writeDisposition('WRITE_TRUNCATE');
+     * ```
+     *
+     * @param string $writeDisposition The write disposition. Acceptable values
+     *        include `"WRITE_TRUNCATE"`, `"WRITE_APPEND"`, `"WRITE_EMPTY"`.
+     *        **Defaults to** `"WRITE_APPEND"`.
+     * @return LoadJobConfiguration
+     */
+    public function writeDisposition($writeDisposition)
+    {
+        $this->config['configuration']['load']['writeDisposition'] = $writeDisposition;
+
+        return $this;
+    }
+}

--- a/src/BigQuery/QueryJobConfiguration.php
+++ b/src/BigQuery/QueryJobConfiguration.php
@@ -1,0 +1,453 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+/**
+ * Represents a configuration for a query job. For more information on the
+ * available settings please see the
+ * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration).
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\BigQuery\BigQueryClient;
+ *
+ * $bigQuery = new BigQueryClient();
+ * $query = $bigQuery->query('SELECT commit FROM `bigquery-public-data.github_repos.commits` LIMIT 100');
+ * ```
+ */
+class QueryJobConfiguration implements JobConfigurationInterface
+{
+    use JobConfigurationTrait;
+
+    /**
+     * @var ValueMapper Maps values between PHP and BigQuery.
+     */
+    private $mapper;
+
+    /**
+     * @param ValueMapper $mapper Maps values between PHP and BigQuery.
+     * @param string $projectId The project's ID.
+     * @param array $config A set of configuration options for a job.
+     */
+    public function __construct(ValueMapper $mapper, $projectId, array $config)
+    {
+        $this->mapper = $mapper;
+        $this->jobConfigurationProperties($projectId, $config);
+
+        if (!isset($this->config['configuration']['query']['useLegacySql'])) {
+            $this->config['configuration']['query']['useLegacySql'] = false;
+        }
+    }
+
+    /**
+     * Sets whether or not the query can produce arbitrarily large result
+     * tables at a slight cost in performance. Only applies to queries
+     * performed with legacy SQL dialect and requires a
+     * {@see Google\Cloud\BigQuery\QueryJobConfiguration::destinationTable()} to
+     * be set.
+     *
+     * Example:
+     * ```
+     * $query->allowLargeResults(true);
+     * ```
+     *
+     * @param bool $allowLargeResults Whether or not to allow large result sets.
+     * @return QueryJobConfiguration
+     */
+    public function allowLargeResults($allowLargeResults)
+    {
+        $this->config['configuration']['query']['allowLargeResults'] = $allowLargeResults;
+
+        return $this;
+    }
+
+    /**
+     * Sets whether the job is allowed to create new tables.
+     *
+     * Example:
+     * ```
+     * $query->createDisposition('CREATE_NEVER');
+     * ```
+     *
+     * @param string $createDisposition The create disposition. Acceptable
+     *        values include `"CREATE_IF_NEEDED"`, `"CREATE_NEVER"`.
+     * @return QueryJobConfiguration
+     */
+    public function createDisposition($createDisposition)
+    {
+        $this->config['configuration']['query']['createDisposition'] = $createDisposition;
+
+        return $this;
+    }
+
+    /**
+     * Sets the default dataset to use for unqualified table names in the query.
+     *
+     * Example:
+     * ```
+     * $dataset = $bigQuery->dataset('my_dataset');
+     * $query->defaultDataset($dataset);
+     * ```
+     *
+     * @param Dataset $defaultDataset The default dataset.
+     * @return QueryJobConfiguration
+     */
+    public function defaultDataset(Dataset $defaultDataset)
+    {
+        $this->config['configuration']['query']['defaultDataset'] = $defaultDataset->identity();
+
+        return $this;
+    }
+
+    /**
+     * Sets the custom encryption configuration (e.g., Cloud KMS keys).
+     *
+     * Example:
+     * ```
+     * $query->destinationEncryptionConfiguration([
+     *     'kmsKeyName' => 'my_key'
+     * ]);
+     * ```
+     *
+     * @param array $configuration Custom encryption configuration.
+     * @return QueryJobConfiguration
+     */
+    public function destinationEncryptionConfiguration(array $configuration)
+    {
+        $this->config['configuration']['query']['destinationEncryptionConfiguration'] = $configuration;
+
+        return $this;
+    }
+
+    /**
+     * Sets the table where the query results should be stored. If not set, a
+     * new table will be created to store the results. This property must be set
+     * for large results that exceed the maximum response size.
+     *
+     * Example:
+     * ```
+     * $table = $bigQuery->dataset('my_dataset')
+     *     ->table('my_table');
+     * $query->destinationTable($table);
+     * ```
+     *
+     * @param Table $destinationTable The destination table.
+     * @return QueryJobConfiguration
+     */
+    public function destinationTable(Table $destinationTable)
+    {
+        $this->config['configuration']['query']['destinationTable'] = $destinationTable->identity();
+
+        return $this;
+    }
+
+    /**
+     * Sets whether or not to flatten all nested and repeated fields in the
+     * query results. Only applies to queries performed with legacy SQL dialect.
+     * {@see Google\Cloud\BigQuery\QueryJobConfiguration::allowLargeResults()}
+     * must be true if this is set to false.
+     *
+     * Example:
+     * ```
+     * $query->useLegacySql(true)
+     *     ->flattenResults(true);
+     * ```
+     *
+     * @param bool $flattenResults Whether or not to flatten results.
+     * @return QueryJobConfiguration
+     */
+    public function flattenResults($flattenResults)
+    {
+        $this->config['configuration']['query']['flattenResults'] = $flattenResults;
+
+        return $this;
+    }
+
+    /**
+     * Sets the billing tier limit for this job. Queries that have resource
+     * usage beyond this tier will fail (without incurring a charge). If
+     * unspecified, this will be set to your project default.
+     *
+     * Example:
+     * ```
+     * $query->maximumBillingTier(1);
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/pricing#high-compute High-Compute queries
+     *
+     * @param int $maximumBillingTier The maximum billing tier.
+     * @return QueryJobConfiguration
+     */
+    public function maximumBillingTier($maximumBillingTier)
+    {
+        $this->config['configuration']['query']['maximumBillingTier'] = $maximumBillingTier;
+
+        return $this;
+    }
+
+    /**
+     * Sets a bytes billed limit for this job. Queries that will have bytes
+     * billed beyond this limit will fail (without incurring a charge). If
+     * unspecified, this will be set to your project default.
+     *
+     * Example:
+     * ```
+     * $query->maximumBytesBilled(3000);
+     * ```
+     *
+     * @param int $maximumBytesBilled The maximum allowable bytes to bill.
+     * @return QueryJobConfiguration
+     */
+    public function maximumBytesBilled($maximumBytesBilled)
+    {
+        $this->config['configuration']['query']['maximumBytesBilled'] = $maximumBytesBilled;
+
+        return $this;
+    }
+
+    /**
+     * Sets parameters to be used on the query. Only available for standard SQL
+     * queries.
+     *
+     * For examples of usage please see
+     * {@see Google\Cloud\BigQuery\BigQueryClient::runQuery()}.
+     *
+     * @param array $parameters Parameters to use on the query. When providing
+     *        a non-associative array positional parameters (`?`) will be used.
+     *        When providing an associative array named parameters will be used
+     *        (`@name`).
+     * @return QueryJobConfiguration
+     */
+    public function parameters(array $parameters)
+    {
+        $queryParams = [];
+        $this->config['configuration']['query']['parameterMode'] = $this->isAssoc($parameters)
+            ? 'named'
+            : 'positional';
+
+        foreach ($parameters as $name => $value) {
+            $param = $this->mapper->toParameter($value);
+
+            if ($this->config['configuration']['query']['parameterMode'] === 'named') {
+                $param += ['name' => $name];
+            }
+
+            $queryParams[] = $param;
+        }
+
+        $this->config['configuration']['query']['queryParameters'] = $queryParams;
+
+        return $this;
+    }
+
+    /**
+     * Sets a priority for the query.
+     *
+     * Example:
+     * ```
+     * $query->priority('BATCH');
+     * ```
+     *
+     * @param string $priority The priority. Acceptable values include
+     *        `"INTERACTIVE"`, `"BATCH"`. **Defaults to** `"INTERACTIVE"`.
+     * @return QueryJobConfiguration
+     */
+    public function priority($priority)
+    {
+        $this->config['configuration']['query']['priority'] = $priority;
+
+        return $this;
+    }
+
+    /**
+     * Sets the SQL query.
+     *
+     * Example:
+     * ```
+     * $query->query(
+     *     'SELECT commit FROM `bigquery-public-data.github_repos.commits` LIMIT 100'
+     * );
+     * ```
+     *
+     * @param string $query SQL query text to execute.
+     * @return QueryJobConfiguration
+     */
+    public function query($query)
+    {
+        $this->config['configuration']['query']['query'] = $query;
+
+        return $this;
+    }
+
+    /**
+     * Sets options to allow the schema of the destination table to be updated
+     * as a side effect of the query job. Schema update options are supported
+     * in two cases: when writeDisposition is `"WRITE_APPEND"`; when
+     * writeDisposition is `"WRITE_TRUNCATE"` and the destination table is a
+     * partition of a table, specified by partition decorators. For normal
+     * tables, `"WRITE_TRUNCATE"` will always overwrite the schema.
+     *
+     * Example:
+     * ```
+     * $query->schemaUpdateOptions([
+     *     'ALLOW_FIELD_ADDITION'
+     * ]);
+     * ```
+     *
+     * @param array $schemaUpdateOptions Schema update options. Acceptable
+     *        values include `"ALLOW_FIELD_ADDITION"` (allow adding a nullable
+     *        field to the schema),  `"ALLOW_FIELD_RELAXATION"` (allow relaxing
+     *        a required field in the original schema to nullable).
+     * @return QueryJobConfiguration
+     */
+    public function schemaUpdateOptions(array $schemaUpdateOptions)
+    {
+        $this->config['configuration']['query']['schemaUpdateOptions'] = $schemaUpdateOptions;
+
+        return $this;
+    }
+
+    /**
+     * Sets table definitions for querying an external data source outside of
+     * BigQuery. Describes the data format, location and other properties of the
+     * data source.
+     *
+     * Example:
+     * ```
+     * $query->tableDefinitions([
+     *     'autodetect' => true,
+     *     'sourceUris' => [
+     *         'gs://my_bucket/table.json'
+     *     ]
+     * ]);
+     * ```
+     *
+     * @param array $tableDefinitions The table definitions.
+     * @return QueryJobConfiguration
+     */
+    public function tableDefinitions(array $tableDefinitions)
+    {
+        $this->config['configuration']['query']['tableDefinitions'] = $tableDefinitions;
+
+        return $this;
+    }
+
+    /**
+     * Sets time-based partitioning for the destination table.
+     *
+     * Example:
+     * ```
+     * $query->timePartitioning([
+     *     'type' => 'DAY'
+     * ]);
+     * ```
+     *
+     * @param array $timePartitioning Time-based partitioning configuration.
+     * @return QueryJobConfiguration
+     */
+    public function timePartitioning(array $timePartitioning)
+    {
+        $this->config['configuration']['query']['timePartitioning'] = $timePartitioning;
+
+        return $this;
+    }
+
+    /**
+     * Sets whether or not to use legacy SQL dialect. When not set, defaults to
+     * false in this client.
+     *
+     * Example:
+     * ```
+     * $query->useLegacySql(true);
+     * ```
+     *
+     * @param bool $useLegacySql Whether or not to use legacy SQL dialect.
+     * @return QueryJobConfiguration
+     */
+    public function useLegacySql($useLegacySql)
+    {
+        $this->config['configuration']['query']['useLegacySql'] = $useLegacySql;
+
+        return $this;
+    }
+
+    /**
+     * Sets whether or not to use the query cache.
+     *
+     * Example:
+     * ```
+     * $query->useQueryCache(true);
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/querying-data#query-caching Query Caching
+     *
+     * @param bool $useQueryCache Whether or not to use the query cache.
+     * @return QueryJobConfiguration
+     */
+    public function useQueryCache($useQueryCache)
+    {
+        $this->config['configuration']['query']['useQueryCache'] = $useQueryCache;
+
+        return $this;
+    }
+
+    /**
+     * Sets user-defined function resources used in the query.
+     *
+     * Example:
+     * ```
+     * $query->userDefinedFunctionResources([
+     *     ['resourceUri' => 'gs://my_bucket/code_path']
+     * ]);
+     * ```
+     *
+     * @param array $userDefinedFunctionResources User-defined function
+     *        resources used in the query. This is to be formatted as a list of
+     *        sub-arrays containing either a key `resourceUri` or `inlineCode`.
+     * @return QueryJobConfiguration
+     */
+    public function userDefinedFunctionResources(array $userDefinedFunctionResources)
+    {
+        $this->config['configuration']['query']['userDefinedFunctionResources'] = $userDefinedFunctionResources;
+
+        return $this;
+    }
+
+    /**
+     * Sets the action that occurs if the destination table already exists. Each
+     * action is atomic and only occurs if BigQuery is able to complete the job
+     * successfully. Creation, truncation and append actions occur as one atomic
+     * update upon job completion.
+     *
+     * Example:
+     * ```
+     * $query->writeDisposition('WRITE_TRUNCATE');
+     * ```
+     *
+     * @param string $writeDisposition The write disposition. Acceptable values
+     *        include `"WRITE_TRUNCATE"`, `"WRITE_APPEND"`, `"WRITE_EMPTY"`.
+     *        **Defaults to** `"WRITE_EMPTY"`.
+     * @return QueryJobConfiguration
+     */
+    public function writeDisposition($writeDisposition)
+    {
+        $this->config['configuration']['query']['writeDisposition'] = $writeDisposition;
+
+        return $this;
+    }
+}

--- a/src/BigQuery/QueryResults.php
+++ b/src/BigQuery/QueryResults.php
@@ -30,7 +30,7 @@ use Google\Cloud\Core\Iterator\PageIterator;
  * calling {@see Google\Cloud\BigQuery\BigQueryClient::runQuery()} or
  * {@see Google\Cloud\BigQuery\Job::queryResults()}.
  */
-class QueryResults
+class QueryResults implements \IteratorAggregate
 {
     /**
      * @var ConnectionInterface Represents a connection to BigQuery.
@@ -53,17 +53,11 @@ class QueryResults
     private $mapper;
 
     /**
-     * @var array The options to use when reloading query data.
-     */
-    private $reloadOptions;
-
-    /**
      * @param ConnectionInterface $connection Represents a connection to
      *        BigQuery.
      * @param string $jobId The job's ID.
      * @param string $projectId The project's ID.
      * @param array $info The query result's metadata.
-     * @param array $reloadOptions The options to use when reloading query data.
      * @param ValueMapper $mapper Maps values between PHP and BigQuery.
      */
     public function __construct(
@@ -71,12 +65,10 @@ class QueryResults
         $jobId,
         $projectId,
         array $info,
-        array $reloadOptions,
         ValueMapper $mapper
     ) {
         $this->connection = $connection;
         $this->info = $info;
-        $this->reloadOptions = $reloadOptions;
         $this->identity = [
             'jobId' => $jobId,
             'projectId' => $projectId
@@ -86,8 +78,7 @@ class QueryResults
 
     /**
      * Retrieves the rows associated with the query and merges them together
-     * with the table's schema. It is recommended to check the completeness of
-     * the query before attempting to access rows.
+     * with the table's schema.
      *
      * Refer to the table below for a guide on how BigQuery types are mapped as
      * they come back from the API.
@@ -109,27 +100,19 @@ class QueryResults
      *
      * Example:
      * ```
-     * $isComplete = $queryResults->isComplete();
+     * $rows = $queryResults->rows();
      *
-     * if ($isComplete) {
-     *     $rows = $queryResults->rows();
-     *
-     *     foreach ($rows as $row) {
-     *         echo $row['name'] . PHP_EOL;
-     *     }
+     * foreach ($rows as $row) {
+     *     echo $row['name'] . PHP_EOL;
      * }
      * ```
      *
      * @param array $options [optional] Configuration options.
      * @return ItemIterator
-     * @throws GoogleException Thrown if the query has not yet completed.
+     * @throws GoogleException Thrown in the case of a malformed response.
      */
     public function rows(array $options = [])
     {
-        if (!$this->isComplete()) {
-            throw new GoogleException('The query has not completed yet.');
-        }
-
         $schema = $this->info['schema']['fields'];
 
         return new ItemIterator(
@@ -164,30 +147,6 @@ class QueryResults
     }
 
     /**
-     * Checks the query's completeness. Useful in combination with
-     * {@see Google\Cloud\BigQuery\QueryResults::reload()} to poll for query status.
-     *
-     * Example:
-     * ```
-     * $isComplete = $queryResults->isComplete();
-     *
-     * while (!$isComplete) {
-     *     sleep(1); // small delay between requests
-     *     $queryResults->reload();
-     *     $isComplete = $queryResults->isComplete();
-     * }
-     *
-     * echo 'Query complete!';
-     * ```
-     *
-     * @return bool
-     */
-    public function isComplete()
-    {
-        return $this->info['jobComplete'];
-    }
-
-    /**
      * Retrieves the cached query details.
      *
      * Example:
@@ -209,20 +168,9 @@ class QueryResults
     /**
      * Triggers a network request to reload the query's details.
      *
-     * Useful when needing to poll an incomplete query
-     * for status. Configuration options will be inherited from
-     * {@see Google\Cloud\BigQuery\Job::queryResults()} or
-     * {@see Google\Cloud\BigQuery\BigQueryClient::runQuery()}, but they can be
-     * overridden if needed.
-     *
      * Example:
      * ```
-     * $queryResults->isComplete(); // returns false
-     * sleep(1); // let's wait for a moment...
-     * $queryResults->reload(); // executes a network request
-     * if ($queryResults->isComplete()) {
-     *     echo "Query complete!";
-     * }
+     * $queryResults->reload();
      * ```
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs/getQueryResults
@@ -240,8 +188,9 @@ class QueryResults
      */
     public function reload(array $options = [])
     {
-        $options += $this->identity;
-        return $this->info = $this->connection->getQueryResults($options + $this->reloadOptions);
+        return $this->info = $this->connection->getQueryResults(
+            $options + $this->identity
+        );
     }
 
     /**
@@ -259,5 +208,26 @@ class QueryResults
     public function identity()
     {
         return $this->identity;
+    }
+
+    /**
+     * Checks the query's completeness.
+     *
+     * @access private
+     * @return bool
+     */
+    public function isComplete()
+    {
+        return $this->info['jobComplete'];
+    }
+
+    /**
+     * @access private
+     * @return ItemIterator
+     * @throws GoogleException Thrown in the case of a malformed response.
+     */
+    public function getIterator()
+    {
+        return $this->rows();
     }
 }

--- a/src/BigQuery/Table.php
+++ b/src/BigQuery/Table.php
@@ -18,7 +18,6 @@
 namespace Google\Cloud\BigQuery;
 
 use Google\Cloud\BigQuery\Connection\ConnectionInterface;
-use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\ConcurrencyControlTrait;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Iterator\ItemIterator;
@@ -33,7 +32,6 @@ use Psr\Http\Message\StreamInterface;
  */
 class Table
 {
-    use ArrayTrait;
     use ConcurrencyControlTrait;
     use JobConfigurationTrait;
 
@@ -240,6 +238,8 @@ class Table
      *     @type array $jobConfig Configuration settings for a copy job are
      *           outlined in the [API Docs for `configuration.copy`](https://goo.gl/m8dro9).
      *           If not provided default settings will be used.
+     *     @type string $jobIdPrefix If given, the returned job ID will be of
+     *           format `{$jobIdPrefix-}{jobId}`. **Defaults to** `null`.
      * }
      * @return Job
      */
@@ -288,6 +288,8 @@ class Table
      *     @type array $jobConfig Configuration settings for an extract job are
      *           outlined in the [API Docs for `configuration.extract`](https://goo.gl/SQ9XAE).
      *           If not provided default settings will be used.
+     *     @type string $jobIdPrefix If given, the returned job ID will be of
+     *           format `{$jobIdPrefix-}{jobId}`. **Defaults to** `null`.
      * }
      * @return Job
      */
@@ -335,6 +337,8 @@ class Table
      *     @type array $jobConfig Configuration settings for a load job are
      *           outlined in the [API Docs for `configuration.load`](https://goo.gl/j6jyHv).
      *           If not provided default settings will be used.
+     *     @type string $jobIdPrefix If given, the returned job ID will be of
+     *           format `{$jobIdPrefix-}{jobId}`. **Defaults to** `null`.
      * }
      * @return Job
      */

--- a/src/BigQuery/Table.php
+++ b/src/BigQuery/Table.php
@@ -18,10 +18,13 @@
 namespace Google\Cloud\BigQuery;
 
 use Google\Cloud\BigQuery\Connection\ConnectionInterface;
+use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\ConcurrencyControlTrait;
+use Google\Cloud\Core\Exception\ConflictException;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Core\Iterator\PageIterator;
+use Google\Cloud\Core\RetryDeciderTrait;
 use Google\Cloud\Storage\StorageObject;
 use Psr\Http\Message\StreamInterface;
 
@@ -32,8 +35,12 @@ use Psr\Http\Message\StreamInterface;
  */
 class Table
 {
+    const MAX_RETRIES = 100;
+    const INSERT_CREATE_MAX_DELAY_MICROSECONDS = 60000000;
+
+    use ArrayTrait;
     use ConcurrencyControlTrait;
-    use JobConfigurationTrait;
+    use RetryDeciderTrait;
 
     /**
      * @var ConnectionInterface Represents a connection to BigQuery.
@@ -80,6 +87,11 @@ class Table
             'datasetId' => $datasetId,
             'projectId' => $projectId
         ];
+        $this->setHttpRetryCodes([]);
+        $this->setHttpRetryMessages([
+            'rateLimitExceeded',
+            'backendError'
+        ]);
     }
 
     /**
@@ -108,6 +120,9 @@ class Table
     /**
      * Delete the table.
      *
+     * Please note that by default the library will not attempt to retry this
+     * call on your behalf.
+     *
      * Example:
      * ```
      * $table->delete();
@@ -119,7 +134,11 @@ class Table
      */
     public function delete(array $options = [])
     {
-        $this->connection->deleteTable($options + $this->identity);
+        $this->connection->deleteTable(
+            $options
+            + ['retries' => 0]
+            + $this->identity
+        );
     }
 
     /**
@@ -129,6 +148,9 @@ class Table
      * update protection. This is useful in preventing override of modifications
      * made by another user. The resource's current etag can be obtained via a
      * GET request on the resource.
+     *
+     * Please note that by default the library will not automatically retry this
+     * call on your behalf unless an `etag` is set.
      *
      * Example:
      * ```
@@ -146,12 +168,17 @@ class Table
      */
     public function update(array $metadata, array $options = [])
     {
-        $options += $metadata;
-        $this->info = $this->connection->patchTable(
-            $this->applyEtagHeader($options + $this->identity)
+        $options = $this->applyEtagHeader(
+            $options
+            + $metadata
+            + $this->identity
         );
 
-        return $this->info;
+        if (!isset($options['etag']) && !isset($options['retries'])) {
+            $options['retries'] = 0;
+        }
+
+        return $this->info = $this->connection->patchTable($options);
     }
 
     /**
@@ -219,47 +246,64 @@ class Table
     }
 
     /**
-     * Runs a copy job which copies this table to a specified destination table.
+     * Starts a job in an synchronous fashion, waiting for the job to complete
+     * before returning.
      *
      * Example:
      * ```
-     * $sourceTable = $bigQuery->dataset('myDataset')->table('mySourceTable');
-     * $destinationTable = $bigQuery->dataset('myDataset')->table('myDestinationTable');
-     *
-     * $job = $sourceTable->copy($destinationTable);
+     * $job = $table->runJob($jobConfig);
+     * echo $job->isComplete(); // true
      * ```
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
      *
-     * @param Table $destination The destination table.
+     * @param JobConfigurationInterface $config The job configuration.
      * @param array $options [optional] {
      *     Configuration options.
      *
-     *     @type array $jobConfig Configuration settings for a copy job are
-     *           outlined in the [API Docs for `configuration.copy`](https://goo.gl/m8dro9).
-     *           If not provided default settings will be used.
-     *     @type string $jobIdPrefix If given, the returned job ID will be of
-     *           format `{$jobIdPrefix-}{jobId}`. **Defaults to** `null`.
+     *     @type int $maxRetries The number of times to retry, checking if the
+     *           job has completed. **Defaults to** `100`.
      * }
      * @return Job
      */
-    public function copy(Table $destination, array $options = [])
+    public function runJob(JobConfigurationInterface $config, array $options = [])
     {
-        $config = $this->buildJobConfig(
-            'copy',
-            $this->identity['projectId'],
-            [
-                'destinationTable' => $destination->identity(),
-                'sourceTable' => $this->identity
-            ],
-            $options
-        );
+        $maxRetries = $this->pluck('maxRetries', $options, false);
+        $job = $this->startJob($config, $options);
+        $job->waitUntilComplete(['maxRetries' => $maxRetries]);
 
-        $response = $this->connection->insertJob($config);
+        return $job;
+    }
+
+    /**
+     * Starts a job in an asynchronous fashion. In this case, it will be
+     * required to manually trigger a call to wait for job completion.
+     *
+     * Example:
+     * ```
+     * $job = $table->startJob($jobConfig);
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     *
+     * @param JobConfigurationInterface $config The job configuration.
+     * @param array $options [optional] Configuration options.
+     * @return Job
+     */
+    public function startJob(JobConfigurationInterface $config, array $options = [])
+    {
+        $response = null;
+        $config = $config->toArray() + $options;
+
+        if (isset($config['data'])) {
+            $response = $this->connection->insertJobUpload($config)->upload();
+        } else {
+            $response = $this->connection->insertJob($config);
+        }
 
         return new Job(
             $this->connection,
-            $response['jobReference']['jobId'],
+            $config['jobReference']['jobId'],
             $this->identity['projectId'],
             $this->mapper,
             $response
@@ -267,13 +311,52 @@ class Table
     }
 
     /**
-     * Runs an extract job which exports the contents of a table to Cloud
-     * Storage.
+     * Returns a copy job configuration to be passed to either
+     * {@see Google\Cloud\BigQuery\Table::runJob()} or
+     * {@see Google\Cloud\BigQuery\Table::startJob()}. A
+     * configuration can be built using fluent setters or by providing a full
+     * set of options at once.
+     *
+     * Example:
+     * ```
+     * $sourceTable = $bigQuery->dataset('myDataset')
+     *     ->table('mySourceTable');
+     * $destinationTable = $bigQuery->dataset('myDataset')
+     *     ->table('myDestinationTable');
+     *
+     * $copyJobConfig = $sourceTable->copy($destinationTable);
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
+     *
+     * @param Table $destination The destination table.
+     * @param array $options [optional] Please see the
+     *        [upstream API documentation for Job configuration]
+     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
+     *        for the available options.
+     * @return CopyJobConfiguration
+     */
+    public function copy(Table $destination, array $options = [])
+    {
+        return (new CopyJobConfiguration(
+            $this->identity['projectId'],
+            $options
+        ))
+            ->destinationTable($destination)
+            ->sourceTable($this);
+    }
+
+    /**
+     * Returns an extract job configuration to be passed to either
+     * {@see Google\Cloud\BigQuery\Table::runJob()} or
+     * {@see Google\Cloud\BigQuery\Table::startJob()}. A
+     * configuration can be built using fluent setters or by providing a full
+     * set of options at once.
      *
      * Example:
      * ```
      * $destinationObject = $storage->bucket('myBucket')->object('tableOutput');
-     * $job = $table->export($destinationObject);
+     * $extractJobConfig = $table->extract($destinationObject);
      * ```
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
@@ -282,100 +365,73 @@ class Table
      *        a {@see Google\Cloud\Storage\StorageObject} or a URI pointing to
      *        a Google Cloud Storage object in the format of
      *        `gs://{bucket-name}/{object-name}`.
-     * @param array $options [optional] {
-     *     Configuration options.
-     *
-     *     @type array $jobConfig Configuration settings for an extract job are
-     *           outlined in the [API Docs for `configuration.extract`](https://goo.gl/SQ9XAE).
-     *           If not provided default settings will be used.
-     *     @type string $jobIdPrefix If given, the returned job ID will be of
-     *           format `{$jobIdPrefix-}{jobId}`. **Defaults to** `null`.
-     * }
-     * @return Job
+     * @param array $options [optional] Please see the
+     *        [upstream API documentation for Job configuration]
+     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
+     *        for the available options.
+     * @return ExportJobConfiguration
      */
-    public function export($destination, array $options = [])
+    public function extract($destination, array $options = [])
     {
         if ($destination instanceof StorageObject) {
             $destination = $destination->gcsUri();
         }
 
-        $config = $this->buildJobConfig(
-            'extract',
+        return (new ExtractJobConfiguration(
             $this->identity['projectId'],
-            [
-                'sourceTable' => $this->identity,
-                'destinationUris' => [$destination]
-            ],
             $options
-        );
-
-        $response = $this->connection->insertJob($config);
-
-        return new Job(
-            $this->connection,
-            $response['jobReference']['jobId'],
-            $this->identity['projectId'],
-            $this->mapper,
-            $response
-        );
+        ))
+            ->destinationUris([$destination])
+            ->sourceTable($this);
     }
 
     /**
-     * Runs a load job which loads the provided data into the table.
+     * Returns a load job configuration to be passed to either
+     * {@see Google\Cloud\BigQuery\Table::runJob()} or
+     * {@see Google\Cloud\BigQuery\Table::startJob()}. A
+     * configuration can be built using fluent setters or by providing a full
+     * set of options at once.
      *
      * Example:
      * ```
-     * $job = $table->load(fopen('/path/to/my/data.csv', 'r'));
+     * $loadJobConfig = $table->load(fopen('/path/to/my/data.csv', 'r'));
      * ```
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
      *
      * @param string|resource|StreamInterface $data The data to load.
-     * @param array $options [optional] {
-     *     Configuration options.
-     *
-     *     @type array $jobConfig Configuration settings for a load job are
-     *           outlined in the [API Docs for `configuration.load`](https://goo.gl/j6jyHv).
-     *           If not provided default settings will be used.
-     *     @type string $jobIdPrefix If given, the returned job ID will be of
-     *           format `{$jobIdPrefix-}{jobId}`. **Defaults to** `null`.
-     * }
-     * @return Job
+     * @param array $options [optional] Please see the
+     *        [upstream API documentation for Job configuration]
+     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
+     *        for the available options.
+     * @return LoadJobConfiguration
      */
     public function load($data, array $options = [])
     {
-        $response = null;
-        $config = $this->buildJobConfig(
-            'load',
+        $config = (new LoadJobConfiguration(
             $this->identity['projectId'],
-            ['destinationTable' => $this->identity],
             $options
-        );
+        ))
+            ->destinationTable($this);
 
         if ($data) {
-            $config['data'] = $data;
-            $response = $this->connection->insertJobUpload($config)->upload();
-        } else {
-            $response = $this->connection->insertJob($config);
+            $config->data($data);
         }
 
-        return new Job(
-            $this->connection,
-            $response['jobReference']['jobId'],
-            $this->identity['projectId'],
-            $this->mapper,
-            $response
-        );
+        return $config;
     }
 
     /**
-     * Runs a load job which loads data from a file in a Storage bucket into the
-     * table.
+     * Returns a load job configuration to be passed to either
+     * {@see Google\Cloud\BigQuery\Table::runJob()} or
+     * {@see Google\Cloud\BigQuery\Table::startJob()}. A
+     * configuration can be built using fluent setters or by providing a full
+     * set of options at once.
      *
      * Example:
      * ```
      * $object = $storage->bucket('myBucket')->object('important-data.csv');
-     * $job = $table->load($object);
+     * $loadJobConfig = $table->loadFromStorage($object);
      * ```
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs insert API Documentation.
@@ -384,14 +440,11 @@ class Table
      *        a {@see Google\Cloud\Storage\StorageObject} or a URI pointing to a
      *        Google Cloud Storage object in the format of
      *        `gs://{bucket-name}/{object-name}`.
-     * @param array $options [optional] {
-     *     Configuration options.
-     *
-     *     @type array $jobConfig Configuration settings for a load job are
-     *           outlined in the [API Docs for `configuration.load`](https://goo.gl/j6jyHv).
-     *           If not provided default settings will be used.
-     * }
-     * @return Job
+     * @param array $options [optional] Please see the
+     *        [upstream API documentation for Job configuration]
+     *        (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
+     *        for the available options.
+     * @return LoadJobConfiguration
      */
     public function loadFromStorage($object, array $options = [])
     {
@@ -399,13 +452,16 @@ class Table
             $object = $object->gcsUri();
         }
 
-        $options['jobConfig']['sourceUris'] = [$object];
+        $options['configuration']['load']['sourceUris'] = [$object];
 
         return $this->load(null, $options);
     }
 
     /**
      * Insert a record into the table without running a load job.
+     *
+     * Please note that by default the library will not automatically retry this
+     * call on your behalf unless an `insertId` is set.
      *
      * Example:
      * ```
@@ -461,6 +517,9 @@ class Table
     /**
      * Insert records into the table without running a load job.
      *
+     * Please note that by default the library will not automatically retry this
+     * call on your behalf unless an `insertId` is set.
+     *
      * Example:
      * ```
      * $rows = [
@@ -505,6 +564,19 @@ class Table
      * @param array $options [optional] {
      *     Configuration options.
      *
+     *     @type bool $autoCreate Whether or not to attempt to automatically
+     *           create the table in the case it does not exist. Please note, it
+     *           will be required to provide a schema through
+     *           $tableMetadata['schema'] in the case the table does not already
+     *           exist. **Defaults to** `false`.
+     *     @type $tableMetadata Metadata to apply to table to be created. The
+     *           full set of metadata are outlined at the
+     *           [Table Resource API docs](https://cloud.google.com/bigquery/docs/reference/v2/tables#resource).
+     *           Only applies when `autoCreate` is `true`.
+     *     @type $maxRetries The maximum number of times to attempt creating the
+     *           table in the case of failure. Please note, each retry attempt
+     *           may take up to two minutes. Only applies when `autoCreate` is
+     *           `true`. **Defaults to** `100`.
      *     @type bool $skipInvalidRows Insert all valid rows of a request, even
      *           if invalid rows exist. The default value is `false`, which
      *           causes the entire request to fail if any invalid rows exist.
@@ -522,14 +594,24 @@ class Table
      *           for considerations when working with templates tables.
      * }
      * @return InsertResponse
-     * @throws \InvalidArgumentException
+     * @throws \InvalidArgumentException If a provided row does not contain a
+     *         `data` key, if a schema is not defined when `autoCreate` is
+     *         `true`, or if less than 1 row is provided.
      * @codingStandardsIgnoreEnd
      */
     public function insertRows(array $rows, array $options = [])
     {
+        if (count($rows) === 0) {
+            throw new \InvalidArgumentException('Must provide at least a single row.');
+        }
+
         foreach ($rows as $row) {
             if (!isset($row['data'])) {
                 throw new \InvalidArgumentException('A row must have a data key.');
+            }
+
+            if (!isset($options['retries']) && !isset($row['insertId'])) {
+                $options['retries'] = 0;
             }
 
             foreach ($row['data'] as $key => $item) {
@@ -542,7 +624,7 @@ class Table
         }
 
         return new InsertResponse(
-            $this->connection->insertAllTableData($this->identity + $options),
+            $this->handleInsert($options),
             $options['rows']
         );
     }
@@ -621,5 +703,69 @@ class Table
     public function identity()
     {
         return $this->identity;
+    }
+
+    /**
+     * Delay execution in microseconds.
+     *
+     * @param int $microSeconds
+     */
+    protected function usleep($microSeconds)
+    {
+        usleep($microSeconds);
+    }
+
+    /**
+     * Handles inserting table data and manages custom retry logic in the case
+     * a table needs to be created.
+     *
+     * @param array $options Configuration options.
+     * @return array
+     */
+    private function handleInsert(array $options)
+    {
+        $attempt = 0;
+        $metadata = $this->pluck('tableMetadata', $options, false) ?: [];
+        $autoCreate = $this->pluck('autoCreate', $options, false) ?: false;
+        $maxRetries = $this->pluck('maxRetries', $options, false) ?: self::MAX_RETRIES;
+
+        while (true) {
+            try {
+                return $this->connection->insertAllTableData(
+                    $this->identity + $options
+                );
+            } catch (NotFoundException $ex) {
+                if ($autoCreate === true && $attempt <= $maxRetries) {
+                    if (!isset($metadata['schema'])) {
+                        throw new \InvalidArgumentException(
+                            'A schema is required when creating a table.'
+                        );
+                    }
+
+                    $this->usleep(mt_rand(1, self::INSERT_CREATE_MAX_DELAY_MICROSECONDS));
+
+                    try {
+                        $this->connection->insertTable($metadata + [
+                            'projectId' => $this->identity['projectId'],
+                            'datasetId' => $this->identity['datasetId'],
+                            'tableReference' => $this->identity,
+                            'retries' => 0
+                        ]);
+                    } catch (ConflictException $ex) {
+                    } catch (\Exception $ex) {
+                        $retryFunction = $this->getRetryFunction();
+
+                        if (!$retryFunction($ex)) {
+                            throw $ex;
+                        }
+                    }
+
+                    $this->usleep(self::INSERT_CREATE_MAX_DELAY_MICROSECONDS);
+                    $attempt++;
+                } else {
+                    throw $ex;
+                }
+            }
+        }
     }
 }

--- a/src/BigQuery/composer.json
+++ b/src/BigQuery/composer.json
@@ -4,7 +4,8 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.0"
+        "google/cloud-core": "^1.0",
+        "ramsey/uuid": "~3"
     },
     "suggest": {
         "google/cloud-storage": "Makes it easier to load data from Cloud Storage into BigQuery"

--- a/src/Core/ArrayTrait.php
+++ b/src/Core/ArrayTrait.php
@@ -53,7 +53,7 @@ trait ArrayTrait
      *
      * @param string $keys
      * @param array $arr
-     * @return string
+     * @return array
      */
     private function pluckArray(array $keys, &$arr)
     {

--- a/src/Core/ConcurrencyControlTrait.php
+++ b/src/Core/ConcurrencyControlTrait.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core;
+
+/**
+ * Methods to control concurrent updates.
+ */
+trait ConcurrencyControlTrait
+{
+    /**
+     * Apply the If-Match header to requests requiring concurrency control.
+     *
+     * @param array $options
+     * @param string $argName
+     * @return array
+     */
+    private function applyEtagHeader(array $options, $argName = 'etag')
+    {
+        if (isset($options[$argName])) {
+            if (!isset($options['restOptions'])) {
+                $options['restOptions'] = [];
+            }
+
+            if (!isset($options['restOptions']['headers'])) {
+                $options['restOptions']['headers'] = [];
+            }
+
+            $options['restOptions']['headers']['If-Match'] = $options[$argName];
+        }
+
+        return $options;
+    }
+}

--- a/src/Core/RetryDeciderTrait.php
+++ b/src/Core/RetryDeciderTrait.php
@@ -77,4 +77,20 @@ trait RetryDeciderTrait
             return false;
         };
     }
+
+    /**
+     * @param array $codes
+     */
+    private function setHttpRetryCodes(array $codes)
+    {
+        $this->httpRetryCodes = $codes;
+    }
+
+    /**
+     * @param array $messages
+     */
+    private function setHttpRetryMessages(array $messages)
+    {
+        $this->httpRetryMessages = $messages;
+    }
 }

--- a/tests/snippets/BigQuery/BigQueryClientTest.php
+++ b/tests/snippets/BigQuery/BigQueryClientTest.php
@@ -36,6 +36,8 @@ use Prophecy\Argument;
  */
 class BigQueryClientTest extends SnippetTestCase
 {
+    const JOBID = 'myJobId';
+
     private $connection;
     private $client;
     private $result = [
@@ -63,7 +65,7 @@ class BigQueryClientTest extends SnippetTestCase
     public function setUp()
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
-        $this->client = \Google\Cloud\Dev\stub(BigQueryClient::class);
+        $this->client = \Google\Cloud\Dev\stub(BigQueryTestClient::class);
         $this->client->___setProperty('connection', $this->connection->reveal());
     }
 
@@ -106,6 +108,7 @@ class BigQueryClientTest extends SnippetTestCase
         $this->connection
             ->insertJob([
                 'projectId' => 'my-awesome-project',
+                'jobReference' => ['projectId' => 'my-awesome-project', 'jobId' => self::JOBID],
                 'configuration' => [
                     'query' => [
                         'parameterMode' => 'named',
@@ -159,6 +162,7 @@ class BigQueryClientTest extends SnippetTestCase
         $this->connection
             ->insertJob([
                 'projectId' => 'my-awesome-project',
+                'jobReference' => ['projectId' => 'my-awesome-project', 'jobId' => self::JOBID],
                 'configuration' => [
                     'query' => [
                         'parameterMode' => 'positional',
@@ -349,5 +353,13 @@ class BigQueryClientTest extends SnippetTestCase
         $res = $snippet->invoke('timestamp');
 
         $this->assertInstanceOf(Timestamp::class, $res->returnVal());
+    }
+}
+
+class BigQueryTestClient extends BigQueryClient
+{
+    protected function generateJobId($jobIdPrefix = null)
+    {
+        return $jobIdPrefix ? $jobIdPrefix . '-' . BigQueryClientTest::JOBID : BigQueryClientTest::JOBID;
     }
 }

--- a/tests/snippets/BigQuery/BigQueryClientTest.php
+++ b/tests/snippets/BigQuery/BigQueryClientTest.php
@@ -79,7 +79,6 @@ class BigQueryClientTest extends SnippetTestCase
     {
         $snippet = $this->snippetFromMethod(BigQueryClient::class, 'runQuery');
         $snippet->addLocal('bigQuery', $this->client);
-        $snippet->replace('sleep(1);', '');
         $this->connection->query(Argument::any())
             ->shouldBeCalled()
             ->willReturn([
@@ -102,7 +101,6 @@ class BigQueryClientTest extends SnippetTestCase
     {
         $snippet = $this->snippetFromMethod(BigQueryClient::class, 'runQuery', 1);
         $snippet->addLocal('bigQuery', $this->client);
-        $snippet->replace('sleep(1);', '');
         $this->connection
             ->query(Argument::withEntry('queryParameters', [
                 [
@@ -145,7 +143,6 @@ class BigQueryClientTest extends SnippetTestCase
     {
         $snippet = $this->snippetFromMethod(BigQueryClient::class, 'runQuery', 2);
         $snippet->addLocal('bigQuery', $this->client);
-        $snippet->replace('sleep(1);', '');
         $this->connection
             ->query(Argument::withEntry('queryParameters', [
                 [

--- a/tests/snippets/BigQuery/CopyJobConfigurationTest.php
+++ b/tests/snippets/BigQuery/CopyJobConfigurationTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Snippets\BigQuery;
+
+use Google\Cloud\BigQuery\BigQueryClient;
+use Google\Cloud\BigQuery\CopyJobConfiguration;
+use Google\Cloud\Dev\Snippet\SnippetTestCase;
+
+/**
+ * @group bigquery
+ */
+class CopyJobConfigurationTest extends SnippetTestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const TABLE_ID = 'my_table';
+    const JOB_ID = '123';
+
+    private $config;
+
+    public function setUp()
+    {
+        $this->config = new CopyJobConfiguration(
+            self::PROJECT_ID,
+            ['jobReference' => ['jobId' => self::JOB_ID]]
+        );
+    }
+
+    public function testClass()
+    {
+        $snippet = $this->snippetFromClass(CopyJobConfiguration::class);
+        $res = $snippet->invoke('copyJobConfig');
+
+        $this->assertInstanceOf(CopyJobConfiguration::class, $res->returnVal());
+    }
+
+    /**
+     * @dataProvider setterDataProvider
+     */
+    public function testSetters($method, $expected, $bq = null)
+    {
+        $snippet = $this->snippetFromMethod(CopyJobConfiguration::class, $method);
+        $snippet->addLocal('copyJobConfig', $this->config);
+
+        if ($bq) {
+            $snippet->addLocal('bigQuery', $bq);
+        }
+
+        $actual = $snippet->invoke('copyJobConfig')
+            ->returnVal()
+            ->toArray()['configuration']['copy'][$method];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function setterDataProvider()
+    {
+        $bq = \Google\Cloud\Dev\stub(BigQueryClient::class, [
+            ['projectId' => self::PROJECT_ID]
+        ]);
+
+        return [
+            [
+                'createDisposition',
+                'CREATE_NEVER'
+            ],
+            [
+                'destinationEncryptionConfiguration',
+                [
+                    'kmsKeyName' => 'my_key'
+                ]
+            ],
+            [
+                'destinationTable',
+                [
+                    'projectId' => self::PROJECT_ID,
+                    'datasetId' => self::DATASET_ID,
+                    'tableId' => self::TABLE_ID
+                ],
+                $bq
+            ],
+            [
+                'sourceTable',
+                [
+                    'projectId' => self::PROJECT_ID,
+                    'datasetId' => self::DATASET_ID,
+                    'tableId' => 'source_table'
+                ],
+                $bq
+            ],
+            [
+                'writeDisposition',
+                'WRITE_TRUNCATE'
+            ]
+        ];
+    }
+}

--- a/tests/snippets/BigQuery/ExtractJobConfigurationTest.php
+++ b/tests/snippets/BigQuery/ExtractJobConfigurationTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Snippets\BigQuery;
+
+use Google\Cloud\BigQuery\BigQueryClient;
+use Google\Cloud\BigQuery\ExtractJobConfiguration;
+use Google\Cloud\BigQuery\Table;
+use Google\Cloud\Dev\Snippet\SnippetTestCase;
+
+/**
+ * @group bigquery
+ */
+class ExtractJobConfigurationTest extends SnippetTestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const TABLE_ID = 'my_table';
+    const JOB_ID = '123';
+
+    private $config;
+
+    public function setUp()
+    {
+        $this->config = new ExtractJobConfiguration(
+            self::PROJECT_ID,
+            ['jobReference' => ['jobId' => self::JOB_ID]]
+        );
+    }
+
+    public function testClass()
+    {
+        $snippet = $this->snippetFromClass(ExtractJobConfiguration::class);
+        $res = $snippet->invoke('extractJobConfig');
+
+        $this->assertInstanceOf(ExtractJobConfiguration::class, $res->returnVal());
+    }
+
+    /**
+     * @dataProvider setterDataProvider
+     */
+    public function testSetters($method, $expected, $bq = null)
+    {
+        $snippet = $this->snippetFromMethod(ExtractJobConfiguration::class, $method);
+        $snippet->addLocal('extractJobConfig', $this->config);
+
+        if ($bq) {
+            $snippet->addLocal('bigQuery', $bq);
+        }
+
+        $actual = $snippet->invoke('extractJobConfig')
+            ->returnVal()
+            ->toArray()['configuration']['extract'][$method];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function setterDataProvider()
+    {
+        $bq = \Google\Cloud\Dev\stub(BigQueryClient::class, [
+            ['projectId' => self::PROJECT_ID]
+        ]);
+
+        return [
+            [
+                'compression',
+                'GZIP'
+            ],
+            [
+                'destinationFormat',
+                'NEWLINE_DELIMITED_JSON'
+            ],
+            [
+                'destinationUris',
+                ['gs://my_bucket/destination.csv']
+            ],
+            [
+                'fieldDelimiter',
+                ','
+            ],
+            [
+                'printHeader',
+                false
+            ],
+            [
+                'sourceTable',
+                [
+                    'projectId' => self::PROJECT_ID,
+                    'datasetId' => self::DATASET_ID,
+                    'tableId' => self::TABLE_ID
+                ],
+                $bq
+            ]
+        ];
+    }
+}

--- a/tests/snippets/BigQuery/JobTest.php
+++ b/tests/snippets/BigQuery/JobTest.php
@@ -82,7 +82,6 @@ class JobTest extends SnippetTestCase
             ]
         ]);
         $snippet = $this->snippetFromMethod(Job::class, 'cancel');
-        $snippet->replace('sleep(1);', '');
         $snippet->addLocal('job', $job);
         $snippet->invoke();
     }
@@ -91,13 +90,25 @@ class JobTest extends SnippetTestCase
     {
         $this->connection->getQueryResults(Argument::any())
             ->shouldBeCalledTimes(1)
-            ->willReturn([]);
+            ->willReturn(['jobComplete' => true]);
         $job = $this->getJob($this->connection);
         $snippet = $this->snippetFromMethod(Job::class, 'queryResults');
         $snippet->addLocal('job', $job);
         $res = $snippet->invoke('queryResults');
 
         $this->assertInstanceOf(QueryResults::class, $res->returnVal());
+    }
+
+    public function testWaitUntilComplete()
+    {
+        $job = $this->getJob($this->connection, [
+            'status' => [
+                'state' => 'DONE'
+            ]
+        ]);
+        $snippet = $this->snippetFromMethod(Job::class, 'waitUntilComplete');
+        $snippet->addLocal('job', $job);
+        $snippet->invoke();
     }
 
     public function testIsComplete()
@@ -116,7 +127,6 @@ class JobTest extends SnippetTestCase
         ]);
         $snippet = $this->snippetFromMethod(Job::class, 'isComplete');
         $snippet->addLocal('job', $job);
-        $snippet->replace('sleep(1);', '');
         $snippet->invoke();
     }
 
@@ -151,7 +161,6 @@ class JobTest extends SnippetTestCase
         ]);
         $snippet = $this->snippetFromMethod(Job::class, 'reload');
         $snippet->addLocal('job', $job);
-        $snippet->replace('sleep(1);', '');
         $snippet->invoke();
     }
 

--- a/tests/snippets/BigQuery/LoadJobConfigurationTest.php
+++ b/tests/snippets/BigQuery/LoadJobConfigurationTest.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Snippets\BigQuery;
+
+use Google\Cloud\BigQuery\BigQueryClient;
+use Google\Cloud\BigQuery\LoadJobConfiguration;
+use Google\Cloud\Dev\Snippet\SnippetTestCase;
+
+/**
+ * @group bigquery
+ */
+class LoadJobConfigurationTest extends SnippetTestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const TABLE_ID = 'my_table';
+    const JOB_ID = '123';
+
+    private $config;
+
+    public function setUp()
+    {
+        $this->config = new LoadJobConfiguration(
+            self::PROJECT_ID,
+            ['jobReference' => ['jobId' => self::JOB_ID]]
+        );
+    }
+
+    public function testClass()
+    {
+        $snippet = $this->snippetFromClass(LoadJobConfiguration::class);
+        $snippet->replace('fopen(\'/path/to/my/data.csv\', \'r\')', '123');
+        $res = $snippet->invoke('loadJobConfig');
+
+        $this->assertInstanceOf(LoadJobConfiguration::class, $res->returnVal());
+    }
+
+    public function testData()
+    {
+        $snippet = $this->snippetFromMethod(LoadJobConfiguration::class, 'data');
+        $snippet->addLocal('loadJobConfig', $this->config);
+        $snippet->replace('fopen(\'/path/to/my/data.csv\', \'r\')', '123');
+        $res = $snippet->invoke('loadJobConfig');
+
+        $this->assertEquals('123', $res->returnVal()->toArray()['data']);
+    }
+
+    /**
+     * @dataProvider setterDataProvider
+     */
+    public function testSetters($method, $expected, $bq = null)
+    {
+        $snippet = $this->snippetFromMethod(LoadJobConfiguration::class, $method);
+        $snippet->addLocal('loadJobConfig', $this->config);
+
+        if ($bq) {
+            $snippet->addLocal('bigQuery', $bq);
+        }
+
+        $actual = $snippet->invoke('loadJobConfig')
+            ->returnVal()
+            ->toArray()['configuration']['load'][$method];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function setterDataProvider()
+    {
+        $bq = \Google\Cloud\Dev\stub(BigQueryClient::class, [
+            ['projectId' => self::PROJECT_ID]
+        ]);
+
+        return [
+            [
+                'allowJaggedRows',
+                true
+            ],
+            [
+                'allowQuotedNewlines',
+                true
+            ],
+            [
+                'autodetect',
+                true
+            ],
+            [
+                'createDisposition',
+                'CREATE_NEVER'
+            ],
+            [
+                'destinationEncryptionConfiguration',
+                [
+                    'kmsKeyName' => 'my_key'
+                ]
+            ],
+            [
+                'destinationTable',
+                [
+                    'projectId' => self::PROJECT_ID,
+                    'datasetId' => self::DATASET_ID,
+                    'tableId' => self::TABLE_ID
+                ],
+                $bq
+            ],
+            [
+                'encoding',
+                'UTF-8'
+            ],
+            [
+                'fieldDelimiter',
+                '\t'
+            ],
+            [
+                'ignoreUnknownValues',
+                true
+            ],
+            [
+                'maxBadRecords',
+                10
+            ],
+            [
+                'nullMarker',
+                '\N',
+            ],
+            [
+                'projectionFields',
+                ['field_name']
+            ],
+            [
+                'quote',
+                '"'
+            ],
+            [
+                'schema',
+                [
+                    'fields' => [
+                        [
+                            'name' => 'col1',
+                            'type' => 'STRING'
+                        ],
+                        [
+                            'name' => 'col2',
+                            'type' => 'BOOL'
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'schemaUpdateOptions',
+                ['ALLOW_FIELD_ADDITION']
+            ],
+            [
+                'skipLeadingRows',
+                10
+            ],
+            [
+                'sourceFormat',
+                'NEWLINE_DELIMITED_JSON'
+            ],
+            [
+                'sourceUris',
+                ['gs://my_bucket/source.csv']
+            ],
+            [
+                'timePartitioning',
+                ['type' => 'DAY']
+            ],
+            [
+                'writeDisposition',
+                'WRITE_TRUNCATE'
+            ]
+        ];
+    }
+}

--- a/tests/snippets/BigQuery/QueryJobConfigurationTest.php
+++ b/tests/snippets/BigQuery/QueryJobConfigurationTest.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Snippets\BigQuery;
+
+use Google\Cloud\BigQuery\BigQueryClient;
+use Google\Cloud\BigQuery\QueryJobConfiguration;
+use Google\Cloud\BigQuery\ValueMapper;
+use Google\Cloud\Dev\Snippet\SnippetTestCase;
+
+/**
+ * @group bigquery
+ */
+class QueryJobConfigurationTest extends SnippetTestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const TABLE_ID = 'my_table';
+    const JOB_ID = '123';
+
+    private $config;
+
+    public function setUp()
+    {
+        $this->config = new QueryJobConfiguration(
+            new ValueMapper(false),
+            self::PROJECT_ID,
+            ['jobReference' => ['jobId' => self::JOB_ID]]
+        );
+    }
+
+    public function testClass()
+    {
+        $snippet = $this->snippetFromClass(QueryJobConfiguration::class);
+        $res = $snippet->invoke('query');
+
+        $this->assertInstanceOf(QueryJobConfiguration::class, $res->returnVal());
+    }
+
+    /**
+     * @dataProvider setterDataProvider
+     */
+    public function testSetters($method, $expected, $bq = null)
+    {
+        $snippet = $this->snippetFromMethod(QueryJobConfiguration::class, $method);
+        $snippet->addLocal('query', $this->config);
+
+        if ($bq) {
+            $snippet->addLocal('bigQuery', $bq);
+        }
+
+        $actual = $snippet->invoke('query')
+            ->returnVal()
+            ->toArray()['configuration']['query'][$method];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function setterDataProvider()
+    {
+        $bq = \Google\Cloud\Dev\stub(BigQueryClient::class, [
+            ['projectId' => self::PROJECT_ID]
+        ]);
+
+        return [
+            [
+                'allowLargeResults',
+                true
+            ],
+            [
+                'createDisposition',
+                'CREATE_NEVER'
+            ],
+            [
+                'defaultDataset',
+                [
+                    'projectId' => self::PROJECT_ID,
+                    'datasetId' => self::DATASET_ID
+                ],
+                $bq
+            ],
+            [
+                'destinationEncryptionConfiguration',
+                [
+                    'kmsKeyName' => 'my_key'
+                ]
+            ],
+            [
+                'destinationTable',
+                [
+                    'projectId' => self::PROJECT_ID,
+                    'datasetId' => self::DATASET_ID,
+                    'tableId' => self::TABLE_ID
+                ],
+                $bq
+            ],
+            [
+                'flattenResults',
+                true
+            ],
+            [
+                'maximumBillingTier',
+                1
+            ],
+            [
+                'maximumBytesBilled',
+                3000
+            ],
+            [
+                'priority',
+                'BATCH'
+            ],
+            [
+                'query',
+                'SELECT commit FROM `bigquery-public-data.github_repos.commits` LIMIT 100',
+            ],
+            [
+                'schemaUpdateOptions',
+                ['ALLOW_FIELD_ADDITION']
+            ],
+            [
+                'tableDefinitions',
+                [
+                    'autodetect' => true,
+                    'sourceUris' => [
+                        'gs://my_bucket/table.json'
+                    ]
+                ]
+            ],
+            [
+                'timePartitioning',
+                ['type' => 'DAY']
+            ],
+            [
+                'useLegacySql',
+                true
+            ],
+            [
+                'useQueryCache',
+                true
+            ],
+            [
+                'userDefinedFunctionResources',
+                [['resourceUri' => 'gs://my_bucket/code_path']]
+            ],
+            [
+                'writeDisposition',
+                'WRITE_TRUNCATE'
+            ]
+        ];
+    }
+}

--- a/tests/snippets/BigQuery/QueryResultsTest.php
+++ b/tests/snippets/BigQuery/QueryResultsTest.php
@@ -60,7 +60,6 @@ class QueryResultsTest extends SnippetTestCase
                 ]
             ]
         ];
-        $this->reload = [];
 
         $this->connection = $this->prophesize(ConnectionInterface::class);
         $this->qr = \Google\Cloud\Dev\stub(QueryResults::class, [
@@ -68,7 +67,6 @@ class QueryResultsTest extends SnippetTestCase
             self::JOB_ID,
             self::PROJECT,
             $this->info,
-            $this->reload,
             new ValueMapper(false)
         ]);
     }
@@ -88,21 +86,6 @@ class QueryResultsTest extends SnippetTestCase
 
         $res = $snippet->invoke();
         $this->assertEquals('abcd', trim($res->output()));
-    }
-
-    public function testIsComplete()
-    {
-        $snippet = $this->snippetFromMethod(QueryResults::class, 'isComplete');
-        $snippet->addLocal('queryResults', $this->qr);
-
-        $this->info['jobComplete'] = true;
-        $this->connection->getQueryResults(Argument::any())
-            ->willReturn($this->info);
-
-        $this->qr->___setProperty('connection', $this->connection->reveal());
-
-        $res = $snippet->invoke();
-        $this->assertEquals('Query complete!', $res->output());
     }
 
     public function testIdentity()
@@ -133,9 +116,7 @@ class QueryResultsTest extends SnippetTestCase
 
         $snippet = $this->snippetFromMethod(QueryResults::class, 'reload');
         $snippet->addLocal('queryResults', $this->qr);
-        $snippet->replace('sleep(1);', '');
 
         $res = $snippet->invoke();
-        $this->assertEquals('Query complete!', $res->output());
     }
 }

--- a/tests/system/BigQuery/LoadDataAndQueryTest.php
+++ b/tests/system/BigQuery/LoadDataAndQueryTest.php
@@ -91,16 +91,16 @@ class LoadDataAndQueryTest extends BigQueryTestCase
      */
     public function testRunQuery($useLegacySql)
     {
-        $query =  sprintf(
+        $queryString =  sprintf(
             $useLegacySql
                 ? 'SELECT Name, Age, Weight, IsMagic, Spells.* FROM [%s.%s]'
                 : 'SELECT Name, Age, Weight, IsMagic, Spells FROM `%s.%s`',
             self::$dataset->id(),
             self::$table->id()
         );
-        $results = self::$client->runQuery($query, [
-            'useLegacySql' => $useLegacySql
-        ]);
+        $query = self::$client->query($queryString)
+            ->useLegacySql($useLegacySql);
+        $results = self::$client->runQuery($query);
         $backoff = new ExponentialBackoff(8);
         $backoff->execute(function () use ($results) {
             $results->reload();
@@ -147,20 +147,18 @@ class LoadDataAndQueryTest extends BigQueryTestCase
      * @depends testInsertRowToTable
      * @dataProvider useLegacySqlProvider
      */
-    public function testRunQueryAsJob($useLegacySql)
+    public function testStartQuery($useLegacySql)
     {
-        $query = sprintf(
+        $queryString = sprintf(
             $useLegacySql
                 ? 'SELECT FavoriteNumbers, ImportantDates.* FROM [%s.%s]'
                 : 'SELECT FavoriteNumbers, ImportantDates FROM `%s.%s`',
             self::$dataset->id(),
             self::$table->id()
         );
-        $job = self::$client->runQueryAsJob($query, [
-            'jobConfig' => [
-                'useLegacySql' => $useLegacySql
-            ]
-        ]);
+        $query = self::$client->query($queryString)
+            ->useLegacySql($useLegacySql);
+        $job = self::$client->startQuery($query);
         $results = $job->queryResults();
         $backoff = new ExponentialBackoff(8);
         $backoff->execute(function () use ($results) {
@@ -206,7 +204,7 @@ class LoadDataAndQueryTest extends BigQueryTestCase
 
     public function testRunQueryWithNamedParameters()
     {
-        $query = 'SELECT'
+        $queryString = 'SELECT'
             . '@structType as structType,'
             . '@arrayStruct as arrayStruct,'
             . '@nestedStruct as nestedStruct,'
@@ -245,7 +243,9 @@ class LoadDataAndQueryTest extends BigQueryTestCase
             'time' => self::$client->time(new \DateTime('11:15:02')),
             'bytes' => $bytes
         ];
-        $results = self::$client->runQuery($query, ['parameters' => $params]);
+        $query = self::$client->query($queryString)
+            ->parameters($params);
+        $results = self::$client->runQuery($query);
 
         $backoff = new ExponentialBackoff(8);
         $backoff->execute(function () use ($results) {
@@ -271,19 +271,11 @@ class LoadDataAndQueryTest extends BigQueryTestCase
 
     public function testRunQueryWithPositionalParameters()
     {
-        $results = self::$client->runQuery('SELECT 1 IN UNNEST(?) AS arr', [
-            'parameters' => [
+        $query = self::$client->query('SELECT 1 IN UNNEST(?) AS arr')
+            ->parameters([
                 [1, 2, 3]
-            ]
-        ]);
-        $backoff = new ExponentialBackoff(8);
-        $backoff->execute(function () use ($results) {
-            $results->reload();
-
-            if (!$results->isComplete()) {
-                throw new \Exception();
-            }
-        });
+            ]);
+        $results = self::$client->runQuery($query);
 
         if (!$results->isComplete()) {
             $this->fail('Query did not complete within the allotted time.');
@@ -297,14 +289,13 @@ class LoadDataAndQueryTest extends BigQueryTestCase
         $this->assertEquals($expectedRows, $actualRows);
     }
 
-    public function testRunQueryAsJobWithNamedParameters()
+    public function testStartQueryWithNamedParameters()
     {
-        $query = 'SELECT @int as int';
-        $job = self::$client->runQueryAsJob($query, [
-            'parameters' => [
+        $query = self::$client->query('SELECT @int as int')
+            ->parameters([
                 'int' => 5
-            ]
-        ]);
+            ]);
+        $job = self::$client->startQuery($query);
         $results = $job->queryResults();
         $backoff = new ExponentialBackoff(8);
         $backoff->execute(function () use ($results) {
@@ -325,13 +316,13 @@ class LoadDataAndQueryTest extends BigQueryTestCase
         $this->assertEquals($expectedRows, $actualRows);
     }
 
-    public function testRunQueryAsJobWithPositionalParameters()
+    public function testStartQueryWithPositionalParameters()
     {
-        $job = self::$client->runQueryAsJob('SELECT 1 IN UNNEST(?) AS arr', [
-            'parameters' => [
+        $query = self::$client->query('SELECT 1 IN UNNEST(?) AS arr')
+            ->parameters([
                 [1, 2, 3]
-            ]
-        ]);
+            ]);
+        $job = self::$client->startQuery($query);
         $results = $job->queryResults();
         $backoff = new ExponentialBackoff(8);
         $backoff->execute(function () use ($results) {
@@ -356,15 +347,13 @@ class LoadDataAndQueryTest extends BigQueryTestCase
 
     /**
      * @dataProvider rowProvider
-     * @depends testInsertRowToTable
      */
     public function testLoadsDataToTable($data)
     {
-        $job = self::$table->load($data, [
-            'jobConfig' => [
-                'sourceFormat' => 'NEWLINE_DELIMITED_JSON'
-            ]
-        ]);
+        $loadJobConfig = self::$table->load($data)
+            ->sourceFormat('NEWLINE_DELIMITED_JSON');
+
+        $job = self::$table->startJob($loadJobConfig);
         $backoff = new ExponentialBackoff(8);
         $backoff->execute(function () use ($job) {
             $job->reload();
@@ -404,11 +393,9 @@ class LoadDataAndQueryTest extends BigQueryTestCase
             fopen(__DIR__ . '/../data/table-data.json', 'r')
         );
 
-        $job = self::$table->loadFromStorage($object, [
-            'jobConfig' => [
-                'sourceFormat' => 'NEWLINE_DELIMITED_JSON'
-            ]
-        ]);
+        $loadJobConfig = self::$table->loadFromStorage($object)
+            ->sourceFormat('NEWLINE_DELIMITED_JSON');
+        $job = self::$table->startJob($loadJobConfig);
         $backoff = new ExponentialBackoff(8);
         $backoff->execute(function () use ($job) {
             $job->reload();
@@ -442,5 +429,34 @@ class LoadDataAndQueryTest extends BigQueryTestCase
 
         $this->assertTrue($insertResponse->isSuccessful());
         $this->assertEquals(self::$expectedRows, $actualRows);
+    }
+
+    public function testInsertRowsToTableWithAutoCreate()
+    {
+        $tName = uniqid(BigQueryTestCase::TESTING_PREFIX);
+        $rows = [
+            ['data' => ['hello' => 'world']]
+        ];
+        $insertResponse = self::$dataset->table($tName)
+            ->insertRows($rows, [
+                'autoCreate' => true,
+                'tableMetadata' => [
+                    'schema' => [
+                        'fields' => [
+                            [
+                                'name' => 'hello',
+                                'type' => 'STRING'
+                            ]
+                        ]
+                    ]
+                ]
+            ]);
+        $results = self::$dataset
+            ->table($tName)
+            ->rows();
+        $actualRows = count(iterator_to_array($results));
+
+        $this->assertTrue($insertResponse->isSuccessful());
+        $this->assertEquals(count($rows), $actualRows);
     }
 }

--- a/tests/system/BigQuery/ManageDatasetsTest.php
+++ b/tests/system/BigQuery/ManageDatasetsTest.php
@@ -75,6 +75,19 @@ class ManageDatasetsTest extends BigQueryTestCase
         $this->assertEquals($metadata['friendlyName'], $info['friendlyName']);
     }
 
+    /**
+     * @expectedException Google\Cloud\Core\Exception\FailedPreconditionException
+     */
+    public function testUpdateDatasetConcurrentUpdateFails()
+    {
+        $data = [
+            'friendlyName' => 'foo',
+            'etag' => 'blah'
+        ];
+
+        self::$dataset->update($data);
+    }
+
     public function testReloadsDataset()
     {
         $this->assertEquals('bigquery#dataset', self::$dataset->reload()['kind']);

--- a/tests/system/BigQuery/ManageJobsTest.php
+++ b/tests/system/BigQuery/ManageJobsTest.php
@@ -27,13 +27,12 @@ class ManageJobsTest extends BigQueryTestCase
 {
     public function testListJobs()
     {
-        self::$client->runQueryAsJob(
-            sprintf(
-                'SELECT * FROM [%s.%s]',
-                self::$dataset->id(),
-                self::$table->id()
-            )
-        );
+        $query = self::$client->query(sprintf(
+            'SELECT * FROM [%s.%s]',
+            self::$dataset->id(),
+            self::$table->id()
+        ));
+        self::$client->startQuery($query);
         $jobs = self::$client->jobs();
         $job = null;
 
@@ -59,13 +58,12 @@ class ManageJobsTest extends BigQueryTestCase
 
     public function testCancelsJob()
     {
-        $job = self::$client->runQueryAsJob(
-            sprintf(
-                'SELECT * FROM [%s.%s]',
-                self::$dataset->id(),
-                self::$table->id()
-            )
-        );
+        $query = self::$client->query(sprintf(
+            'SELECT * FROM [%s.%s]',
+            self::$dataset->id(),
+            self::$table->id()
+        ));
+        $job = self::$client->startQuery($query);
         $job->cancel();
     }
 

--- a/tests/system/BigQuery/ManageTablesTest.php
+++ b/tests/system/BigQuery/ManageTablesTest.php
@@ -129,6 +129,19 @@ class ManageTablesTest extends BigQueryTestCase
         $this->assertEquals($metadata['friendlyName'], $info['friendlyName']);
     }
 
+    /**
+     * @expectedException Google\Cloud\Core\Exception\FailedPreconditionException
+     */
+    public function testUpdateTableConcurrentUpdateFails()
+    {
+        $data = [
+            'friendlyName' => 'foo',
+            'etag' => 'blah'
+        ];
+
+        self::$table->update($data);
+    }
+
     public function testReloadsTable()
     {
         $this->assertEquals('bigquery#table', self::$table->reload()['kind']);

--- a/tests/system/BigQuery/ManageTablesTest.php
+++ b/tests/system/BigQuery/ManageTablesTest.php
@@ -74,7 +74,8 @@ class ManageTablesTest extends BigQueryTestCase
      */
     public function testCopiesTable($table)
     {
-        $job = self::$table->copy($table);
+        $copyJobConfig = self::$table->copy($table);
+        $job = self::$table->startJob($copyJobConfig);
         $backoff = new ExponentialBackoff(8);
         $backoff->execute(function () use ($job) {
             $job->reload();
@@ -91,17 +92,15 @@ class ManageTablesTest extends BigQueryTestCase
         $this->assertArrayNotHasKey('errorResult', $job->info()['status']);
     }
 
-    public function testExportsTable()
+    public function testExtractsTable()
     {
         $object = self::$bucket->object(
             uniqid(self::TESTING_PREFIX)
         );
 
-        $job = self::$table->export($object, [
-            'jobConfig' => [
-                'destinationFormat' => 'NEWLINE_DELIMITED_JSON'
-            ]
-        ]);
+        $extractJobConfig = self::$table->extract($object)
+            ->destinationFormat('NEWLINE_DELIMITED_JSON');
+        $job = self::$table->startJob($extractJobConfig);
 
         $backoff = new ExponentialBackoff(8);
         $backoff->execute(function () use ($job) {

--- a/tests/unit/BigQuery/BigQueryClientTest.php
+++ b/tests/unit/BigQuery/BigQueryClientTest.php
@@ -51,7 +51,19 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testRunsQuery($query, $options, $expected)
     {
-        $this->connection->query($expected)
+        $projectId = $expected['projectId'];
+        unset($expected['projectId']);
+        $this->connection->insertJob([
+            'projectId' => $projectId,
+            'configuration' => [
+                'query' => $expected
+            ]
+        ])
+            ->willReturn([
+                'jobReference' => ['jobId' => $this->jobId]
+            ])
+            ->shouldBeCalledTimes(1);
+        $this->connection->getQueryResults(Argument::any())
             ->willReturn([
                 'jobReference' => [
                     'jobId' => $this->jobId
@@ -71,15 +83,18 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testRunsQueryWithRetry($query, $options, $expected)
     {
-        $this->connection->query($expected)
+        $projectId = $expected['projectId'];
+        unset($expected['projectId']);
+        $this->connection->insertJob([
+            'projectId' => $projectId,
+            'configuration' => [
+                'query' => $expected
+            ]
+        ])
             ->willReturn([
-                'jobReference' => [
-                    'jobId' => $this->jobId
-                ],
-                'jobComplete' => false
+                'jobReference' => ['jobId' => $this->jobId]
             ])
             ->shouldBeCalledTimes(1);
-
         $this->connection->getQueryResults(Argument::any())
             ->willReturn([
                 'jobReference' => [

--- a/tests/unit/BigQuery/BigQueryClientTest.php
+++ b/tests/unit/BigQuery/BigQueryClientTest.php
@@ -130,7 +130,8 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
                 [],
                 [
                     'projectId' => $this->projectId,
-                    'query' => $query
+                    'query' => $query,
+                    'useLegacySql' => false
                 ]
             ],
             [

--- a/tests/unit/BigQuery/BigQueryClientTest.php
+++ b/tests/unit/BigQuery/BigQueryClientTest.php
@@ -23,6 +23,7 @@ use Google\Cloud\BigQuery\Connection\ConnectionInterface;
 use Google\Cloud\BigQuery\Dataset;
 use Google\Cloud\BigQuery\Date;
 use Google\Cloud\BigQuery\Job;
+use Google\Cloud\BigQuery\QueryJobConfiguration;
 use Google\Cloud\BigQuery\QueryResults;
 use Google\Cloud\BigQuery\Time;
 use Google\Cloud\BigQuery\Timestamp;
@@ -34,69 +35,78 @@ use Prophecy\Argument;
  */
 class BigQueryClientTest extends \PHPUnit_Framework_TestCase
 {
-    const JOBID = 'myJobId';
+    const JOB_ID = 'myJobId';
+    const PROJECT_ID = 'myProjectId';
+    const DATASET_ID = 'myDatasetId';
+    const QUERY_STRING = 'someQuery';
 
     public $connection;
-    public $projectId = 'myProjectId';
-    public $datasetId = 'myDatasetId';
     public $client;
 
     public function setUp()
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
-        $this->client = \Google\Cloud\Dev\stub(BigQueryTestClient::class, ['options' => ['projectId' => $this->projectId]]);
+        $this->client = \Google\Cloud\Dev\stub(BigQueryClient::class, ['options' => ['projectId' => self::PROJECT_ID]]);
     }
 
-    /**
-     * @dataProvider queryDataProvider
-     */
-    public function testRunsQuery($query, $options, $expected)
+    public function testRunsQuery()
     {
-        $projectId = $expected['projectId'];
-        unset($expected['projectId']);
+        $query = $this->client->query(self::QUERY_STRING, [
+            'jobReference' => ['jobId' => self::JOB_ID]
+        ]);
         $this->connection->insertJob([
-            'projectId' => $projectId,
+            'projectId' => self::PROJECT_ID,
             'configuration' => [
-                'query' => $expected
+                'query' => [
+                    'query' => self::QUERY_STRING,
+                    'useLegacySql' => false
+                ]
             ],
-            'jobReference' => ['projectId' => $projectId, 'jobId' => self::JOBID]
+            'jobReference' => [
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
+            ]
         ])
             ->willReturn([
-                'jobReference' => ['jobId' => self::JOBID]
+                'jobReference' => ['jobId' => self::JOB_ID]
             ])
             ->shouldBeCalledTimes(1);
         $this->connection->getQueryResults(Argument::any())
             ->willReturn([
                 'jobReference' => [
-                    'jobId' => self::JOBID
+                    'jobId' => self::JOB_ID
                 ],
                 'jobComplete' => true
             ])
             ->shouldBeCalledTimes(1);
         $this->client->___setProperty('connection', $this->connection->reveal());
-        $queryResults = $this->client->runQuery($query, $options);
+        $queryResults = $this->client->runQuery($query);
 
         $this->assertInstanceOf(QueryResults::class, $queryResults);
-        $this->assertEquals(self::JOBID, $queryResults->identity()['jobId']);
+        $this->assertEquals(self::JOB_ID, $queryResults->identity()['jobId']);
     }
 
-    /**
-     * @dataProvider queryDataProvider
-     */
-    public function testRunsQueryWithRetry($query, $options, $expected)
+    public function testRunsQueryWithRetry()
     {
-        $projectId = $expected['projectId'];
-        unset($expected['projectId']);
+        $query = $this->client->query(self::QUERY_STRING, [
+            'jobReference' => ['jobId' => self::JOB_ID]
+        ]);
         $this->connection->insertJob([
-            'projectId' => $projectId,
+            'projectId' => self::PROJECT_ID,
             'configuration' => [
-                'query' => $expected
+                'query' => [
+                    'query' => self::QUERY_STRING,
+                    'useLegacySql' => false
+                ]
             ],
-            'jobReference' => ['projectId' => $projectId, 'jobId' => self::JOBID]
+            'jobReference' => [
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
+            ]
         ])
             ->willReturn([
                 'jobReference' => [
-                    'jobId' => self::JOBID
+                    'jobId' => self::JOB_ID
                 ],
                 'jobComplete' => false
             ])
@@ -104,129 +114,58 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
         $this->connection->getQueryResults(Argument::any())
             ->willReturn([
                 'jobReference' => [
-                    'jobId' => self::JOBID
+                    'jobId' => self::JOB_ID
                 ],
                 'jobComplete' => true
             ])
             ->shouldBeCalledTimes(1);
 
         $this->client->___setProperty('connection', $this->connection->reveal());
-        $queryResults = $this->client->runQuery($query, $options);
+        $queryResults = $this->client->runQuery($query);
 
         $this->assertInstanceOf(QueryResults::class, $queryResults);
-        $this->assertEquals(self::JOBID, $queryResults->identity()['jobId']);
+        $this->assertEquals(self::JOB_ID, $queryResults->identity()['jobId']);
     }
 
-    /**
-     * @dataProvider queryDataProvider
-     */
-    public function testRunsQueryAsJob($query, $options, $expected)
+    public function testStartQuery()
     {
-        $projectId = $expected['projectId'];
-        unset($expected['projectId']);
+        $query = $this->client->query(self::QUERY_STRING, [
+            'jobReference' => ['jobId' => self::JOB_ID]
+        ]);
         $this->connection->insertJob([
-            'projectId' => $projectId,
+            'projectId' => self::PROJECT_ID,
             'configuration' => [
-                'query' => $expected
+                'query' => [
+                    'query' => self::QUERY_STRING,
+                    'useLegacySql' => false
+                ]
             ],
             'jobReference' => [
-                'projectId' => $projectId,
-                'jobId' => self::JOBID
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
             ]
         ])
             ->willReturn([
-                'jobReference' => ['jobId' => self::JOBID]
+                'jobReference' => ['jobId' => self::JOB_ID]
             ])
             ->shouldBeCalledTimes(1);
 
         $this->client->___setProperty('connection', $this->connection->reveal());
-        $job = $this->client->runQueryAsJob($query, $options);
+        $job = $this->client->startQuery($query);
 
         $this->assertInstanceOf(Job::class, $job);
-        $this->assertEquals(self::JOBID, $job->id());
-    }
-
-    public function queryDataProvider()
-    {
-        $query = 'someQuery';
-
-        return [
-            [
-                $query,
-                [],
-                [
-                    'projectId' => $this->projectId,
-                    'query' => $query,
-                    'useLegacySql' => false
-                ]
-            ],
-            [
-                $query,
-                [
-                    'parameters' => [
-                        'test' => 'parameter'
-                    ]
-                ],
-                [
-                    'projectId' => $this->projectId,
-                    'query' => $query,
-                    'parameterMode' => 'named',
-                    'useLegacySql' => false,
-                    'queryParameters' => [
-                        [
-                            'name' => 'test',
-                            'parameterType' => [
-                                'type' => 'STRING'
-                            ],
-                            'parameterValue' => [
-                                'value' => 'parameter'
-                            ]
-                        ]
-                    ]
-                ]
-            ],
-            [
-                $query,
-                [
-                    'parameters' => [1, 2]
-                ],
-                [
-                    'projectId' => $this->projectId,
-                    'query' => 'someQuery',
-                    'parameterMode' => 'positional',
-                    'useLegacySql' => false,
-                    'queryParameters' => [
-                        [
-                            'parameterType' => [
-                                'type' => 'INT64'
-                            ],
-                            'parameterValue' => [
-                                'value' => 1
-                            ]
-                        ],
-                        [
-                            'parameterType' => [
-                                'type' => 'INT64'
-                            ],
-                            'parameterValue' => [
-                                'value' => 2
-                            ]
-                        ]
-                    ]
-                ]
-            ]
-        ];
+        $this->assertEquals(self::JOB_ID, $job->id());
     }
 
     public function testGetsJob()
     {
         $this->client->___setProperty('connection', $this->connection->reveal());
-        $this->assertInstanceOf(Job::class, $this->client->job(self::JOBID));
+        $this->assertInstanceOf(Job::class, $this->client->job(self::JOB_ID));
     }
 
     public function testGetsJobsWithNoResults()
     {
-        $this->connection->listJobs(['projectId' => $this->projectId])
+        $this->connection->listJobs(['projectId' => self::PROJECT_ID])
             ->willReturn([])
             ->shouldBeCalledTimes(1);
 
@@ -238,10 +177,10 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
 
     public function testGetsJobsWithoutToken()
     {
-        $this->connection->listJobs(['projectId' => $this->projectId])
+        $this->connection->listJobs(['projectId' => self::PROJECT_ID])
             ->willReturn([
                 'jobs' => [
-                    ['jobReference' => ['jobId' => self::JOBID]]
+                    ['jobReference' => ['jobId' => self::JOB_ID]]
                 ]
             ])
             ->shouldBeCalledTimes(1);
@@ -249,13 +188,13 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
         $this->client->___setProperty('connection', $this->connection->reveal());
         $jobs = iterator_to_array($this->client->jobs());
 
-        $this->assertEquals(self::JOBID, $jobs[0]->id());
+        $this->assertEquals(self::JOB_ID, $jobs[0]->id());
     }
 
     public function testGetsJobsWithToken()
     {
         $token = 'token';
-        $this->connection->listJobs(['projectId' => $this->projectId])
+        $this->connection->listJobs(['projectId' => self::PROJECT_ID])
             ->willReturn([
                 'nextPageToken' => $token,
                 'jobs' => [
@@ -263,25 +202,25 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
                 ]
             ])->shouldBeCalledTimes(1);
         $this->connection->listJobs([
-            'projectId' => $this->projectId,
+            'projectId' => self::PROJECT_ID,
             'pageToken' => $token
         ])
             ->willReturn([
                 'jobs' => [
-                    ['jobReference' => ['jobId' => self::JOBID]]
+                    ['jobReference' => ['jobId' => self::JOB_ID]]
                 ]
             ])->shouldBeCalledTimes(1);
 
         $this->client->___setProperty('connection', $this->connection->reveal());
         $job = iterator_to_array($this->client->jobs());
 
-        $this->assertEquals(self::JOBID, $job[1]->id());
+        $this->assertEquals(self::JOB_ID, $job[1]->id());
     }
 
     public function testGetsDataset()
     {
         $this->client->___setProperty('connection', $this->connection->reveal());
-        $this->assertInstanceOf(Dataset::class, $this->client->dataset($this->datasetId));
+        $this->assertInstanceOf(Dataset::class, $this->client->dataset(self::DATASET_ID));
     }
 
     public function testGetsDatasetsWithNoResults()
@@ -301,7 +240,7 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
         $this->connection->listDatasets(Argument::any())
             ->willReturn([
                 'datasets' => [
-                    ['datasetReference' => ['datasetId' => $this->datasetId]]
+                    ['datasetReference' => ['datasetId' => self::DATASET_ID]]
                 ]
             ])
             ->shouldBeCalledTimes(1);
@@ -309,7 +248,7 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
         $this->client->___setProperty('connection', $this->connection->reveal());
         $datasets = iterator_to_array($this->client->datasets());
 
-        $this->assertEquals($this->datasetId, $datasets[0]->id());
+        $this->assertEquals(self::DATASET_ID, $datasets[0]->id());
     }
 
     public function testGetsDatasetsWithToken()
@@ -324,7 +263,7 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
                 ],
                     [
                     'datasets' => [
-                        ['datasetReference' => ['datasetId' => $this->datasetId]]
+                        ['datasetReference' => ['datasetId' => self::DATASET_ID]]
                     ]
                 ]
             )
@@ -333,7 +272,7 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
         $this->client->___setProperty('connection', $this->connection->reveal());
         $dataset = iterator_to_array($this->client->datasets());
 
-        $this->assertEquals($this->datasetId, $dataset[1]->id());
+        $this->assertEquals(self::DATASET_ID, $dataset[1]->id());
     }
 
     public function testCreatesDataset()
@@ -341,13 +280,13 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
         $this->connection->insertDataset(Argument::any())
             ->willReturn([
                 'datasetReference' => [
-                    'datasetId' => $this->datasetId
+                    'datasetId' => self::DATASET_ID
                 ]
             ])
             ->shouldBeCalledTimes(1);
         $this->client->___setProperty('connection', $this->connection->reveal());
 
-        $dataset = $this->client->createDataset($this->datasetId, [
+        $dataset = $this->client->createDataset(self::DATASET_ID, [
             'metadata' => [
                 'friendlyName' => 'A dataset.'
             ]
@@ -382,13 +321,5 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
         $bytes = $this->client->timestamp(new \DateTime());
 
         $this->assertInstanceOf(Timestamp::class, $bytes);
-    }
-}
-
-class BigQueryTestClient extends BigQueryClient
-{
-    protected function generateJobId($jobIdPrefix = null)
-    {
-        return $jobIdPrefix ? $jobIdPrefix . '-' . BigQueryClientTest::JOBID : BigQueryClientTest::JOBID;
     }
 }

--- a/tests/unit/BigQuery/Connection/RestTest.php
+++ b/tests/unit/BigQuery/Connection/RestTest.php
@@ -98,6 +98,9 @@ class RestTest extends \PHPUnit_Framework_TestCase
     {
         $actualRequest = null;
         $config = [
+            'labels' => [],
+            'dryRun' => false,
+            'jobReference' => [],
             'configuration' => [
                 'load' => [
                     'destinationTable' => [

--- a/tests/unit/BigQuery/CopyJobConfigurationTest.php
+++ b/tests/unit/BigQuery/CopyJobConfigurationTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\BigQuery;
+
+use Google\Cloud\BigQuery\Dataset;
+use Google\Cloud\BigQuery\CopyJobConfiguration;
+use Google\Cloud\BigQuery\Table;
+
+/**
+ * @group bigquery
+ */
+class CopyJobConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const TABLE_ID = 'my_table';
+    const JOB_ID = '1234';
+
+    private $config;
+    private $tableIdentity = [
+        'projectId' => self::PROJECT_ID,
+        'datasetId' => self::DATASET_ID,
+        'tableId' => self::TABLE_ID
+    ];
+    private $expectedConfig;
+
+    public function setUp()
+    {
+        $this->expectedConfig = [
+            'projectId' => self::PROJECT_ID,
+            'jobReference' => [
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
+            ],
+            'configuration' => [
+                'copy' => []
+            ]
+        ];
+        $this->config = new CopyJobConfiguration(
+            self::PROJECT_ID,
+            ['jobReference' => ['jobId' => self::JOB_ID]]
+        );
+    }
+
+    public function testFluentSetters()
+    {
+        $destinationTable = $this->prophesize(Table::class);
+        $destinationTable->identity()
+            ->willReturn($this->tableIdentity);
+        $sourceTable = $this->prophesize(Table::class);
+        $sourceTable->identity()
+            ->willReturn($this->tableIdentity);
+        $copy = [
+            'createDisposition' => 'CREATE_NEVER',
+            'destinationEncryptionConfiguration' => [
+                'kmsKeyName' => 'my_key'
+            ],
+            'destinationTable' => $this->tableIdentity,
+            'sourceTable' => $this->tableIdentity,
+            'writeDisposition' => 'WRITE_TRUNCATE'
+        ];
+        $this->expectedConfig['configuration']['copy'] = $copy
+            + $this->expectedConfig['configuration']['copy'];
+        $this->config
+            ->createDisposition($copy['createDisposition'])
+            ->destinationEncryptionConfiguration($copy['destinationEncryptionConfiguration'])
+            ->destinationTable($destinationTable->reveal())
+            ->sourceTable($sourceTable->reveal())
+            ->writeDisposition($copy['writeDisposition']);
+
+        $this->assertEquals(
+            $this->expectedConfig,
+            $this->config->toArray()
+        );
+    }
+}

--- a/tests/unit/BigQuery/DatasetTest.php
+++ b/tests/unit/BigQuery/DatasetTest.php
@@ -94,6 +94,22 @@ class DatasetTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($updateData['friendlyName'], $dataset->info()['friendlyName']);
     }
 
+    public function testUpdatesDataWithEtag()
+    {
+        $updateData = ['friendlyName' => 'wow a name', 'etag' => 'foo'];
+        $this->connection->patchDataset(Argument::that(function ($args) {
+            if ($args['restOptions']['headers']['If-Match'] !== 'foo') return false;
+
+            return true;
+        }))
+            ->willReturn($updateData)
+            ->shouldBeCalledTimes(1);
+        $dataset = $this->getDataset($this->connection, ['friendlyName' => 'another name']);
+        $dataset->update($updateData);
+
+        $this->assertEquals($updateData['friendlyName'], $dataset->info()['friendlyName']);
+    }
+
     public function testGetsTable()
     {
         $dataset = $this->getDataset($this->connection);

--- a/tests/unit/BigQuery/Exception/JobExceptionTest.php
+++ b/tests/unit/BigQuery/Exception/JobExceptionTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\BigQuery\Exception;
+
+use Google\Cloud\BigQuery\Exception\JobException;
+use Google\Cloud\BigQuery\Job;
+
+/**
+ * @group bigquery
+ */
+class JobExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetsJob()
+    {
+        $message = 'Job Failed.';
+        $ex = new JobException(
+            $message,
+            $this->prophesize(Job::class)->reveal()
+        );
+
+        $this->assertEquals($message, $ex->getMessage());
+        $this->assertInstanceOf(Job::class, $ex->getJob());
+    }
+}

--- a/tests/unit/BigQuery/ExtractJobConfigurationTest.php
+++ b/tests/unit/BigQuery/ExtractJobConfigurationTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\BigQuery;
+
+use Google\Cloud\BigQuery\Dataset;
+use Google\Cloud\BigQuery\ExtractJobConfiguration;
+use Google\Cloud\BigQuery\Table;
+
+/**
+ * @group bigquery
+ */
+class ExtractJobConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const TABLE_ID = 'my_table';
+    const JOB_ID = '1234';
+
+    private $config;
+    private $tableIdentity = [
+        'projectId' => self::PROJECT_ID,
+        'datasetId' => self::DATASET_ID,
+        'tableId' => self::TABLE_ID
+    ];
+    private $expectedConfig;
+
+    public function setUp()
+    {
+        $this->expectedConfig = [
+            'projectId' => self::PROJECT_ID,
+            'jobReference' => [
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
+            ],
+            'configuration' => [
+                'extract' => []
+            ]
+        ];
+        $this->config = new ExtractJobConfiguration(
+            self::PROJECT_ID,
+            ['jobReference' => ['jobId' => self::JOB_ID]]
+        );
+    }
+
+    public function testFluentSetters()
+    {
+        $sourceTable = $this->prophesize(Table::class);
+        $sourceTable->identity()
+            ->willReturn($this->tableIdentity);
+        $extract = [
+            'compression' => 'GZIP',
+            'destinationFormat' => 'CSV',
+            'destinationUris' => ['gs://my_bucket/destination.csv'],
+            'fieldDelimiter' => ',',
+            'printHeader' => true,
+            'sourceTable' => $this->tableIdentity
+        ];
+        $this->expectedConfig['configuration']['extract'] = $extract
+            + $this->expectedConfig['configuration']['extract'];
+        $this->config
+            ->compression($extract['compression'])
+            ->destinationFormat($extract['destinationFormat'])
+            ->destinationUris($extract['destinationUris'])
+            ->fieldDelimiter($extract['fieldDelimiter'])
+            ->printHeader($extract['printHeader'])
+            ->sourceTable($sourceTable->reveal());
+
+        $this->assertEquals(
+            $this->expectedConfig,
+            $this->config->toArray()
+        );
+    }
+}

--- a/tests/unit/BigQuery/JobConfigurationTraitTest.php
+++ b/tests/unit/BigQuery/JobConfigurationTraitTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\BigQuery;
+
+use Google\Cloud\BigQuery\JobConfigurationTrait;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * @group bigquery
+ */
+class JobConfigurationTraitTest extends \PHPUnit_Framework_TestCase
+{
+    private $trait;
+
+    public function setUp()
+    {
+        $this->trait = \Google\Cloud\Dev\impl(JobConfigurationTrait::class);
+    }
+
+    public function testGenerateJobId()
+    {
+        $uuid = $this->trait->call('generateJobId');
+        $this->assertTrue(is_string($uuid));
+        $this->assertTrue(Uuid::isValid($uuid));
+    }
+
+    public function testGenerateJobIdWithPrefix()
+    {
+        $this->assertTrue(strpos($this->trait->call('generateJobId', ['foobar']), 'foobar-') === 0);
+    }
+}

--- a/tests/unit/BigQuery/JobTest.php
+++ b/tests/unit/BigQuery/JobTest.php
@@ -104,18 +104,6 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $job->waitUntilComplete();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Job did not complete within the allowed number of retries.
-     */
-    public function testWaitsUntilCompleteThrowsExceptionAfterMaxRetries()
-    {
-        $this->jobInfo['status']['state'] = 'RUNNING';
-
-        $job = $this->getJob($this->connection, $this->jobInfo);
-        $job->waitUntilComplete(['maxRetries' => 1]);
-    }
-
     public function testIsCompleteTrue()
     {
         $job = $this->getJob($this->connection, $this->jobInfo);

--- a/tests/unit/BigQuery/JobWaitTraitTest.php
+++ b/tests/unit/BigQuery/JobWaitTraitTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\BigQuery;
+
+use Google\Cloud\BigQuery\Job;
+use Google\Cloud\BigQuery\JobWaitTrait;
+
+/**
+ * @group bigquery
+ */
+class JobWaitTraitTest extends \PHPUnit_Framework_TestCase
+{
+    private $trait;
+    private $job;
+
+    public function setUp()
+    {
+        $this->trait = \Google\Cloud\Dev\impl(JobWaitTrait::class);
+        $this->job = $this->prophesize(Job::class)->reveal();
+    }
+
+    public function testWaitSucceedsWhenAlreadyComplete()
+    {
+        $isCompleteCalled = false;
+        $isReloadCalled = false;
+
+        $this->trait->call('wait', [
+            function() use (&$isCompleteCalled) {
+                $isCompleteCalled = true;
+                return true;
+            },
+            function() use (&$isReloadCalled) {
+                $isReloadCalled = true;
+                return ['complete' => true];
+            },
+            $this->job,
+            1
+        ]);
+
+        $this->assertTrue($isCompleteCalled);
+        $this->assertFalse($isReloadCalled);
+    }
+
+    public function testWaitCallsReloadThenSucceeds()
+    {
+        $isCompleteCallCount = 0;
+        $isReloadCalled = false;
+
+        $this->trait->call('wait', [
+            function() use (&$isCompleteCallCount, &$isReloadCalled) {
+                $isCompleteCallCount++;
+                return $isReloadCalled ? true : false;
+            },
+            function() use (&$isReloadCalled) {
+                $isReloadCalled = true;
+                return ['complete' => true];
+            },
+            $this->job,
+            1
+        ]);
+
+        $this->assertEquals(2, $isCompleteCallCount);
+        $this->assertTrue($isReloadCalled);
+    }
+
+    /**
+     * @expectedException Google\Cloud\BigQuery\Exception\JobException
+     * @expectedExceptionMessage Job did not complete within the allowed number of retries.
+     */
+    public function testWaitThrowsExceptionWhenMaxAttemptsMet()
+    {
+        $this->trait->call('wait', [
+            function() { return false; },
+            function () { return ['complete' => false]; },
+            $this->job,
+            1
+        ]);
+    }
+}

--- a/tests/unit/BigQuery/LoadJobConfigurationTest.php
+++ b/tests/unit/BigQuery/LoadJobConfigurationTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\BigQuery;
+
+use Google\Cloud\BigQuery\LoadJobConfiguration;
+use Google\Cloud\BigQuery\Table;
+
+/**
+ * @group bigquery
+ */
+class LoadJobConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const TABLE_ID = 'my_table';
+    const JOB_ID = '1234';
+
+    private $config;
+    private $tableIdentity = [
+        'projectId' => self::PROJECT_ID,
+        'datasetId' => self::DATASET_ID,
+        'tableId' => self::TABLE_ID
+    ];
+    private $expectedConfig;
+
+    public function setUp()
+    {
+        $this->expectedConfig = [
+            'projectId' => self::PROJECT_ID,
+            'jobReference' => [
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
+            ],
+            'configuration' => [
+                'load' => []
+            ]
+        ];
+        $this->config = new LoadJobConfiguration(
+            self::PROJECT_ID,
+            ['jobReference' => ['jobId' => self::JOB_ID]]
+        );
+    }
+
+    public function testFluentSetters()
+    {
+        $destinationTable = $this->prophesize(Table::class);
+        $destinationTable->identity()
+            ->willReturn($this->tableIdentity);
+        $data = '1234';
+        $load = [
+            'allowJaggedRows' => true,
+            'allowQuotedNewlines' => true,
+            'autodetect' => true,
+            'createDisposition' => 'CREATE_NEVER',
+            'destinationEncryptionConfiguration' => [
+                'kmsKeyName' => 'my_key'
+            ],
+            'destinationTable' => $this->tableIdentity,
+            'encoding' => 'UTF-8',
+            'fieldDelimiter' => '\t',
+            'ignoreUnknownValues' => true,
+            'maxBadRecords' => 10,
+            'nullMarker' => '\N',
+            'projectionFields' => ['field_name'],
+            'quote' => '"',
+            'schema' => ['fields' => [['name' => 'col1', 'type' => 'STRING']]],
+            'schemaUpdateOptions' => ['ALLOW_FIELD_ADDITION'],
+            'skipLeadingRows' => 10,
+            'sourceFormat' => 'CSV',
+            'sourceUris' => ['gs://my_bucket/source.csv'],
+            'timePartitioning' => [
+                'type' => 'DAY'
+            ],
+            'writeDisposition' => 'WRITE_TRUNCATE'
+        ];
+        $this->expectedConfig['configuration']['load'] = $load
+            + $this->expectedConfig['configuration']['load'];
+        $this->config
+            ->allowJaggedRows($load['allowJaggedRows'])
+            ->allowQuotedNewlines($load['allowQuotedNewlines'])
+            ->autodetect($load['autodetect'])
+            ->createDisposition($load['createDisposition'])
+            ->destinationEncryptionConfiguration($load['destinationEncryptionConfiguration'])
+            ->data($data)
+            ->destinationTable($destinationTable->reveal())
+            ->encoding($load['encoding'])
+            ->fieldDelimiter($load['fieldDelimiter'])
+            ->ignoreUnknownValues($load['ignoreUnknownValues'])
+            ->maxBadRecords($load['maxBadRecords'])
+            ->nullMarker($load['nullMarker'])
+            ->projectionFields($load['projectionFields'])
+            ->quote($load['quote'])
+            ->schema($load['schema'])
+            ->schemaUpdateOptions($load['schemaUpdateOptions'])
+            ->skipLeadingRows($load['skipLeadingRows'])
+            ->sourceFormat($load['sourceFormat'])
+            ->sourceUris($load['sourceUris'])
+            ->timePartitioning($load['timePartitioning'])
+            ->writeDisposition($load['writeDisposition']);
+
+        $this->assertEquals(
+            $this->expectedConfig + ['data' => $data],
+            $this->config->toArray()
+        );
+    }
+}

--- a/tests/unit/BigQuery/QueryJobConfigurationTest.php
+++ b/tests/unit/BigQuery/QueryJobConfigurationTest.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\BigQuery;
+
+use Google\Cloud\BigQuery\Dataset;
+use Google\Cloud\BigQuery\QueryJobConfiguration;
+use Google\Cloud\BigQuery\Table;
+use Google\Cloud\BigQuery\ValueMapper;
+
+/**
+ * @group bigquery
+ */
+class QueryJobConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const TABLE_ID = 'my_table';
+    const JOB_ID = '1234';
+
+    private $config;
+    private $datasetIdentity = [
+        'projectId' => self::PROJECT_ID,
+        'datasetId' => self::DATASET_ID
+    ];
+    private $tableIdentity = [
+        'projectId' => self::PROJECT_ID,
+        'datasetId' => self::DATASET_ID,
+        'tableId' => self::TABLE_ID
+    ];
+    private $expectedConfig;
+
+    public function setUp()
+    {
+        $this->expectedConfig = [
+            'projectId' => self::PROJECT_ID,
+            'jobReference' => [
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
+            ],
+            'configuration' => [
+                'query' => [
+                    'useLegacySql' => false
+                ]
+            ]
+        ];
+        $this->config = new QueryJobConfiguration(
+            new ValueMapper(false),
+            self::PROJECT_ID,
+            ['jobReference' => ['jobId' => self::JOB_ID]]
+        );
+    }
+
+    public function testFluentSetters()
+    {
+        $defaultDataset = $this->prophesize(Dataset::class);
+        $defaultDataset->identity()
+            ->willReturn($this->datasetIdentity);
+        $destinationTable = $this->prophesize(Table::class);
+        $destinationTable->identity()
+            ->willReturn($this->tableIdentity);
+        $query = [
+            'allowLargeResults' => true,
+            'createDisposition' => 'CREATE_NEVER',
+            'defaultDataset' => $this->datasetIdentity,
+            'destinationEncryptionConfiguration' => [
+                'kmsKeyName' => 'my_key'
+            ],
+            'destinationTable' => $this->tableIdentity,
+            'flattenResults' => true,
+            'maximumBillingTier' => 1,
+            'maximumBytesBilled' => 100,
+            'priority' => 'BATCH',
+            'query' => 'SELECT * FROM test',
+            'schemaUpdateOptions' => ['ALLOW_FIELD_ADDITION'],
+            'tableDefinitions' => [
+                'autodetect' => true,
+                'sourceUris' => [
+                    'gs://my_bucket/table.json'
+                ]
+            ],
+            'timePartitioning' => [
+                'type' => 'DAY'
+            ],
+            'useLegacySql' => true,
+            'useQueryCache' => true,
+            'userDefinedFunctionResources' => [
+                ['resourceUri' => 'gs://my_bucket/code_path']
+            ],
+            'writeDisposition' => 'WRITE_TRUNCATE'
+        ];
+        $this->expectedConfig['configuration']['query'] = $query
+            + $this->expectedConfig['configuration']['query'];
+        $this->config
+            ->allowLargeResults($query['allowLargeResults'])
+            ->createDisposition($query['createDisposition'])
+            ->defaultDataset($defaultDataset->reveal())
+            ->destinationEncryptionConfiguration($query['destinationEncryptionConfiguration'])
+            ->destinationTable($destinationTable->reveal())
+            ->flattenResults($query['flattenResults'])
+            ->maximumBillingTier($query['maximumBillingTier'])
+            ->maximumBytesBilled($query['maximumBytesBilled'])
+            ->priority($query['priority'])
+            ->query($query['query'])
+            ->schemaUpdateOptions($query['schemaUpdateOptions'])
+            ->tableDefinitions($query['tableDefinitions'])
+            ->timePartitioning($query['timePartitioning'])
+            ->useLegacySql($query['useLegacySql'])
+            ->useQueryCache($query['useQueryCache'])
+            ->userDefinedFunctionResources($query['userDefinedFunctionResources'])
+            ->writeDisposition($query['writeDisposition']);
+
+        $this->assertEquals($this->expectedConfig, $this->config->toArray());
+    }
+
+    /**
+     * @dataProvider parameterDataProvider
+     */
+    public function testParameters($args, $expectedQuery)
+    {
+        $this->expectedConfig['configuration']['query'] = $expectedQuery
+            + $this->expectedConfig['configuration']['query'];
+        $this->config
+            ->parameters($args);
+
+        $this->assertEquals($this->expectedConfig, $this->config->toArray());
+    }
+
+    public function parameterDataProvider()
+    {
+        return [
+            [
+                ['test' => 'parameter'],
+                [
+                    'parameterMode' => 'named',
+                    'queryParameters' => [
+                        [
+                            'name' => 'test',
+                            'parameterType' => [
+                                'type' => 'STRING'
+                            ],
+                            'parameterValue' => [
+                                'value' => 'parameter'
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                [1, 2],
+                [
+                    'parameterMode' => 'positional',
+                    'queryParameters' => [
+                        [
+                            'parameterType' => [
+                                'type' => 'INT64'
+                            ],
+                            'parameterValue' => [
+                                'value' => 1
+                            ]
+                        ],
+                        [
+                            'parameterType' => [
+                                'type' => 'INT64'
+                            ],
+                            'parameterValue' => [
+                                'value' => 2
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+}

--- a/tests/unit/BigQuery/QueryResultsTest.php
+++ b/tests/unit/BigQuery/QueryResultsTest.php
@@ -57,21 +57,8 @@ class QueryResultsTest extends \PHPUnit_Framework_TestCase
             $this->jobId,
             $this->projectId,
             $data,
-            [],
             new ValueMapper(false)
         );
-    }
-
-    /**
-     * @expectedException \Google\Cloud\Core\Exception\GoogleException
-     */
-    public function testGetsRowsThrowsExceptionWhenQueryNotComplete()
-    {
-        $this->queryData['jobComplete'] = false;
-        unset($this->queryData['rows']);
-        $this->connection->getQueryResults()->shouldNotBeCalled();
-        $queryResults = $this->getQueryResults($this->connection, $this->queryData);
-        $queryResults->rows()->next();
     }
 
     public function testGetsRowsWithNoResults()
@@ -105,6 +92,16 @@ class QueryResultsTest extends \PHPUnit_Framework_TestCase
         $rows = iterator_to_array($queryResults->rows());
 
         $this->assertEquals('Alton', $rows[1]['first_name']);
+    }
+
+    public function testGetIterator()
+    {
+        $this->connection->getQueryResults()->shouldNotBeCalled();
+        unset($this->queryData['rows']);
+        $queryResults = $this->getQueryResults($this->connection, $this->queryData);
+        $rows = iterator_to_array($queryResults);
+
+        $this->assertEmpty($rows);
     }
 
     public function testIsCompleteTrue()

--- a/tests/unit/BigQuery/TableTest.php
+++ b/tests/unit/BigQuery/TableTest.php
@@ -33,6 +33,8 @@ use Prophecy\Argument;
  */
 class TableTest extends \PHPUnit_Framework_TestCase
 {
+    const JOBID = 'myJobId';
+
     public $connection;
     public $storageConnection;
     public $mapper;
@@ -58,7 +60,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
     ];
     public $insertJobResponse = [
         'jobReference' => [
-            'jobId' => 'myJobId'
+            'jobId' => self::JOBID
         ]
     ];
 
@@ -80,7 +82,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
     public function getTable($connection, array $data = [], $tableId = null)
     {
-        return new Table(
+        return new TableStub(
             $connection->reveal(),
             $tableId ?: $this->tableId,
             $this->datasetId,
@@ -221,6 +223,10 @@ class TableTest extends \PHPUnit_Framework_TestCase
                         'projectId' => $this->projectId
                     ]
                 ]
+            ],
+            'jobReference' => [
+                'projectId' => $this->projectId,
+                'jobId' => self::JOBID
             ]
         ];
         $this->connection->insertJob(Argument::exact($expectedArguments))
@@ -251,6 +257,10 @@ class TableTest extends \PHPUnit_Framework_TestCase
                         'projectId' => $this->projectId
                     ]
                 ]
+            ],
+            'jobReference' => [
+                'projectId' => $this->projectId,
+                'jobId' => self::JOBID
             ]
         ];
         $this->connection->insertJob(Argument::exact($expectedArguments))
@@ -295,6 +305,10 @@ class TableTest extends \PHPUnit_Framework_TestCase
                         'projectId' => $this->projectId
                     ]
                 ]
+            ],
+            'jobReference' => [
+                'projectId' => $this->projectId,
+                'jobId' => self::JOBID
             ]
         ];
         $this->connection->insertJobUpload(Argument::exact($expectedArguments))
@@ -323,6 +337,10 @@ class TableTest extends \PHPUnit_Framework_TestCase
                         'projectId' => $this->projectId
                     ]
                 ]
+            ],
+            'jobReference' => [
+                'projectId' => $this->projectId,
+                'jobId' => self::JOBID
             ]
         ];
         $this->connection->insertJob(Argument::exact($expectedArguments))
@@ -437,5 +455,13 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($this->tableId, $table->identity()['tableId']);
         $this->assertEquals($this->projectId, $table->identity()['projectId']);
+    }
+}
+
+class TableStub extends Table
+{
+    protected function generateJobId($jobIdPrefix = null)
+    {
+        return $jobIdPrefix ? $jobIdPrefix . '-' . BigQueryClientTest::JOBID : BigQueryClientTest::JOBID;
     }
 }

--- a/tests/unit/BigQuery/TableTest.php
+++ b/tests/unit/BigQuery/TableTest.php
@@ -122,6 +122,22 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
     public function testUpdatesData()
     {
+        $updateData = ['friendlyName' => 'wow a name', 'etag' => 'foo'];
+        $this->connection->patchTable(Argument::that(function ($args) {
+            if ($args['restOptions']['headers']['If-Match'] !== 'foo') return false;
+
+            return true;
+        }))
+            ->willReturn($updateData)
+            ->shouldBeCalledTimes(1);
+        $table = $this->getTable($this->connection, ['friendlyName' => 'another name']);
+        $table->update($updateData);
+
+        $this->assertEquals($updateData['friendlyName'], $table->info()['friendlyName']);
+    }
+
+    public function testUpdatesDataWithEtag()
+    {
         $updateData = ['friendlyName' => 'wow a name'];
         $this->connection->patchTable(Argument::any())
             ->willReturn($updateData)

--- a/tests/unit/BigQuery/TableTest.php
+++ b/tests/unit/BigQuery/TableTest.php
@@ -18,10 +18,15 @@
 namespace Google\Cloud\Tests\Unit\BigQuery;
 
 use Google\Cloud\BigQuery\Connection\ConnectionInterface;
+use Google\Cloud\BigQuery\CopyJobConfiguration;
+use Google\Cloud\BigQuery\ExtractJobConfiguration;
 use Google\Cloud\BigQuery\InsertResponse;
 use Google\Cloud\BigQuery\Job;
+use Google\Cloud\BigQuery\JobConfigurationInterface;
+use Google\Cloud\BigQuery\LoadJobConfiguration;
 use Google\Cloud\BigQuery\Table;
 use Google\Cloud\BigQuery\ValueMapper;
+use Google\Cloud\Core\Exception\ConflictException;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Upload\AbstractUploader;
 use Google\Cloud\Storage\Connection\ConnectionInterface as StorageConnectionInterface;
@@ -33,16 +38,16 @@ use Prophecy\Argument;
  */
 class TableTest extends \PHPUnit_Framework_TestCase
 {
-    const JOBID = 'myJobId';
+    const JOB_ID = 'myJobId';
+    const PROJECT_ID = 'myProjectId';
+    const BUCKET_NAME = 'myBucket';
+    const FILE_NAME = 'myfile.csv';
+    const TABLE_ID = 'myTableId';
+    const DATASET_ID = 'myDatasetId';
 
     public $connection;
     public $storageConnection;
     public $mapper;
-    public $fileName = 'myfile.csv';
-    public $bucketName = 'myBucket';
-    public $projectId = 'myProjectId';
-    public $tableId = 'myTableId';
-    public $datasetId = 'myDatasetId';
     public $rowData = [
         'rows' => [
             ['f' => [['v' => 'Alton']]]
@@ -60,7 +65,10 @@ class TableTest extends \PHPUnit_Framework_TestCase
     ];
     public $insertJobResponse = [
         'jobReference' => [
-            'jobId' => self::JOBID
+            'jobId' => self::JOB_ID
+        ],
+        'status' => [
+            'state' => 'RUNNING'
         ]
     ];
 
@@ -75,8 +83,8 @@ class TableTest extends \PHPUnit_Framework_TestCase
     {
         return new StorageObject(
             $this->storageConnection->reveal(),
-            $this->fileName,
-            $this->bucketName
+            self::FILE_NAME,
+            self::BUCKET_NAME
         );
     }
 
@@ -84,9 +92,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
     {
         return new TableStub(
             $connection->reveal(),
-            $tableId ?: $this->tableId,
-            $this->datasetId,
-            $this->projectId,
+            $tableId ?: self::TABLE_ID,
+            self::DATASET_ID,
+            self::PROJECT_ID,
             $this->mapper,
             $data
         );
@@ -96,7 +104,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
     {
         $this->connection->getTable(Argument::any())
             ->willReturn([
-                'tableReference' => ['tableId' => $this->tableId]
+                'tableReference' => ['tableId' => self::TABLE_ID]
             ])
             ->shouldBeCalledTimes(1);
         $table = $this->getTable($this->connection);
@@ -204,73 +212,145 @@ class TableTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($name, $rows[1]['first_name']);
     }
 
-    public function testRunsCopyJob()
+    /**
+     * @dataProvider jobConfigDataProvider
+     */
+    public function testRunJob($expectedData, $expectedMethod, $returnedData)
+    {
+        $jobConfig = $this->prophesize(JobConfigurationInterface::class);
+        $jobConfig->toArray()
+            ->willReturn($expectedData);
+        $this->connection->$expectedMethod($expectedData)
+            ->willReturn($returnedData)
+            ->shouldBeCalledTimes(1);
+        $this->connection->getJob(Argument::any())
+            ->willReturn([
+                'status' => [
+                    'state' => 'DONE'
+                ]
+            ])
+            ->shouldBeCalledTimes(1);
+        $table = $this->getTable($this->connection);
+        $job = $table->runJob($jobConfig->reveal());
+
+        $this->assertInstanceOf(Job::class, $job);
+        $this->assertTrue($job->isComplete());
+    }
+
+    /**
+     * @dataProvider jobConfigDataProvider
+     */
+    public function testStartJob($expectedData, $expectedMethod, $returnedData)
+    {
+        $jobConfig = $this->prophesize(JobConfigurationInterface::class);
+        $jobConfig->toArray()
+            ->willReturn($expectedData);
+        $this->connection->$expectedMethod($expectedData)
+            ->willReturn($returnedData)
+            ->shouldBeCalledTimes(1);
+        $this->connection->getJob(Argument::any())
+            ->shouldNotBeCalled();
+        $table = $this->getTable($this->connection);
+        $job = $table->startJob($jobConfig->reveal());
+
+        $this->assertInstanceOf(Job::class, $job);
+        $this->assertFalse($job->isComplete());
+        $this->assertEquals($this->insertJobResponse, $job->info());
+    }
+
+    public function jobConfigDataProvider()
+    {
+        $expected = [
+            'projectId' => self::PROJECT_ID,
+            'jobReference' => [
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
+            ]
+        ];
+        $uploader = $this->prophesize(AbstractUploader::class);
+        $uploader->upload()
+            ->willReturn($this->insertJobResponse)
+            ->shouldBeCalledTimes(1);
+
+        return [
+            [
+                $expected,
+                'insertJob',
+                $this->insertJobResponse
+            ],
+            [
+                $expected + ['data' => 'abc'],
+                'insertJobUpload',
+                $uploader->reveal()
+            ]
+        ];
+    }
+
+    public function testGetsCopyJobConfiguration()
     {
         $destinationTableId = 'destinationTable';
         $destinationTable = $this->getTable($this->connection, [], $destinationTableId);
-        $expectedArguments = [
-            'projectId' => $this->projectId,
+        $expected = [
+            'projectId' => self::PROJECT_ID,
             'configuration' => [
                 'copy' => [
                     'destinationTable' => [
-                        'datasetId' => $this->datasetId,
+                        'datasetId' => self::DATASET_ID,
                         'tableId' => $destinationTableId,
-                        'projectId' => $this->projectId
+                        'projectId' => self::PROJECT_ID
                     ],
                     'sourceTable' => [
-                        'datasetId' => $this->datasetId,
-                        'tableId' => $this->tableId,
-                        'projectId' => $this->projectId
+                        'datasetId' => self::DATASET_ID,
+                        'tableId' => self::TABLE_ID,
+                        'projectId' => self::PROJECT_ID
                     ]
                 ]
             ],
             'jobReference' => [
-                'projectId' => $this->projectId,
-                'jobId' => self::JOBID
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
             ]
         ];
-        $this->connection->insertJob(Argument::exact($expectedArguments))
-            ->willReturn($this->insertJobResponse)
-            ->shouldBeCalledTimes(1);
         $table = $this->getTable($this->connection);
-        $job = $table->copy($destinationTable);
+        $config = $table->copy($destinationTable, [
+            'jobReference' => ['jobId' => self::JOB_ID]
+        ]);
 
-        $this->assertInstanceOf(Job::class, $job);
-        $this->assertEquals($this->insertJobResponse, $job->info());
+        $this->assertInstanceOf(CopyJobConfiguration::class, $config);
+        $this->assertEquals($expected, $config->toArray());
     }
 
     /**
      * @dataProvider destinationProvider
      */
-    public function testRunsExportJob($destinationObject)
+    public function testGetsExtractJobConfiguration($destinationObject)
     {
-        $expectedArguments = [
-            'projectId' => $this->projectId,
+        $expected = [
+            'projectId' => self::PROJECT_ID,
             'configuration' => [
                 'extract' => [
                     'destinationUris' => [
-                        'gs://' . $this->bucketName . '/' . $this->fileName
+                        'gs://' . self::BUCKET_NAME . '/' . self::FILE_NAME
                     ],
                     'sourceTable' => [
-                        'datasetId' => $this->datasetId,
-                        'tableId' => $this->tableId,
-                        'projectId' => $this->projectId
+                        'datasetId' => self::DATASET_ID,
+                        'tableId' => self::TABLE_ID,
+                        'projectId' => self::PROJECT_ID
                     ]
                 ]
             ],
             'jobReference' => [
-                'projectId' => $this->projectId,
-                'jobId' => self::JOBID
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
             ]
         ];
-        $this->connection->insertJob(Argument::exact($expectedArguments))
-            ->willReturn($this->insertJobResponse)
-            ->shouldBeCalledTimes(1);
         $table = $this->getTable($this->connection);
-        $job = $table->export($destinationObject);
+        $config = $table->extract($destinationObject, [
+            'jobReference' => ['jobId' => self::JOB_ID]
+        ]);
 
-        $this->assertInstanceOf(Job::class, $job);
-        $this->assertEquals($this->insertJobResponse, $job->info());
+        $this->assertInstanceOf(ExtractJobConfiguration::class, $config);
+        $this->assertEquals($expected, $config->toArray());
     }
 
     public function destinationProvider()
@@ -281,76 +361,70 @@ class TableTest extends \PHPUnit_Framework_TestCase
             [$this->getObject()],
             [sprintf(
                 'gs://%s/%s',
-                $this->bucketName,
-                $this->fileName
+                self::BUCKET_NAME,
+                self::FILE_NAME
             )]
         ];
     }
 
-    public function testRunsLoadJob()
+    public function testGetsLoadJobConfiguration()
     {
         $data = 'abc';
-        $uploader = $this->prophesize(AbstractUploader::class);
-        $uploader->upload()
-            ->willReturn($this->insertJobResponse)
-            ->shouldBeCalledTimes(1);
-        $expectedArguments = [
+        $expected = [
             'data' => $data,
-            'projectId' => $this->projectId,
+            'projectId' => self::PROJECT_ID,
             'configuration' => [
                 'load' => [
                     'destinationTable' => [
-                        'datasetId' => $this->datasetId,
-                        'tableId' => $this->tableId,
-                        'projectId' => $this->projectId
+                        'datasetId' => self::DATASET_ID,
+                        'tableId' => self::TABLE_ID,
+                        'projectId' => self::PROJECT_ID
                     ]
                 ]
             ],
             'jobReference' => [
-                'projectId' => $this->projectId,
-                'jobId' => self::JOBID
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
             ]
         ];
-        $this->connection->insertJobUpload(Argument::exact($expectedArguments))
-            ->willReturn($uploader)
-            ->shouldBeCalledTimes(1);
         $table = $this->getTable($this->connection);
-        $job = $table->load($data);
+        $config = $table->load($data, [
+            'jobReference' => ['jobId' => self::JOB_ID]
+        ]);
 
-        $this->assertInstanceOf(Job::class, $job);
-        $this->assertEquals($this->insertJobResponse, $job->info());
+        $this->assertInstanceOf(LoadJobConfiguration::class, $config);
+        $this->assertEquals($expected, $config->toArray());
     }
 
-    public function testRunsLoadJobFromStorage()
+    public function testGetsLoadJobConfigurationFromStorage()
     {
         $sourceObject = $this->getObject();
-        $expectedArguments = [
-            'projectId' => $this->projectId,
+        $expected = [
+            'projectId' => self::PROJECT_ID,
             'configuration' => [
                 'load' => [
                     'sourceUris' => [
-                        'gs://' . $this->bucketName . '/' . $this->fileName
+                        'gs://' . self::BUCKET_NAME . '/' . self::FILE_NAME
                     ],
                     'destinationTable' => [
-                        'datasetId' => $this->datasetId,
-                        'tableId' => $this->tableId,
-                        'projectId' => $this->projectId
+                        'datasetId' => self::DATASET_ID,
+                        'tableId' => self::TABLE_ID,
+                        'projectId' => self::PROJECT_ID
                     ]
                 ]
             ],
             'jobReference' => [
-                'projectId' => $this->projectId,
-                'jobId' => self::JOBID
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
             ]
         ];
-        $this->connection->insertJob(Argument::exact($expectedArguments))
-            ->willReturn($this->insertJobResponse)
-            ->shouldBeCalledTimes(1);
         $table = $this->getTable($this->connection);
-        $job = $table->loadFromStorage($sourceObject);
+        $config = $table->loadFromStorage($sourceObject, [
+            'jobReference' => ['jobId' => self::JOB_ID]
+        ]);
 
-        $this->assertInstanceOf(Job::class, $job);
-        $this->assertEquals($this->insertJobResponse, $job->info());
+        $this->assertInstanceOf(LoadJobConfiguration::class, $config);
+        $this->assertEquals($expected, $config->toArray());
     }
 
     public function testInsertsRow()
@@ -358,9 +432,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
         $insertId = '1';
         $rowData = ['key' => 'value'];
         $expectedArguments = [
-            'tableId' => $this->tableId,
-            'projectId' => $this->projectId,
-            'datasetId' => $this->datasetId,
+            'tableId' => self::TABLE_ID,
+            'projectId' => self::PROJECT_ID,
+            'datasetId' => self::DATASET_ID,
             'rows' => [
                 [
                     'json' => $rowData,
@@ -392,9 +466,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
             ]
         ];
         $expectedArguments = [
-            'tableId' => $this->tableId,
-            'projectId' => $this->projectId,
-            'datasetId' => $this->datasetId,
+            'tableId' => self::TABLE_ID,
+            'projectId' => self::PROJECT_ID,
+            'datasetId' => self::DATASET_ID,
             'rows' => [
                 [
                     'json' => $data,
@@ -406,8 +480,72 @@ class TableTest extends \PHPUnit_Framework_TestCase
             ->willReturn([])
             ->shouldBeCalledTimes(1);
         $table = $this->getTable($this->connection);
-
         $insertResponse = $table->insertRows($rowData);
+
+        $this->assertInstanceOf(InsertResponse::class, $insertResponse);
+        $this->assertTrue($insertResponse->isSuccessful());
+    }
+
+    public function testInsertsRowsWithAutoCreate()
+    {
+        $insertId = '1';
+        $data = ['key' => 'value'];
+        $rowData = [
+            [
+                'insertId' => $insertId,
+                'data' => $data
+            ]
+        ];
+        $schema = [
+            'fields' => [
+                [
+                    'name' => 'key',
+                    'type' => 'STRING'
+                ]
+            ]
+        ];
+        $expectedInsertTableDataArguments = [
+            'tableId' => self::TABLE_ID,
+            'projectId' => self::PROJECT_ID,
+            'datasetId' => self::DATASET_ID,
+            'rows' => [
+                [
+                    'json' => $data,
+                    'insertId' => $insertId
+                ]
+            ]
+        ];
+        $expectedInsertTableArguments = [
+            'schema' => $schema,
+            'retries' => 0,
+            'projectId' => self::PROJECT_ID,
+            'datasetId' => self::DATASET_ID,
+            'tableReference' => [
+                'projectId' => self::PROJECT_ID,
+                'datasetId' => self::DATASET_ID,
+                'tableId' => self::TABLE_ID
+            ]
+        ];
+        $callCount = 0;
+        $this->connection->insertAllTableData($expectedInsertTableDataArguments)
+            ->will(function () use (&$callCount) {
+                if ($callCount === 0) {
+                    $callCount++;
+                    throw new NotFoundException(null);
+                }
+
+                return [];
+            })
+            ->shouldBeCalledTimes(2);
+        $this->connection->insertTable($expectedInsertTableArguments)
+            ->willReturn([]);
+        $table = $this->getTable($this->connection);
+        $insertResponse = $table->insertRows($rowData, [
+            'autoCreate' => true,
+            'tableMetadata' => [
+                'schema' => $schema
+            ]
+        ]);
 
         $this->assertInstanceOf(InsertResponse::class, $insertResponse);
         $this->assertTrue($insertResponse->isSuccessful());
@@ -415,16 +553,99 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \InvalidArgumentException
+     * @expectedMessage A schema is required when creating a table.
      */
-    public function testInsertRowsThrowsException()
+    public function testInsertRowsThrowsExceptionWithoutSchema()
+    {
+        $options = [
+            'autoCreate' => true
+        ];
+        $this->connection->insertAllTableData(Argument::any())
+            ->willThrow(new NotFoundException(null));
+        $table = $this->getTable($this->connection);
+        $table->insertRows([
+            [
+                'data' => [
+                    'city' => 'state'
+                ]
+            ]
+        ], $options);
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testInsertRowsThrowsExceptionWithUnretryableTableFailure()
+    {
+        $options = [
+            'autoCreate' => true,
+            'tableMetadata' => [
+                'schema' => []
+            ]
+        ];
+        $this->connection->insertAllTableData(Argument::any())
+            ->willThrow(new NotFoundException(null));
+        $this->connection->insertTable(Argument::any())
+            ->willThrow(new \Exception());
+        $table = $this->getTable($this->connection);
+        $table->insertRows([
+            [
+                'data' => [
+                    'city' => 'state'
+                ]
+            ]
+        ], $options);
+    }
+
+    /**
+     * @expectedException Google\Cloud\Core\Exception\NotFoundException
+     */
+    public function testInsertRowsThrowsExceptionWhenMaxRetryLimitHit()
+    {
+        $options = [
+            'autoCreate' => true,
+            'maxRetries' => 0,
+            'tableMetadata' => [
+                'schema' => []
+            ]
+        ];
+        $this->connection->insertAllTableData(Argument::any())
+            ->willThrow(new NotFoundException(null));
+        $this->connection->insertTable(Argument::any())
+            ->willThrow(new ConflictException(null));
+        $table = $this->getTable($this->connection);
+        $table->insertRows([
+            [
+                'data' => [
+                    'city' => 'state'
+                ]
+            ]
+        ], $options);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedMessage A row must have a data key.
+     */
+    public function testInsertRowsThrowsExceptionWithoutDataKey()
     {
         $table = $this->getTable($this->connection);
         $table->insertRows([[], []]);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedMessage Must provide at least a single row.
+     */
+    public function testInsertRowsThrowsExceptionWithZeroRows()
+    {
+        $table = $this->getTable($this->connection);
+        $table->insertRows([]);
+    }
+
     public function testGetsInfo()
     {
-        $tableInfo = ['tableReference' => ['tableId' => $this->tableId]];
+        $tableInfo = ['tableReference' => ['tableId' => self::TABLE_ID]];
         $this->connection->getTable(Argument::any())->shouldNotBeCalled();
         $table = $this->getTable($this->connection, $tableInfo);
 
@@ -433,7 +654,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
     public function testGetsInfoWithReload()
     {
-        $tableInfo = ['tableReference' => ['tableId' => $this->tableId]];
+        $tableInfo = ['tableReference' => ['tableId' => self::TABLE_ID]];
         $this->connection->getTable(Argument::any())
             ->willReturn($tableInfo)
             ->shouldBeCalledTimes(1);
@@ -446,22 +667,22 @@ class TableTest extends \PHPUnit_Framework_TestCase
     {
         $table = $this->getTable($this->connection);
 
-        $this->assertEquals($this->tableId, $table->id());
+        $this->assertEquals(self::TABLE_ID, $table->id());
     }
 
     public function testGetsIdentity()
     {
         $table = $this->getTable($this->connection);
 
-        $this->assertEquals($this->tableId, $table->identity()['tableId']);
-        $this->assertEquals($this->projectId, $table->identity()['projectId']);
+        $this->assertEquals(self::TABLE_ID, $table->identity()['tableId']);
+        $this->assertEquals(self::PROJECT_ID, $table->identity()['projectId']);
     }
 }
 
 class TableStub extends Table
 {
-    protected function generateJobId($jobIdPrefix = null)
+    protected function usleep($ms)
     {
-        return $jobIdPrefix ? $jobIdPrefix . '-' . BigQueryClientTest::JOBID : BigQueryClientTest::JOBID;
+        return;
     }
 }

--- a/tests/unit/Core/ConcurrencyControlTraitTest.php
+++ b/tests/unit/Core/ConcurrencyControlTraitTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Core;
+
+use Google\Cloud\Core\ConcurrencyControlTrait;
+
+/**
+ * @group core
+ */
+class ConcurrencyControlTraitTest extends \PHPUnit_Framework_TestCase
+{
+    const ETAG = 'foobar';
+
+    private $trait;
+
+    public function setUp()
+    {
+        $this->trait = \Google\Cloud\Dev\impl(ConcurrencyControlTrait::class);
+    }
+
+    public function testApplyEtagHeader()
+    {
+        $input = ['etag' => self::ETAG];
+
+        $res = $this->trait->call('applyEtagHeader', [$input]);
+
+        $this->assertEquals(self::ETAG, $res['restOptions']['headers']['If-Match']);
+    }
+
+    public function testApplyEtagHeaderCustomName()
+    {
+        $input = ['test' => self::ETAG];
+
+        $res = $this->trait->call('applyEtagHeader', [$input, 'test']);
+
+        $this->assertEquals(self::ETAG, $res['restOptions']['headers']['If-Match']);
+    }
+}

--- a/tests/unit/Core/RetryDeciderTraitTest.php
+++ b/tests/unit/Core/RetryDeciderTraitTest.php
@@ -34,6 +34,18 @@ class RetryDeciderTraitTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider retryProvider
      */
+    public function testDisableRetry($exception)
+    {
+        $this->implementation->call('setHttpRetryCodes', [[]]);
+        $this->implementation->call('setHttpRetryMessages', [[]]);
+        $retryFunction = $this->implementation->call('getRetryFunction');
+
+        $this->assertFalse($retryFunction($exception));
+    }
+
+    /**
+     * @dataProvider retryProvider
+     */
     public function testShouldRetry($exception, $shouldRetryMessage, $expected)
     {
         $retryFunction = $this->implementation->call('getRetryFunction', [$shouldRetryMessage]);


### PR DESCRIPTION
These changes help us prepare for a GA release of BigQuery. For more details on the work, please refer to the following PRs which have been aggregated here:

https://github.com/GoogleCloudPlatform/google-cloud-php/pull/604 - Run query and wait for it to complete
https://github.com/GoogleCloudPlatform/google-cloud-php/pull/634 - Add support for etags on bigquery tables and datasets
https://github.com/GoogleCloudPlatform/google-cloud-php/pull/640 - Switch to standard SQL by default
https://github.com/GoogleCloudPlatform/google-cloud-php/pull/642 - Implement waitUntilComplete and block while waiting for query results
https://github.com/GoogleCloudPlatform/google-cloud-php/pull/643 - Generate BigQuery Job ID on client side with optional prefix

Edit: Also now includes https://github.com/GoogleCloudPlatform/google-cloud-php/pull/686

/cc @tswast @michaelbausor 