### PR TITLE
Implement automatic downsizing of session pool

### DIFF
--- a/src/Spanner/Connection/Grpc.php
+++ b/src/Spanner/Connection/Grpc.php
@@ -120,6 +120,11 @@ class Grpc implements ConnectionInterface
     private $longRunningGrpcClients;
 
     /**
+     * @var AgentHeaderDescriptor
+     */
+    private $headerDescriptor;
+
+    /**
      * @param array $config [optional]
      */
     public function __construct(array $config = [])
@@ -156,6 +161,9 @@ class Grpc implements ConnectionInterface
             $this->instanceAdminClient,
             $this->databaseAdminClient
         ];
+        $this->headerDescriptor = new AgentHeaderDescriptor([
+            'gapicVersion' => trim(file_get_contents(__DIR__ . '/../VERSION'))
+        ]);
     }
 
     /**
@@ -460,10 +468,7 @@ class Grpc implements ConnectionInterface
     public function deleteSessionAsync(array $args)
     {
         $database = $this->pluck('database', $args);
-        $headerDescriptor = new AgentHeaderDescriptor([
-            'gapicVersion' => trim(file_get_contents(__DIR__ . '/../VERSION'))
-        ]);
-        $headers = $headerDescriptor->getHeader()
+        $headers = $this->headerDescriptor->getHeader()
             + $this->addResourcePrefixHeader($args, $database)['userHeaders'];
         $request = new DeleteSessionRequest();
         $request->setName($this->pluck('name', $args));

--- a/src/Spanner/Database.php
+++ b/src/Spanner/Database.php
@@ -1458,6 +1458,18 @@ class Database
     }
 
     /**
+     * Returns the underlying connection.
+     *
+     * @access private
+     * @return ConnectionInterface
+     * @experimental
+     */
+    public function connection()
+    {
+        return $this->connection;
+    }
+
+    /**
      * Represent the class in a more readable and digestable fashion.
      *
      * @access private

--- a/src/Spanner/Session/CacheSessionPool.php
+++ b/src/Spanner/Session/CacheSessionPool.php
@@ -39,19 +39,18 @@ use Psr\Cache\CacheItemPoolInterface;
  * recommended way to bootstrap the session pool.
  *
  * Sessions are created on demand up to the maximum session value set during
- * instantiation of the pool. After peak usage hours, you may find that more
- * sessions are available than your demand may require. It is important to make
- * sure the number of active sessions managed by the Spanner backend is kept
- * as minimal as possible. In order to help maintain this balance, please use
- * the {@see Google\Cloud\Spanner\Session\CacheSessionPool::downsize()} method
- * on an interval that matches when you expect to see a decrease in traffic.
- * This will help ensure you never run into issues where the Spanner backend is
+ * instantiation of the pool. To help ensure the minimum number of sessions
+ * required are managed by the pool, attempts will be made to automatically
+ * downsize after every 10 minute window. This feature is configurable and one
+ * may also downsize at their own choosing via
+ * {@see Google\Cloud\Spanner\Session\CacheSessionPool::downsize()}. Downsizing
+ * will help ensure you never run into issues where the Spanner backend is
  * locked up after having met the maximum number of sessions assigned per node.
  * For reference, the current maximum sessions per database per node is 10k. For
  * more information on limits please see
  * [here](https://cloud.google.com/spanner/docs/limits).
  *
- * Additionally, when expecting a long period of inactivity (such as a
+ * When expecting a long period of inactivity (such as a
  * maintenance window), please make sure to call
  * {@see Google\Cloud\Spanner\Session\CacheSessionPool::clear()} in order to
  * delete any active sessions.
@@ -83,9 +82,9 @@ class CacheSessionPool implements SessionPoolInterface
     use SysvTrait;
 
     const CACHE_KEY_TEMPLATE = 'cache-session-pool.%s.%s.%s';
-
     const DURATION_TWENTY_MINUTES = 1200;
     const DURATION_ONE_MINUTE = 60;
+    const WINDOW_SIZE = 600;
 
     /**
      * @var array
@@ -95,7 +94,8 @@ class CacheSessionPool implements SessionPoolInterface
         'minSessions' => 1,
         'shouldWaitForSession' => true,
         'maxCyclesToWaitForSession' => 30,
-        'sleepIntervalSeconds' => .5
+        'sleepIntervalSeconds' => .5,
+        'shouldAutoDownsize' => true
     ];
 
     /**
@@ -119,6 +119,11 @@ class CacheSessionPool implements SessionPoolInterface
     private $database;
 
     /**
+     * @var array
+     */
+    private $deleteQueue = [];
+
+    /**
      * @param CacheItemPoolInterface $cacheItemPool A PSR-6 compatible cache
      *        implementation used to store the session data.
      * @param array $config [optional] {
@@ -140,6 +145,9 @@ class CacheSessionPool implements SessionPoolInterface
      *           **Defaults to** a semaphore based implementation if the
      *           required extensions are installed, otherwise an flock based
      *           implementation.
+     *     @type bool $shouldAutoDownsize Determines whether or not to
+     *           automatically attempt to downsize the pool after every 10
+     *           minute window. **Defaults to** `true`.
      * }
      * @throws \InvalidArgumentException
      */
