### PR TITLE
adds version and servicebuilder to entry and release command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
             "id": "google-cloud",
             "target": "git@github.com:jdpedrie-gcp/google-cloud-php.git",
             "path": "src",
-            "entry": null
+            "entry": ["Version.php", "ServiceBuilder.php"]
         }
     }
 }

--- a/dev/src/Release/Command/Release.php
+++ b/dev/src/Release/Command/Release.php
@@ -108,12 +108,20 @@ class Release extends Command
             $version
         ));
 
-        $this->updateComponentVersionConstant($version, $component);
-        $output->writeln(sprintf(
-            'File %s VERSION constant updated to %s',
-            $component['entry'],
-            $version
-        ));
+        foreach ((array) $component['entry'] as $entry) {
+            $entryUpdated = $this->updateComponentVersionConstant(
+                $version,
+                $component['path'],
+                $entry
+            );
+            if ($entryUpdated) {
+                $output->writeln(sprintf(
+                    'File %s VERSION constant updated to %s',
+                    $entry,
+                    $version
+                ));
+            }
+        }
 
         if ($component['id'] !== 'google-cloud') {
             $this->updateComponentVersionFile($version, $component);
@@ -166,13 +174,13 @@ class Release extends Command
         }
     }
 
-    private function updateComponentVersionConstant($version, array $component)
+    private function updateComponentVersionConstant($version, $componentPath, $componentEntry)
     {
-        if (is_null($component['entry'])) {
+        if (is_null($componentEntry)) {
             return false;
         }
 
-        $path = $this->cliBasePath .'/../'. $component['path'] .'/'. $component['entry'];
+        $path = $this->cliBasePath .'/../'. $componentPath .'/'. $componentEntry;
         if (!file_exists($path)) {
             throw new \RuntimeException(sprintf(
                 'Component entry file %s does not exist',


### PR DESCRIPTION
The following works as expected:

```sh
$ php dev/google-cloud release -c google-cloud minor
Adding version 0.39.0 to Documentation Manifest for component google-cloud.
Setting component version constant to 0.39.0.
File Version.php VERSION constant updated to 0.39.0
File ServiceBuilder.php VERSION constant updated to 0.39.0
Release 0.39.0 generated!
```