### PR TITLE
Add PHP 7.2 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
   include:
   - php: 7.0
   - php: 7.1
+  - php: 7.2
   - php: 5.5.38
   - php: 5.6.25
   - php: hhvm


### PR DESCRIPTION
For test preview, see [this log](https://travis-ci.org/jdpedrie/google-cloud-php/jobs/270450779)