@@ -228,10 +236,13 @@ class CacheSessionPool implements SessionPoolInterface
 
                 if (!$exception) {
                     $session = array_shift($data['queue']);
-
                     $data['inUse'][$session['name']] = $session + [
                         'lastActive' => $this->time()
                     ];
+
+                    if ($this->config['shouldAutoDownsize']) {
+                        $this->manageSessionsToDelete($data);
+                    }
                 }
 
                 $this->cacheItemPool->save($item->set($data));
@@ -255,6 +266,11 @@ class CacheSessionPool implements SessionPoolInterface
             }
 
             $session = $this->waitForNextAvailableSession();
+        }
+
+        if ($this->deleteQueue) {
+            $this->deleteSessions($this->deleteQueue);
+            $this->deleteQueue = [];
         }
 
         return $this->database->session($session['name']);
@@ -414,40 +430,24 @@ class CacheSessionPool implements SessionPoolInterface
     /**
      * Clear the cache and attempt to delete all sessions in the pool.
      *
-     * Please note this method will attempt to synchronously delete sessions and
-     * will block until complete.
+     * A session may be removed from the cache, but still tracked as active by
+     * the Spanner backend if a delete operation failed. To ensure you do not
+     * exceed the maximum number of sessions available per node, please be sure
+     * to check the return value of this method to be certain all sessions have
+     * been deleted.
      */
     public function clear()
     {
         $sessions = $this->config['lock']->synchronize(function () {
-            $sessions = [];
             $item = $this->cacheItemPool->getItem($this->cacheKey);
             $data = (array) $item->get() ?: $this->initialize();
-
-            foreach ($data['queue'] as $session) {
-                $sessions[] = $session['name'];
-            }
-
-            foreach ($data['inUse'] as $session) {
-                $sessions[] = $session['name'];
-            }
-
+            $sessions = $data['queue'] + $data['inUse'];
             $this->cacheItemPool->clear();
 
             return $sessions;
         });
 
-        foreach ($sessions as $sessionName) {
-            $session = $this->database->session($sessionName);
-
-            try {
-                $session->delete();
-            } catch (\Exception $ex) {
-                if ($ex instanceof NotFoundException) {
-                    continue;
-                }
-            }
-        }
+        $this->deleteSessions($sessions);
     }
 
     /**
@@ -557,7 +557,9 @@ class CacheSessionPool implements SessionPoolInterface
         return [
             'queue' => [],
             'inUse' => [],
-            'toCreate' => []
+            'toCreate' => [],
+            'windowStart' => $this->time(),
+            'maxInUseSessions' => 0
         ];
     }
 
@@ -570,17 +572,13 @@ class CacheSessionPool implements SessionPoolInterface
      */
     private function getSessionCount(array $data)
     {
-        $count = 0;
-
-        foreach ($data as $sessionType) {
-            $count += count($sessionType);
-        }
-
-        return $count;
+        return count($data['queue'])
+            + count($data['inUse'])
+            + count($data['toCreate']);
     }
 
     /**
-     * Gets the next session in the queue, clearing out which are expired.
+     * Gets the next session in the queue, clearing out any which are expired.
      *
      * @param array $data
      * @return array|null
@@ -597,6 +595,10 @@ class CacheSessionPool implements SessionPoolInterface
             $data['inUse'][$session['name']] = $session + [
                 'lastActive' => $this->time()
             ];
+
+            if ($this->config['shouldAutoDownsize']) {
+                $this->manageSessionsToDelete($data);
+            }
         }
 
         return $session;
@@ -743,6 +745,65 @@ class CacheSessionPool implements SessionPoolInterface
         if (isset($this->config['lock']) && !$this->config['lock'] instanceof LockInterface) {
             throw new \InvalidArgumentException(
                 'The lock must implement Google\Cloud\Core\Lock\LockInterface'
+            );
+        }
+    }
+
+    /**
+     * Delete the provided sessions.
+     *
+     * @param array $sessions
+     */
+    private function deleteSessions(array $sessions)
+    {
+        $calls = [];
+
+        foreach ($sessions as $session) {
+            $calls[] = $this->database->connection()
+                ->deleteSessionAsync([
+                    'name' => $session['name'],
+                    'database' => $this->database->name()
+                ]);
+        }
+
+        foreach ($calls as $call) {
+            $call->wait();
+        }
+    }
+
+    /**
+     * Checks the maximum number of sessions in use over the last window(s) then
+     * removes the sessions from the cache and prepares them to be deleted from
+     * the Spanner backend.
+     *
+     * @param array $data
+     */
+    private function manageSessionsToDelete(array &$data)
+    {
+        $secondsSinceLastWindow = $this->time() - $data['windowStart'];
+        $inUseCount = count($data['inUse']);
+
+        if ($secondsSinceLastWindow < self::WINDOW_SIZE + 1) {
+            if ($data['maxInUseSessions'] < $inUseCount) {
+                $data['maxInUseSessions'] = $inUseCount;
+            }
+
+            return;
+        }
+
+        $totalCount = $inUseCount + count($data['queue']) + count($data['toCreate']);
+        $windowsPassed = (int) ($secondsSinceLastWindow / self::WINDOW_SIZE);
+        $deletionCount = min(
+            $totalCount - (int) round($data['maxInUseSessions'] / $windowsPassed),
+            $totalCount - $this->config['minSessions']
+        );
+        $data['maxInUseSessions'] = $inUseCount;
+        $data['windowStart'] = $this->time();
+
+        if ($deletionCount) {
+            $this->deleteQueue += array_splice(
+                $data['queue'],
+                (int) -$deletionCount
             );
         }
     }

