### PR TITLE
Fix key used in TableData.List test

### DIFF
--- a/tests/unit/BigQuery/TableTest.php
+++ b/tests/unit/BigQuery/TableTest.php
@@ -175,7 +175,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
             ->shouldBeCalledTimes(1);
         $this->connection->listTableData(Argument::any())
             ->willReturn(
-                $this->rowData + ['nextPageToken' => 'abc'],
+                $this->rowData + ['pageToken' => 'abc'],
                 $secondRowData
             )
             ->shouldBeCalledTimes(2);


### PR DESCRIPTION
Follow up to https://github.com/GoogleCloudPlatform/google-cloud-php/pull/669