### PR TITLE
ensures PSR log level can be int or string

### DIFF
--- a/src/Logging/Connection/Grpc.php
+++ b/src/Logging/Connection/Grpc.php
@@ -312,7 +312,7 @@ class Grpc implements ConnectionInterface
         }
 
         if (isset($entry['severity']) && is_string($entry['severity'])) {
-            $entry['severity'] = array_flip(Logger::getLogLevelMap())[$entry['severity']];
+            $entry['severity'] = array_flip(Logger::getLogLevelMap())[strtoupper($entry['severity'])];
         }
 
         return $this->serializer->decodeMessage(new LogEntry(), $entry);


### PR DESCRIPTION
casts `$level` to an integer to ensure it can be handled by gRPC in `PsrLogger`. Otherwise, passing in a string (such as `"emergency"`) raises the following error:

```
PHP Notice:  Undefined index: warning in vendor/google/cloud-logging/Connection/Grpc.php on line 315

Notice: Undefined index: warning in vendor/google/cloud-logging/Connection/Grpc.php on line 315

                   
  [Exception]      
  Expect integer.  
                   
```