--- a/src/Spanner/V1/SpannerClient.php
+++ b/src/Spanner/V1/SpannerClient.php
@@ -40,7 +40,7 @@ use Google\Spanner\V1\SpannerGrpcClient;
 class SpannerClient extends SpannerGapicClient
 {
     /**
-     * Returns the underyling stub.
+     * Returns the underlying stub.
      *
      * @access private
      * @return SpannerGrpcClient
@@ -52,7 +52,7 @@ class SpannerClient extends SpannerGapicClient
     }
 
     /**
-     * Returns the underyling gRPC credentials helper.
+     * Returns the underlying gRPC credentials helper.
      *
      * @access private
      * @return GrpcCredentialsHelper

--- a/src/Spanner/V1/SpannerClient.php
+++ b/src/Spanner/V1/SpannerClient.php
@@ -31,11 +31,35 @@
 namespace Google\Cloud\Spanner\V1;
 
 use Google\Cloud\Spanner\V1\Gapic\SpannerGapicClient;
+use Google\GAX\GrpcCredentialsHelper;
+use Google\Spanner\V1\SpannerGrpcClient;
 
 /**
  * {@inheritdoc}
  */
 class SpannerClient extends SpannerGapicClient
 {
-    // This class is intentionally empty, and is intended to hold manual additions to the generated {@see SpannerClientImpl} class.
+    /**
+     * Returns the underyling stub.
+     *
+     * @access private
+     * @return SpannerGrpcClient
+     * @experimental
+     */
+    public function getStub()
+    {
+        return $this->spannerStub;
+    }
+
+    /**
+     * Returns the underyling gRPC credentials helper.
+     *
+     * @access private
+     * @return GrpcCredentialsHelper
+     * @experimental
+     */
+    public function getCredentialsHelper()
+    {
+        return $this->grpcCredentialsHelper;
+    }
 }

--- a/tests/unit/Spanner/Session/CacheSessionPoolTest.php
+++ b/tests/unit/Spanner/Session/CacheSessionPoolTest.php
@@ -288,33 +288,6 @@ class CacheSessionPoolTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function testDownsizeFails()
-    {
-        $time = time() + 3600;
-        $pool = new CacheSessionPoolStub($this->getCacheItemPool([
-            'queue' => [
-                [
-                    'name' => 'session0',
-                    'expiration' => $time
-                ],
-                [
-                    'name' => 'session1',
-                    'expiration' => $time
-                ]
-            ],
-            'inUse' => [],
-            'toCreate' => [],
-            'windowStart' => $this->time,
-            'maxInUseSessions' => 1
-        ]));
-        $pool->setDatabase($this->getDatabase());
-        $response = $pool->downsize(100);
-
-        $this->assertEquals(0, $response['deleted']);
-        $this->assertEquals(1, count($response['failed']));
-        $this->assertContainsOnlyInstancesOf(Session::class, $response['failed']);
-    }
-
     /**
      * @dataProvider invalidPercentDownsizeDataProvider
      */


### PR DESCRIPTION
Closes: https://github.com/GoogleCloudPlatform/google-cloud-php/issues/490

Please note, the circumvention of the GAPIC client is intended to be temporary until concurrent request support is built into the clients.