### PR TITLE
Introduce remaining BigQuery to GA items

### DIFF
--- a/src/BigQuery/BigQueryClient.php
+++ b/src/BigQuery/BigQueryClient.php
@@ -21,6 +21,7 @@ use Google\Cloud\BigQuery\Connection\ConnectionInterface;
 use Google\Cloud\BigQuery\Connection\Rest;
 use Google\Cloud\BigQuery\Exception\JobException;
 use Google\Cloud\BigQuery\Job;
+use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\ClientTrait;
 use Google\Cloud\Core\Int64;
 use Google\Cloud\Core\Iterator\ItemIterator;
@@ -42,6 +43,7 @@ use Psr\Http\Message\StreamInterface;
  */
 class BigQueryClient
 {
+    use ArrayTrait;
     use ClientTrait;
 
     const VERSION = '0.2.2';
@@ -111,10 +113,10 @@ class BigQueryClient
      * set of options at once.
      *
      * Unless otherwise specified, all configuration options will default based
-     * on the
-     * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
-     * except for `configuration.query.useLegacy`, which defaults to `false` in
-     * this client.
+     * on the [Jobs configuration API documentation]
+     * (https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration)
+     * except for `configuration.query.useLegacySql`, which defaults to `false`
+     * in this client.
      *
      * Example:
      * ```
@@ -127,7 +129,7 @@ class BigQueryClient
      * // Set create disposition using fluent setters.
      * $queryJobConfig = $bigQuery->query(
      *     'SELECT commit FROM `bigquery-public-data.github_repos.commits` LIMIT 100'
-     * )->createDisposition(QueryJobConfiguration::CREATE_DISPOSITION_CREATE_NEVER);
+     * )->createDisposition('CREATE_NEVER');
      * ```
      *
      * ```
@@ -138,7 +140,7 @@ class BigQueryClient
      *     [
      *         'configuration' => [
      *             'query' => [
-     *                 'createDisposition' => QueryJobConfiguration::CREATE_DISPOSITION_CREATE_NEVER
+     *                 'createDisposition' => 'CREATE_NEVER'
      *             ]
      *         ]
      *     ]
@@ -233,7 +235,7 @@ class BigQueryClient
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs/query Query API documentation.
      *
-     * @param QueryJobConfiguration $query A BigQuery SQL query.
+     * @param QueryJobConfiguration $query A BigQuery SQL query configuration.
      * @param array $options [optional] {
      *     Configuration options.
      *
@@ -251,7 +253,7 @@ class BigQueryClient
      * @throws JobException If the maximum number of retries while waiting for
      *         query completion has been exceeded.
      */
-    public function runQuery(QueryJobConfiguration $query, array $options = [])
+    public function runQuery(JobConfigurationInterface $query, array $options = [])
     {
         $queryResultsOptions = $this->pluckArray([
             'maxResults',
@@ -289,11 +291,11 @@ class BigQueryClient
      *
      * @see https://cloud.google.com/bigquery/docs/reference/v2/jobs/insert Jobs insert API documentation.
      *
-     * @param QueryJobConfiguration $query A BigQuery SQL query.
+     * @param QueryJobConfiguration $query A BigQuery SQL query configuration.
      * @param array $options [optional] Configuration options.
      * @return Job
      */
-    public function startQuery(QueryJobConfiguration $query, array $options = [])
+    public function startQuery(JobConfigurationInterface $query, array $options = [])
     {
         $config = $query->toArray();
         $response = $this->connection->insertJob($config + $options);

--- a/src/BigQuery/Connection/Rest.php
+++ b/src/BigQuery/Connection/Rest.php
@@ -246,12 +246,19 @@ class Rest implements ConnectionInterface
         $args += [
             'projectId' => null,
             'data' => null,
-            'configuration' => []
+            'configuration' => [],
+            'labels' => [],
+            'dryRun' => false,
+            'jobReference' => []
         ];
 
         $args['data'] = Psr7\stream_for($args['data']);
-        $args['metadata']['configuration'] = $args['configuration'];
-        unset($args['configuration']);
+        $args['metadata'] = $this->pluckArray([
+            'labels',
+            'dryRun',
+            'jobReference',
+            'configuration'
+        ], $args);
 
         $uploaderOptionKeys = [
             'restOptions',

--- a/src/BigQuery/CopyJobConfiguration.php
+++ b/src/BigQuery/CopyJobConfiguration.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+/**
+ * Represents a configuration for a copy job. For more information on the
+ * available settings please see the
+ * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration).
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\BigQuery\BigQueryClient;
+ *
+ * $bigQuery = new BigQueryClient();
+ * $sourceTable = $bigQuery->dataset('my_dataset')
+ *     ->table('my_source_table');
+ * $destinationTable = $bigQuery->dataset('my_dataset')
+ *     ->table('my_destination_table');
+ *
+ * $copyJobConfig = $sourceTable->copy($destinationTable);
+ * ```
+ */
+class CopyJobConfiguration implements JobConfigurationInterface
+{
+    use JobConfigurationTrait;
+
+    /**
+     * @param string $projectId The project's ID.
+     * @param array $config A set of configuration options for a job.
+     */
+    public function __construct($projectId, array $config)
+    {
+        $this->jobConfigurationProperties($projectId, $config);
+    }
+
+    /**
+     * Set whether the job is allowed to create new tables. Creation, truncation
+     * and append actions occur as one atomic update upon job completion.
+     *
+     * Example:
+     * ```
+     * $copyJobConfig->createDisposition('CREATE_NEVER');
+     * ```
+     *
+     * @param string $createDisposition The create disposition. Acceptable
+     *        values include `"CREATED_IF_NEEDED"`, `"CREATE_NEVER"`. **Defaults
+     *        to** `"CREATE_IF_NEEDED"`.
+     * @return CopyJobConfiguration
+     */
+    public function createDisposition($createDisposition)
+    {
+        $this->config['configuration']['copy']['createDisposition'] = $createDisposition;
+
+        return $this;
+    }
+
+    /**
+     * Sets the custom encryption configuration (e.g., Cloud KMS keys).
+     *
+     * Example:
+     * ```
+     * $copyJobConfig->destinationEncryptionConfiguration([
+     *     'kmsKeyName' => 'my_key'
+     * ]);
+     * ```
+     *
+     * @param array $configuration Custom encryption configuration.
+     * @return CopyJobConfiguration
+     */
+    public function destinationEncryptionConfiguration(array $configuration)
+    {
+        $this->config['configuration']['copy']['destinationEncryptionConfiguration'] = $configuration;
+
+        return $this;
+    }
+
+    /**
+     * Sets the destination table.
+     *
+     * Example:
+     * ```
+     * $table = $bigQuery->dataset('my_dataset')
+     *     ->table('my_table');
+     * $copyJobConfig->destinationTable($table);
+     * ```
+     *
+     * @param Table $destinationTable The destination table.
+     * @return CopyJobConfiguration
+     */
+    public function destinationTable(Table $destinationTable)
+    {
+        $this->config['configuration']['copy']['destinationTable'] = $destinationTable->identity();
+
+        return $this;
+    }
+
+    /**
+     * Sets the source table to copy.
+     *
+     * Example:
+     * ```
+     * $table = $bigQuery->dataset('my_dataset')
+     *     ->table('source_table');
+     * $copyJobConfig->sourceTable($table);
+     * ```
+     *
+     * @param Table $sourceTable The destination table.
+     * @return CopyJobConfiguration
+     */
+    public function sourceTable(Table $sourceTable)
+    {
+        $this->config['configuration']['copy']['sourceTable'] = $sourceTable->identity();
+
+        return $this;
+    }
+
+    /**
+     * Sets the action that occurs if the destination table already exists. Each
+     * action is atomic and only occurs if BigQuery is able to complete the job
+     * successfully. Creation, truncation and append actions occur as one atomic
+     * update upon job completion.
+     *
+     * Example:
+     * ```
+     * $copyJobConfig->writeDisposition('WRITE_TRUNCATE');
+     * ```
+     *
+     * @param string $writeDisposition The write disposition. Acceptable values
+     *        include `"WRITE_TRUNCATE"`, `"WRITE_APPEND"`, `"WRITE_EMPTY"`.
+     *        **Defaults to** `"WRITE_EMPTY"`.
+     * @return CopyJobConfiguration
+     */
+    public function writeDisposition($writeDisposition)
+    {
+        $this->config['configuration']['copy']['writeDisposition'] = $writeDisposition;
+
+        return $this;
+    }
+}

--- a/src/BigQuery/ExtractJobConfiguration.php
+++ b/src/BigQuery/ExtractJobConfiguration.php
@@ -17,7 +17,22 @@
 
 namespace Google\Cloud\BigQuery;
 
-class ExtractJobConfiguration
+/**
+ * Represents a configuration for an extract job. For more information on the
+ * available settings please see the
+ * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration).
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\BigQuery\BigQueryClient;
+ *
+ * $bigQuery = new BigQueryClient();
+ * $table = $bigQuery->dataset('my_dataset')
+ *     ->table('my_table');
+ * $extractJobConfig = $table->extract('gs://my_bucket/target.csv');
+ * ```
+ */
+class ExtractJobConfiguration implements JobConfigurationInterface
 {
     use JobConfigurationTrait;
 
@@ -31,8 +46,16 @@ class ExtractJobConfiguration
     }
 
     /**
-     * @param string $compression
-     * @return LoadJobConfiguration
+     * Sets the compression type to use for exported files.
+     *
+     * Example:
+     * ```
+     * $extractJobConfig->compression('GZIP');
+     * ```
+     *
+     * @param string $compression The compression type. Acceptable values
+     *        include `"GZIP"`, `"NONE"`. **Defaults to** `"NONE"`.
+     * @return ExtractJobConfiguration
      */
     public function compression($compression)
     {
@@ -42,19 +65,18 @@ class ExtractJobConfiguration
     }
 
     /**
-     * @param string|resource|StreamInterface $data
-     * @return LoadJobConfiguration
-     */
-    public function data($data)
-    {
-        $this->config['data'] = $data;
-
-        return $this;
-    }
-
-    /**
-     * @param string $destinationFormat
-     * @return LoadJobConfiguration
+     * Sets the exported file format. Tables with nested or repeated fields
+     * cannot be exported as CSV.
+     *
+     * Example:
+     * ```
+     * $extractJobConfig->destinationFormat('NEWLINE_DELIMITED_JSON');
+     * ```
+     *
+     * @param string $destinationFormat The exported file format. Acceptable
+     *        values include `"CSV"`, `"NEWLINE_DELIMITED_JSON"`, `"AVRO"`.
+     *        **Defaults to** `"CSV"`.
+     * @return ExtractJobConfiguration
      */
     public function destinationFormat($destinationFormat)
     {
@@ -64,8 +86,18 @@ class ExtractJobConfiguration
     }
 
     /**
-     * @param array $destinationUris
-     * @return LoadJobConfiguration
+     * Sets a list of fully-qualified Google Cloud Storage URIs where the
+     * extracted table should be written.
+     *
+     * Example:
+     * ```
+     * $extractJobConfig->destinationUris([
+     *     'gs://my_bucket/destination.csv'
+     * ]);
+     * ```
+     *
+     * @param array $destinationUris The destination URIs.
+     * @return ExtractJobConfiguration
      */
     public function destinationUris(array $destinationUris)
     {
@@ -75,8 +107,15 @@ class ExtractJobConfiguration
     }
 
     /**
-     * @param string $fieldDelimiter
-     * @return LoadJobConfiguration
+     * Sets the delimiter to use between fields in the exported data.
+     *
+     * Example:
+     * ```
+     * $extractJobConfig->fieldDelimiter(',');
+     * ```
+     *
+     * @param string $fieldDelimiter The field delimiter. **Defaults to** `","`.
+     * @return ExtractJobConfiguration
      */
     public function fieldDelimiter($fieldDelimiter)
     {
@@ -86,8 +125,16 @@ class ExtractJobConfiguration
     }
 
     /**
-     * @param string $printHeader
-     * @return LoadJobConfiguration
+     * Sets whether or not to print out a header row in the results.
+     *
+     * Example:
+     * ```
+     * $extractJobConfig->printHeader(false);
+     * ```
+     *
+     * @param bool $printHeader Whether or not to print out a header row.
+     *        **Defaults to** `true`.
+     * @return ExtractJobConfiguration
      */
     public function printHeader($printHeader)
     {
@@ -97,12 +144,21 @@ class ExtractJobConfiguration
     }
 
     /**
-     * @param array $sourceTable
-     * @return LoadJobConfiguration
+     * Sets a reference to the table being exported.
+     *
+     * Example:
+     * ```
+     * $table = $bigQuery->dataset('my_dataset')
+     *     ->table('my_table');
+     * $extractJobConfig->sourceTable($table);
+     * ```
+     *
+     * @param Table $sourceTable
+     * @return ExtractJobConfiguration
      */
-    public function sourceTable(array $sourceTable)
+    public function sourceTable(Table $sourceTable)
     {
-        $this->config['configuration']['extract']['sourceTable'] = $sourceTable;
+        $this->config['configuration']['extract']['sourceTable'] = $sourceTable->identity();
 
         return $this;
     }

--- a/src/BigQuery/ExtractJobConfiguration.php
+++ b/src/BigQuery/ExtractJobConfiguration.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+class ExtractJobConfiguration
+{
+    use JobConfigurationTrait;
+
+    /**
+     * @param string $projectId The project's ID.
+     * @param array $config A set of configuration options for a job.
+     */
+    public function __construct($projectId, array $config)
+    {
+        $this->jobConfigurationProperties($projectId, $config);
+    }
+
+    /**
+     * @param string $compression
+     * @return LoadJobConfiguration
+     */
+    public function compression($compression)
+    {
+        $this->config['configuration']['extract']['compression'] = $compression;
+
+        return $this;
+    }
+
+    /**
+     * @param string|resource|StreamInterface $data
+     * @return LoadJobConfiguration
+     */
+    public function data($data)
+    {
+        $this->config['data'] = $data;
+
+        return $this;
+    }
+
+    /**
+     * @param string $destinationFormat
+     * @return LoadJobConfiguration
+     */
+    public function destinationFormat($destinationFormat)
+    {
+        $this->config['configuration']['extract']['destinationFormat'] = $destinationFormat;
+
+        return $this;
+    }
+
+    /**
+     * @param array $destinationUris
+     * @return LoadJobConfiguration
+     */
+    public function destinationUris(array $destinationUris)
+    {
+        $this->config['configuration']['extract']['destinationUris'] = $destinationUris;
+
+        return $this;
+    }
+
+    /**
+     * @param string $fieldDelimiter
+     * @return LoadJobConfiguration
+     */
+    public function fieldDelimiter($fieldDelimiter)
+    {
+        $this->config['configuration']['extract']['fieldDelimiter'] = $fieldDelimiter;
+
+        return $this;
+    }
+
+    /**
+     * @param string $printHeader
+     * @return LoadJobConfiguration
+     */
+    public function printHeader($printHeader)
+    {
+        $this->config['configuration']['extract']['printHeader'] = $printHeader;
+
+        return $this;
+    }
+
+    /**
+     * @param array $sourceTable
+     * @return LoadJobConfiguration
+     */
+    public function sourceTable(array $sourceTable)
+    {
+        $this->config['configuration']['extract']['sourceTable'] = $sourceTable;
+
+        return $this;
+    }
+}

--- a/src/BigQuery/Job.php
+++ b/src/BigQuery/Job.php
@@ -103,6 +103,9 @@ class Job
      * Requests that a job be cancelled. You will need to poll the job to ensure
      * the cancel request successfully goes through.
      *
+     * Please note that by default the library will not attempt to retry this
+     * call on your behalf.
+     *
      * Example:
      * ```
      * $job->cancel();
@@ -124,7 +127,11 @@ class Job
      */
     public function cancel(array $options = [])
     {
-        $this->connection->cancelJob($options + $this->identity);
+        $this->connection->cancelJob(
+            $options
+            + ['retries' => 0]
+            + $this->identity
+        );
     }
 
     /**

--- a/src/BigQuery/Job.php
+++ b/src/BigQuery/Job.php
@@ -172,7 +172,7 @@ class Job
      *     Configuration options.
      *
      *     @type int $maxRetries The number of times to retry, checking if the
-     *           query has completed. **Defaults to** `100`.
+     *           job has completed. **Defaults to** `100`.
      * }
      * @throws JobException If the maximum number of retries while waiting for
      *         job completion has been exceeded.

--- a/src/BigQuery/JobConfigurationInterface.php
+++ b/src/BigQuery/JobConfigurationInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+/**
+ * A contract to be implemented by job configurations.
+ */
+interface JobConfigurationInterface
+{
+    /**
+     * Returns the job config as an array.
+     *
+     * @return array
+     */
+    public function toArray();
+}

--- a/src/BigQuery/JobConfigurationTrait.php
+++ b/src/BigQuery/JobConfigurationTrait.php
@@ -35,7 +35,7 @@ trait JobConfigurationTrait
     /**
      * @var array $config
      */
-    private $config;
+    private $config = [];
 
     /**
      * Sets shared job configuration properties.
@@ -46,13 +46,14 @@ trait JobConfigurationTrait
      */
     public function jobConfigurationProperties($projectId, array $config)
     {
-        $this->config = $config + [
+        $this->config = array_replace_recursive([
             'projectId' => $projectId,
-            'jobReference' => [
-                'jobId' => $this->generateJobId(),
-                'projectId' => $projectId
-            ]
-        ];
+            'jobReference' => ['projectId' => $projectId]
+        ], $config);
+
+        if (!isset($this->config['jobReference']['jobId'])) {
+            $this->config['jobReference']['jobId'] = $this->generateJobId();
+        }
     }
 
     /**
@@ -73,7 +74,7 @@ trait JobConfigurationTrait
      * Sets a prefix for the job ID.
      *
      * @param string $jobIdPrefix If provided, the job ID will be of format
-     *        `{$jobIdPrefix-}{jobId}`.
+     *        `{$jobIdPrefix}-{jobId}`.
      * @return JobConfigInterface
      */
     public function jobIdPrefix($jobIdPrefix)
@@ -123,6 +124,6 @@ trait JobConfigurationTrait
      */
     protected function generateJobId()
     {
-        return Uuid::uuid4();
+        return (string) Uuid::uuid4();
     }
 }

--- a/src/BigQuery/LoadJobConfiguration.php
+++ b/src/BigQuery/LoadJobConfiguration.php
@@ -1,0 +1,526 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+/**
+ * Represents a configuration for a load job. For more information on the
+ * available settings please see the
+ * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration).
+ *
+ * Example:
+ * ```
+ * use Google\Cloud\BigQuery\BigQueryClient;
+ *
+ * $bigQuery = new BigQueryClient();
+ * $table = $bigQuery->dataset('my_dataset')
+ *     ->table('my_table');
+ * $loadJobConfig = $table->load(fopen('/path/to/my/data.csv', 'r'));
+ * ```
+ */
+class LoadJobConfiguration implements JobConfigurationInterface
+{
+    use JobConfigurationTrait;
+
+    /**
+     * @param string $projectId The project's ID.
+     * @param array $config A set of configuration options for a job.
+     */
+    public function __construct($projectId, array $config)
+    {
+        $this->jobConfigurationProperties($projectId, $config);
+    }
+
+    /**
+     * Sets whether to accept rows that are missing trailing optional columns.
+     * The missing values are treated as nulls. If false, records with missing
+     * trailing columns are treated as bad records, and if there are too many
+     * bad records, an invalid error is returned in the job result. Only
+     * applicable to CSV, ignored for other formats.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->allowJaggedRows(true);
+     * ```
+     *
+     * @param bool $allowJaggedRows Whether or not to allow jagged rows.
+     *        **Defaults to** `false`.
+     * @return LoadJobConfiguration
+     */
+    public function allowJaggedRows($allowJaggedRows)
+    {
+        $this->config['configuration']['load']['allowJaggedRows'] = $allowJaggedRows;
+
+        return $this;
+    }
+
+    /**
+     * Sets whether quoted data sections that contain newline characters in a
+     * CSV file are allowed.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->allowQuotedNewlines(true);
+     * ```
+     *
+     * @param bool $allowQuotedNewlines Whether or not to allow quoted new
+     *        lines. **Defaults to** `false`.
+     * @return LoadJobConfiguration
+     */
+    public function allowQuotedNewlines($allowQuotedNewlines)
+    {
+        $this->config['configuration']['load']['allowQuotedNewlines'] = $allowQuotedNewlines;
+
+        return $this;
+    }
+
+    /**
+     * Sets whether we should automatically infer the options and schema for CSV
+     * and JSON sources.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->autodetect(true);
+     * ```
+     *
+     * @param bool $autodetect Whether or not to autodetect options and schema.
+     * @return LoadJobConfiguration
+     */
+    public function autodetect($autodetect)
+    {
+        $this->config['configuration']['load']['autodetect'] = $autodetect;
+
+        return $this;
+    }
+
+    /**
+     * Set whether the job is allowed to create new tables. Creation, truncation
+     * and append actions occur as one atomic update upon job completion.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->createDisposition('CREATE_NEVER');
+     * ```
+     *
+     * @param string $createDisposition The create disposition. Acceptable
+     *        values include `"CREATED_IF_NEEDED"`, `"CREATE_NEVER"`. **Defaults
+     *        to** `"CREATE_IF_NEEDED"`.
+     * @return LoadJobConfiguration
+     */
+    public function createDisposition($createDisposition)
+    {
+        $this->config['configuration']['load']['createDisposition'] = $createDisposition;
+
+        return $this;
+    }
+
+    /**
+     * Sets the custom encryption configuration (e.g., Cloud KMS keys).
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->destinationEncryptionConfiguration([
+     *     'kmsKeyName' => 'my_key'
+     * ]);
+     * ```
+     *
+     * @param array $configuration Custom encryption configuration.
+     * @return LoadJobConfiguration
+     */
+    public function destinationEncryptionConfiguration(array $configuration)
+    {
+        $this->config['configuration']['load']['destinationEncryptionConfiguration'] = $configuration;
+
+        return $this;
+    }
+
+    /**
+     * The data to be loaded into the table.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->data(fopen('/path/to/my/data.csv', 'r'));
+     * ```
+     *
+     * @param string|resource|StreamInterface $data The data to be loaded into
+     *        the table.
+     * @return LoadJobConfiguration
+     */
+    public function data($data)
+    {
+        $this->config['data'] = $data;
+
+        return $this;
+    }
+
+    /**
+     * Sets the destination table to load the data into.
+     *
+     * Example:
+     * ```
+     * $table = $bigQuery->dataset('my_dataset')
+     *     ->table('my_table');
+     * $loadJobConfig->destinationTable($table);
+     * ```
+     *
+     * @param Table $destinationTable The destination table.
+     * @return LoadJobConfiguration
+     */
+    public function destinationTable(Table $destinationTable)
+    {
+        $this->config['configuration']['load']['destinationTable'] = $destinationTable->identity();
+
+        return $this;
+    }
+
+    /**
+     * Sets the character encoding of the data. BigQuery decodes the data after
+     * the raw, binary data has been split using the values of the quote and
+     * fieldDelimiter properties.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->encoding('UTF-8');
+     * ```
+     *
+     * @param string $encoding The encoding type. Acceptable values include
+     *        `"UTF-8"`, `"ISO-8859-1"`. **Defaults to** `"UTF-8"`.
+     * @return LoadJobConfiguration
+     */
+    public function encoding($encoding)
+    {
+        $this->config['configuration']['load']['encoding'] = $encoding;
+
+        return $this;
+    }
+
+    /**
+     * Sets the separator for fields in a CSV file. The separator can be any
+     * ISO-8859-1 single-byte character. To use a character in the range
+     * 128-255, you must encode the character as UTF8. BigQuery converts the
+     * string to ISO-8859-1 encoding, and then uses the first byte of the
+     * encoded string to split the data in its raw, binary state. BigQuery also
+     * supports the escape sequence "\t" to specify a tab separator.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->fieldDelimiter('\t');
+     * ```
+     *
+     * @param string $fieldDelimiter The field delimiter. **Defaults to** `","`.
+     * @return LoadJobConfiguration
+     */
+    public function fieldDelimiter($fieldDelimiter)
+    {
+        $this->config['configuration']['load']['fieldDelimiter'] = $fieldDelimiter;
+
+        return $this;
+    }
+
+    /**
+     * Sets whether values that are not represented in the table schema should
+     * be allowed. If true, the extra values are ignored. If false, records with
+     * extra columns are treated as bad records, and if there are too many bad
+     * records, an invalid error is returned in the job result.
+     *
+     * The sourceFormat property determines what BigQuery treats as an extra
+     * value:
+     *
+     * - CSV: Trailing columns.
+     * - JSON: Named values that don't match any column names.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->ignoreUnknownValues(true);
+     * ```
+     *
+     * @param bool $ignoreUnknownValues Whether or not to ignore unknown values.
+     *        **Defaults to** `false`.
+     * @return LoadJobConfiguration
+     */
+    public function ignoreUnknownValues($ignoreUnknownValues)
+    {
+        $this->config['configuration']['load']['ignoreUnknownValues'] = $ignoreUnknownValues;
+
+        return $this;
+    }
+
+    /**
+     * Sets the maximum number of bad records that BigQuery can ignore when
+     * running the job. If the number of bad records exceeds this value, an
+     * invalid error is returned in the job result.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->maxBadRecords(10);
+     * ```
+     *
+     * @param int $maxBadRecords The maximum number of bad records.
+     *        **Defaults to** `0` (requires all records to be valid).
+     * @return LoadJobConfiguration
+     */
+    public function maxBadRecords($maxBadRecords)
+    {
+        $this->config['configuration']['load']['maxBadRecords'] = $maxBadRecords;
+
+        return $this;
+    }
+
+    /**
+     * Sets a string that represents a null value in a CSV file. For example,
+     * if you specify "\N", BigQuery interprets "\N" as a null value when
+     * loading a CSV file. The default value is the empty string. If you set
+     * this property to a custom value, BigQuery throws an error if an empty
+     * string is present for all data types except for STRING and BYTE. For
+     * STRING and BYTE columns, BigQuery interprets the empty string as an
+     * empty value.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->nullMarker('\N');
+     * ```
+     *
+     * @param string $nullMarker The null marker.
+     * @return LoadJobConfiguration
+     */
+    public function nullMarker($nullMarker)
+    {
+        $this->config['configuration']['load']['nullMarker'] = $nullMarker;
+
+        return $this;
+    }
+
+    /**
+     * Sets a list of projection fields. If sourceFormat is set to
+     * "DATASTORE_BACKUP", indicates which entity properties to load into
+     * BigQuery from a Cloud Datastore backup. Property names are case sensitive
+     * and must be top-level properties. If no properties are specified,
+     * BigQuery loads all properties. If any named property isn't found in the
+     * Cloud Datastore backup, an invalid error is returned in the job result.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->projectionFields([
+     *     'field_name'
+     * ]);
+     * ```
+     *
+     * @param array $projectionFields The projection fields.
+     * @return LoadJobConfiguration
+     */
+    public function projectionFields(array $projectionFields)
+    {
+        $this->config['configuration']['load']['projectionFields'] = $projectionFields;
+
+        return $this;
+    }
+
+    /**
+     * Sets the value that is used to quote data sections in a CSV file.
+     * BigQuery converts the string to ISO-8859-1 encoding, and then uses the
+     * first byte of the encoded string to split the data in its raw, binary
+     * state. If your data does not contain quoted sections, set the property
+     * value to an empty string. If your data contains quoted newline
+     * characters, you must also set the allowQuotedNewlines property to true.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->quote('"');
+     * ```
+     *
+     * @param string $quote The quote value. **Defaults to** `"""`
+     *        (double quotes).
+     * @return LoadJobConfiguration
+     */
+    public function quote($quote)
+    {
+        $this->config['configuration']['load']['quote'] = $quote;
+
+        return $this;
+    }
+
+    /**
+     * Sets the schema for the destination table. The schema can be omitted if
+     * the destination table already exists, or if you're loading data from
+     * Google Cloud Datastore.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->schema([
+     *     'fields' => [
+     *         [
+     *             'name' => 'col1',
+     *             'type' => 'STRING',
+     *         ],
+     *         [
+     *             'name' => 'col2',
+     *             'type' => 'BOOL',
+     *         ]
+     *     ]
+     * ]);
+     * ```
+     *
+     * @param array $schema The table schema.
+     * @return LoadJobConfiguration
+     */
+    public function schema(array $schema)
+    {
+        $this->config['configuration']['load']['schema'] = $schema;
+
+        return $this;
+    }
+
+    /**
+     * Sets options to allow the schema of the destination table to be updated
+     * as a side effect of the query job. Schema update options are supported
+     * in two cases: when writeDisposition is `"WRITE_APPEND"`; when
+     * writeDisposition is `"WRITE_TRUNCATE"` and the destination table is a
+     * partition of a table, specified by partition decorators. For normal
+     * tables, `"WRITE_TRUNCATE"` will always overwrite the schema.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->schemaUpdateOptions([
+     *     'ALLOW_FIELD_ADDITION'
+     * ]);
+     * ```
+     *
+     * @param array $schemaUpdateOptions Schema update options. Acceptable
+     *        values include `"ALLOW_FIELD_ADDITION"` (allow adding a nullable
+     *        field to the schema),  `"ALLOW_FIELD_RELAXATION"` (allow relaxing
+     *        a required field in the original schema to nullable).
+     * @return LoadJobConfiguration
+     */
+    public function schemaUpdateOptions(array $schemaUpdateOptions)
+    {
+        $this->config['configuration']['load']['schemaUpdateOptions'] = $schemaUpdateOptions;
+
+        return $this;
+    }
+
+    /**
+     * Sets the number of rows at the top of a CSV file that BigQuery will skip
+     * when loading the data. This property is useful if you have header rows in
+     * the file that should be skipped.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->skipLeadingRows(10);
+     * ```
+     *
+     * @param int $skipLeadingRows The number of rows to skip.
+     *        **Defaults to** `0`.
+     * @return LoadJobConfiguration
+     */
+    public function skipLeadingRows($skipLeadingRows)
+    {
+        $this->config['configuration']['load']['skipLeadingRows'] = $skipLeadingRows;
+
+        return $this;
+    }
+
+    /**
+     * Sets the format of the data files.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->sourceFormat('NEWLINE_DELIMITED_JSON');
+     * ```
+     *
+     * @param string $sourceFormat The source format. Acceptable values include
+     *        `"CSV"`, `"DATASTORE_BACKUP"`. `"NEWLINE_DELIMITED_JSON"`,
+     *        `"AVRO"`. **Defaults to** `"CSV"`.
+     * @return LoadJobConfiguration
+     */
+    public function sourceFormat($sourceFormat)
+    {
+        $this->config['configuration']['load']['sourceFormat'] = $sourceFormat;
+
+        return $this;
+    }
+
+    /**
+     * Sets the fully-qualified URIs that point to your data in Google Cloud.
+     *
+     * - For Google Cloud Storage URIs: Each URI can contain one '*' wildcard
+     *   character and it must come after the 'bucket' name.
+     * - For Google Cloud Bigtable URIs: Exactly one URI can be specified and it
+     *   has be a fully specified and valid HTTPS URL for a Google Cloud Bigtable
+     *   table.
+     * - For Google Cloud Datastore backups: Exactly one URI can be specified.
+     *   Also, the '*' wildcard character is not allowed.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->sourceUris([
+     *     'gs://my_bucket/source.csv'
+     * ]);
+     * ```
+     *
+     * @param array $sourceUris The source URIs.
+     * @return LoadJobConfiguration
+     */
+    public function sourceUris(array $sourceUris)
+    {
+        $this->config['configuration']['load']['sourceUris'] = $sourceUris;
+
+        return $this;
+    }
+
+    /**
+     * Sets time-based partitioning for the destination table.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->timePartitioning([
+     *     'type' => 'DAY'
+     * ]);
+     * ```
+     *
+     * @param array $timePartitioning Time-based partitioning configuration.
+     * @return LoadJobConfiguration
+     */
+    public function timePartitioning(array $timePartitioning)
+    {
+        $this->config['configuration']['load']['timePartitioning'] = $timePartitioning;
+
+        return $this;
+    }
+
+    /**
+     * Sets the action that occurs if the destination table already exists. Each
+     * action is atomic and only occurs if BigQuery is able to complete the job
+     * successfully. Creation, truncation and append actions occur as one atomic
+     * update upon job completion.
+     *
+     * Example:
+     * ```
+     * $loadJobConfig->writeDisposition('WRITE_TRUNCATE');
+     * ```
+     *
+     * @param string $writeDisposition The write disposition. Acceptable values
+     *        include `"WRITE_TRUNCATE"`, `"WRITE_APPEND"`, `"WRITE_EMPTY"`.
+     *        **Defaults to** `"WRITE_APPEND"`.
+     * @return LoadJobConfiguration
+     */
+    public function writeDisposition($writeDisposition)
+    {
+        $this->config['configuration']['load']['writeDisposition'] = $writeDisposition;
+
+        return $this;
+    }
+}

--- a/src/BigQuery/QueryJobConfiguration.php
+++ b/src/BigQuery/QueryJobConfiguration.php
@@ -1,0 +1,328 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\BigQuery;
+
+/**
+ * Represents a configuration for a query job. For more information on the
+ * available settings please see the
+ * [Jobs configuration API documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration).
+ */
+class QueryJobConfiguration
+{
+    use JobConfigurationTrait;
+
+    const CREATE_DISPOSITION_CREATE_IF_NEEDED = 'CREATE_IF_NEEDED';
+    const CREATE_DISPOSITION_CREATE_NEVER = 'CREATE_NEVER';
+    const PRIORITY_INTERACTIVE = 'INTERACTIVE';
+    const PRIORITY_BATCH = 'BATCH';
+    const WRITE_DISPOSITION_WRITE_TRUNCATE = 'WRITE_TRUNCATE';
+    const WRITE_DISPOSITION_WRITE_APPEND = 'WRITE_APPEND';
+    const WRITE_DISPOSITION_WRITE_EMPTY = 'WRITE_EMPTY';
+
+    /**
+     * @var ValueMapper Maps values between PHP and BigQuery.
+     */
+    private $mapper;
+
+    /**
+     * @param ValueMapper $mapper Maps values between PHP and BigQuery.
+     * @param string $projectId The project's ID.
+     * @param array $config A set of configuration options for a job.
+     */
+    public function __construct(ValueMapper $mapper, $projectId, array $config)
+    {
+        $this->mapper = $mapper;
+        $this->jobConfigurationProperties($projectId, $config);
+
+        if (!isset($this->config['configuration']['query']['useLegacySql'])) {
+            $this->config['configuration']['query']['useLegacySql'] = false;
+        }
+    }
+
+    /**
+     * Sets whether or not the query should allow large result sets.
+     *
+     * @param bool $allowLargeResults Whether or not to allow large result sets.
+     * @return QueryJobConfiguration
+     */
+    public function allowLargeResults($allowLargeResults)
+    {
+        $this->config['configuration']['query']['allowLargeResults'] = $allowLargeResults;
+
+        return $this;
+    }
+
+    /**
+     * Sets the create disposition.
+     *
+     * @param string $createDisposition Determine Whether the job is allowed to
+     *        create new tables. Acceptable values include `"CREATE_IF_NEEDED"`,
+     *        `"CREATE_NEVER"`. Please note constants for these values exist
+     *        on this class.
+     * @return QueryJobConfiguration
+     */
+    public function createDisposition($createDisposition)
+    {
+        $this->config['configuration']['query']['createDisposition'] = $createDisposition;
+
+        return $this;
+    }
+
+    /**
+     * Sets the default dataset.
+     *
+     * @param array $defaultDataset The default dataset to use for unqualified
+     *        table names in the query.
+     * @return QueryJobConfiguration
+     */
+    public function defaultDataset(array $defaultDataset)
+    {
+        $this->config['configuration']['query']['defaultDataset'] = $defaultDataset;
+
+        return $this;
+    }
+
+    /**
+     * Sets the encryption configuration.
+     *
+     * @codeCoverageIgnoreEnd
+     *
+     * @param array $configuration Custom encryption configuration (e.g.,
+     *        Cloud KMS keys).
+     * @return QueryJobConfiguration
+     */
+    public function destinationEncryptionConfiguration(array $configuration)
+    {
+        $this->config['configuration']['query']['destinationEncryptionConfiguration'] = $configuration;
+
+        return $this;
+    }
+
+    /**
+     * Sets the destination table.
+     *
+     * @param array $destinationTable The table where the query results should
+     *        be stored. If not set, a new table will be created to store the
+     *        results. This property must be set for large results that exceed
+     *        the maximum response size.
+     * @return QueryJobConfiguration
+     */
+    public function destinationTable(array $destinationTable)
+    {
+        $this->config['configuration']['query']['destinationTable'] = $destinationTable;
+
+        return $this;
+    }
+
+    /**
+     * Sets whether or not to flatten results.
+     *
+     * @param bool $flattenResults Whether or not to flatten results.
+     * @return QueryJobConfiguration
+     */
+    public function flattenResults($flattenResults)
+    {
+        $this->config['configuration']['query']['flattenResults'] = $flattenResults;
+
+        return $this;
+    }
+
+    /**
+     * Sets the maximum billing tier.
+     *
+     * @param int $maximumBillingTier Limits the billing tier for this job.
+     * @return QueryJobConfiguration
+     */
+    public function maximumBillingTier($maximumBillingTier)
+    {
+        $this->config['configuration']['query']['maximumBillingTier'] = $maximumBillingTier;
+
+        return $this;
+    }
+
+    /**
+     * Sets the maximum bytes billed.
+     *
+     * @param int $maximumBytesBilled Limits the bytes billed for this job.
+     * @return QueryJobConfiguration
+     */
+    public function maximumBytesBilled($maximumBytesBilled)
+    {
+        $this->config['configuration']['query']['maximumBytesBilled'] = $maximumBytesBilled;
+
+        return $this;
+    }
+
+    /**
+     * Sets parameters to be used on the query. Only available for standard SQL
+     * queries.
+     *
+     * @param array $parameters Parameters to use on the query. When providing
+     *        a non-associative array positional parameters (`?`) will be used.
+     *        When providing an associative array named parameters will be used
+     *        (`@name`).
+     * @return QueryJobConfiguration
+     */
+    public function parameters(array $parameters)
+    {
+        $this->config['configuration']['query']['parameterMode'] = $this->isAssoc($parameters)
+            ? 'named'
+            : 'positional';
+        $queryParams = [];
+
+        foreach ($parameters as $name => $value) {
+            $param = $this->mapper->toParameter($value);
+
+            if ($this->config['configuration']['query']['parameterMode'] === 'named') {
+                $param += ['name' => $name];
+            }
+
+            $queryParams[] = $param;
+        }
+
+        $this->config['configuration']['query']['queryParameters'] = $queryParams;
+
+        return $this;
+    }
+
+    /**
+     * Sets the priority.
+     *
+     * @param string $priority A priority for the query. Possible
+     *        values include `"INTERACTIVE"` and `"BATCH"`. **Defaults to**
+     *        `"INTERACTIVE"`. Please note constants for these values exist
+     *        on this class.
+     * @return QueryJobConfiguration
+     */
+    public function priority($priority)
+    {
+        $this->config['configuration']['query']['priority'] = $priority;
+
+        return $this;
+    }
+
+    /**
+     * Sets the SQL query.
+     *
+     * @param string $query SQL query text to execute.
+     * @return QueryJobConfiguration
+     */
+    public function query($query)
+    {
+        $this->config['configuration']['query']['query'] = $query;
+
+        return $this;
+    }
+
+    /**
+     * Sets the schema update options. Allows the schema of the destination
+     * table to be updated as a side effect of the query job.
+     *
+     * @param array $schemaUpdateOptions Schema update options.
+     * @return QueryJobConfiguration
+     */
+    public function schemaUpdateOptions(array $schemaUpdateOptions)
+    {
+        $this->config['configuration']['query']['schemaUpdateOptions'] = $schemaUpdateOptions;
+
+        return $this;
+    }
+
+    /**
+     * Sets table definitions. If querying an external data source outside of
+     * BigQuery, describes the data format, location and other properties of the
+     * data source.
+     *
+     * @param array $tableDefinitions The table definitions.
+     * @return QueryJobConfiguration
+     */
+    public function tableDefinitions(array $tableDefinitions)
+    {
+        $this->config['configuration']['query']['tableDefinitions'] = $tableDefinitions;
+
+        return $this;
+    }
+
+    /**
+     * Sets time partitioning.
+     *
+     * @param array $timePartitioning Time-based partitioning for the
+     *        destination table.
+     * @return QueryJobConfiguration
+     */
+    public function timePartitioning(array $timePartitioning)
+    {
+        $this->config['configuration']['query']['timePartitioning'] = $timePartitioning;
+
+        return $this;
+    }
+
+    /**
+     * Sets whether or not to use legacy SQL dialect.
+     *
+     * @param bool $useLegacySql
+     * @return QueryJobConfiguration
+     */
+    public function useLegacySql($useLegacySql)
+    {
+        $this->config['configuration']['query']['useLegacySql'] = $useLegacySql;
+
+        return $this;
+    }
+
+    /**
+     * Sets whether or not to use the query cache.
+     *
+     * @param bool $useQueryCache Whether or not to use the query cache.
+     * @return QueryJobConfiguration
+     */
+    public function useQueryCache($useQueryCache)
+    {
+        $this->config['configuration']['query']['useQueryCache'] = $useQueryCache;
+
+        return $this;
+    }
+
+    /**
+     * Specifies the default dataset to use for unqualified table names in the
+     * query.
+     *
+     * @param string $priority
+     * @return QueryJobConfiguration
+     */
+    public function userDefinedFunctionResources(array $userDefinedFunctionResources)
+    {
+        $this->config['configuration']['query']['userDefinedFunctionResources'] = $userDefinedFunctionResources;
+
+        return $this;
+    }
+
+    /**
+     * Specifies the default dataset to use for unqualified table names in the
+     * query.
+     *
+     * @param string $priority
+     * @return QueryJobConfiguration
+     */
+    public function writeDisposition($writeDisposition)
+    {
+        $this->config['configuration']['query']['writeDisposition'] = $writeDisposition;
+
+        return $this;
+    }
+}

--- a/src/Core/ArrayTrait.php
+++ b/src/Core/ArrayTrait.php
@@ -53,7 +53,7 @@ trait ArrayTrait
      *
      * @param string $keys
      * @param array $arr
-     * @return string
+     * @return array
      */
     private function pluckArray(array $keys, &$arr)
     {

--- a/src/Core/RetryDeciderTrait.php
+++ b/src/Core/RetryDeciderTrait.php
@@ -77,4 +77,20 @@ trait RetryDeciderTrait
             return false;
         };
     }
+
+    /**
+     * @param array $codes
+     */
+    private function setHttpRetryCodes(array $codes)
+    {
+        $this->httpRetryCodes = $codes;
+    }
+
+    /**
+     * @param array $messages
+     */
+    private function setHttpRetryMessages(array $messages)
+    {
+        $this->httpRetryMessages = $messages;
+    }
 }

--- a/tests/snippets/BigQuery/CopyJobConfigurationTest.php
+++ b/tests/snippets/BigQuery/CopyJobConfigurationTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Snippets\BigQuery;
+
+use Google\Cloud\BigQuery\BigQueryClient;
+use Google\Cloud\BigQuery\CopyJobConfiguration;
+use Google\Cloud\Dev\Snippet\SnippetTestCase;
+
+/**
+ * @group bigquery
+ */
+class CopyJobConfigurationTest extends SnippetTestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const TABLE_ID = 'my_table';
+    const JOB_ID = '123';
+
+    private $config;
+
+    public function setUp()
+    {
+        $this->config = new CopyJobConfiguration(
+            self::PROJECT_ID,
+            ['jobReference' => ['jobId' => self::JOB_ID]]
+        );
+    }
+
+    public function testClass()
+    {
+        $snippet = $this->snippetFromClass(CopyJobConfiguration::class);
+        $res = $snippet->invoke('copyJobConfig');
+
+        $this->assertInstanceOf(CopyJobConfiguration::class, $res->returnVal());
+    }
+
+    /**
+     * @dataProvider setterDataProvider
+     */
+    public function testSetters($method, $expected, $bq = null)
+    {
+        $snippet = $this->snippetFromMethod(CopyJobConfiguration::class, $method);
+        $snippet->addLocal('copyJobConfig', $this->config);
+
+        if ($bq) {
+            $snippet->addLocal('bigQuery', $bq);
+        }
+
+        $actual = $snippet->invoke('copyJobConfig')
+            ->returnVal()
+            ->toArray()['configuration']['copy'][$method];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function setterDataProvider()
+    {
+        $bq = \Google\Cloud\Dev\stub(BigQueryClient::class, [
+            ['projectId' => self::PROJECT_ID]
+        ]);
+
+        return [
+            [
+                'createDisposition',
+                'CREATE_NEVER'
+            ],
+            [
+                'destinationEncryptionConfiguration',
+                [
+                    'kmsKeyName' => 'my_key'
+                ]
+            ],
+            [
+                'destinationTable',
+                [
+                    'projectId' => self::PROJECT_ID,
+                    'datasetId' => self::DATASET_ID,
+                    'tableId' => self::TABLE_ID
+                ],
+                $bq
+            ],
+            [
+                'sourceTable',
+                [
+                    'projectId' => self::PROJECT_ID,
+                    'datasetId' => self::DATASET_ID,
+                    'tableId' => 'source_table'
+                ],
+                $bq
+            ],
+            [
+                'writeDisposition',
+                'WRITE_TRUNCATE'
+            ]
+        ];
+    }
+}

--- a/tests/snippets/BigQuery/ExtractJobConfigurationTest.php
+++ b/tests/snippets/BigQuery/ExtractJobConfigurationTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Snippets\BigQuery;
+
+use Google\Cloud\BigQuery\BigQueryClient;
+use Google\Cloud\BigQuery\ExtractJobConfiguration;
+use Google\Cloud\BigQuery\Table;
+use Google\Cloud\Dev\Snippet\SnippetTestCase;
+
+/**
+ * @group bigquery
+ */
+class ExtractJobConfigurationTest extends SnippetTestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const TABLE_ID = 'my_table';
+    const JOB_ID = '123';
+
+    private $config;
+
+    public function setUp()
+    {
+        $this->config = new ExtractJobConfiguration(
+            self::PROJECT_ID,
+            ['jobReference' => ['jobId' => self::JOB_ID]]
+        );
+    }
+
+    public function testClass()
+    {
+        $snippet = $this->snippetFromClass(ExtractJobConfiguration::class);
+        $res = $snippet->invoke('extractJobConfig');
+
+        $this->assertInstanceOf(ExtractJobConfiguration::class, $res->returnVal());
+    }
+
+    /**
+     * @dataProvider setterDataProvider
+     */
+    public function testSetters($method, $expected, $bq = null)
+    {
+        $snippet = $this->snippetFromMethod(ExtractJobConfiguration::class, $method);
+        $snippet->addLocal('extractJobConfig', $this->config);
+
+        if ($bq) {
+            $snippet->addLocal('bigQuery', $bq);
+        }
+
+        $actual = $snippet->invoke('extractJobConfig')
+            ->returnVal()
+            ->toArray()['configuration']['extract'][$method];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function setterDataProvider()
+    {
+        $bq = \Google\Cloud\Dev\stub(BigQueryClient::class, [
+            ['projectId' => self::PROJECT_ID]
+        ]);
+
+        return [
+            [
+                'compression',
+                'GZIP'
+            ],
+            [
+                'destinationFormat',
+                'NEWLINE_DELIMITED_JSON'
+            ],
+            [
+                'destinationUris',
+                ['gs://my_bucket/destination.csv']
+            ],
+            [
+                'fieldDelimiter',
+                ','
+            ],
+            [
+                'printHeader',
+                false
+            ],
+            [
+                'sourceTable',
+                [
+                    'projectId' => self::PROJECT_ID,
+                    'datasetId' => self::DATASET_ID,
+                    'tableId' => self::TABLE_ID
+                ],
+                $bq
+            ]
+        ];
+    }
+}

--- a/tests/snippets/BigQuery/LoadJobConfigurationTest.php
+++ b/tests/snippets/BigQuery/LoadJobConfigurationTest.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Snippets\BigQuery;
+
+use Google\Cloud\BigQuery\BigQueryClient;
+use Google\Cloud\BigQuery\LoadJobConfiguration;
+use Google\Cloud\Dev\Snippet\SnippetTestCase;
+
+/**
+ * @group bigquery
+ */
+class LoadJobConfigurationTest extends SnippetTestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const TABLE_ID = 'my_table';
+    const JOB_ID = '123';
+
+    private $config;
+
+    public function setUp()
+    {
+        $this->config = new LoadJobConfiguration(
+            self::PROJECT_ID,
+            ['jobReference' => ['jobId' => self::JOB_ID]]
+        );
+    }
+
+    public function testClass()
+    {
+        $snippet = $this->snippetFromClass(LoadJobConfiguration::class);
+        $snippet->replace('fopen(\'/path/to/my/data.csv\', \'r\')', '123');
+        $res = $snippet->invoke('loadJobConfig');
+
+        $this->assertInstanceOf(LoadJobConfiguration::class, $res->returnVal());
+    }
+
+    public function testData()
+    {
+        $snippet = $this->snippetFromMethod(LoadJobConfiguration::class, 'data');
+        $snippet->addLocal('loadJobConfig', $this->config);
+        $snippet->replace('fopen(\'/path/to/my/data.csv\', \'r\')', '123');
+        $res = $snippet->invoke('loadJobConfig');
+
+        $this->assertEquals('123', $res->returnVal()->toArray()['data']);
+    }
+
+    /**
+     * @dataProvider setterDataProvider
+     */
+    public function testSetters($method, $expected, $bq = null)
+    {
+        $snippet = $this->snippetFromMethod(LoadJobConfiguration::class, $method);
+        $snippet->addLocal('loadJobConfig', $this->config);
+
+        if ($bq) {
+            $snippet->addLocal('bigQuery', $bq);
+        }
+
+        $actual = $snippet->invoke('loadJobConfig')
+            ->returnVal()
+            ->toArray()['configuration']['load'][$method];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function setterDataProvider()
+    {
+        $bq = \Google\Cloud\Dev\stub(BigQueryClient::class, [
+            ['projectId' => self::PROJECT_ID]
+        ]);
+
+        return [
+            [
+                'allowJaggedRows',
+                true
+            ],
+            [
+                'allowQuotedNewlines',
+                true
+            ],
+            [
+                'autodetect',
+                true
+            ],
+            [
+                'createDisposition',
+                'CREATE_NEVER'
+            ],
+            [
+                'destinationEncryptionConfiguration',
+                [
+                    'kmsKeyName' => 'my_key'
+                ]
+            ],
+            [
+                'destinationTable',
+                [
+                    'projectId' => self::PROJECT_ID,
+                    'datasetId' => self::DATASET_ID,
+                    'tableId' => self::TABLE_ID
+                ],
+                $bq
+            ],
+            [
+                'encoding',
+                'UTF-8'
+            ],
+            [
+                'fieldDelimiter',
+                '\t'
+            ],
+            [
+                'ignoreUnknownValues',
+                true
+            ],
+            [
+                'maxBadRecords',
+                10
+            ],
+            [
+                'nullMarker',
+                '\N',
+            ],
+            [
+                'projectionFields',
+                ['field_name']
+            ],
+            [
+                'quote',
+                '"'
+            ],
+            [
+                'schema',
+                [
+                    'fields' => [
+                        [
+                            'name' => 'col1',
+                            'type' => 'STRING'
+                        ],
+                        [
+                            'name' => 'col2',
+                            'type' => 'BOOL'
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'schemaUpdateOptions',
+                ['ALLOW_FIELD_ADDITION']
+            ],
+            [
+                'skipLeadingRows',
+                10
+            ],
+            [
+                'sourceFormat',
+                'NEWLINE_DELIMITED_JSON'
+            ],
+            [
+                'sourceUris',
+                ['gs://my_bucket/source.csv']
+            ],
+            [
+                'timePartitioning',
+                ['type' => 'DAY']
+            ],
+            [
+                'writeDisposition',
+                'WRITE_TRUNCATE'
+            ]
+        ];
+    }
+}

--- a/tests/snippets/BigQuery/QueryJobConfigurationTest.php
+++ b/tests/snippets/BigQuery/QueryJobConfigurationTest.php
@@ -23,7 +23,7 @@ use Google\Cloud\BigQuery\ValueMapper;
 use Google\Cloud\Dev\Snippet\SnippetTestCase;
 
 /**
- * @group bigquery-2
+ * @group bigquery
  */
 class QueryJobConfigurationTest extends SnippetTestCase
 {

--- a/tests/snippets/BigQuery/QueryJobConfigurationTest.php
+++ b/tests/snippets/BigQuery/QueryJobConfigurationTest.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Snippets\BigQuery;
+
+use Google\Cloud\BigQuery\BigQueryClient;
+use Google\Cloud\BigQuery\QueryJobConfiguration;
+use Google\Cloud\BigQuery\ValueMapper;
+use Google\Cloud\Dev\Snippet\SnippetTestCase;
+
+/**
+ * @group bigquery-2
+ */
+class QueryJobConfigurationTest extends SnippetTestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const TABLE_ID = 'my_table';
+    const JOB_ID = '123';
+
+    private $config;
+
+    public function setUp()
+    {
+        $this->config = new QueryJobConfiguration(
+            new ValueMapper(false),
+            self::PROJECT_ID,
+            ['jobReference' => ['jobId' => self::JOB_ID]]
+        );
+    }
+
+    public function testClass()
+    {
+        $snippet = $this->snippetFromClass(QueryJobConfiguration::class);
+        $res = $snippet->invoke('query');
+
+        $this->assertInstanceOf(QueryJobConfiguration::class, $res->returnVal());
+    }
+
+    /**
+     * @dataProvider setterDataProvider
+     */
+    public function testSetters($method, $expected, $bq = null)
+    {
+        $snippet = $this->snippetFromMethod(QueryJobConfiguration::class, $method);
+        $snippet->addLocal('query', $this->config);
+
+        if ($bq) {
+            $snippet->addLocal('bigQuery', $bq);
+        }
+
+        $actual = $snippet->invoke('query')
+            ->returnVal()
+            ->toArray()['configuration']['query'][$method];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function setterDataProvider()
+    {
+        $bq = \Google\Cloud\Dev\stub(BigQueryClient::class, [
+            ['projectId' => self::PROJECT_ID]
+        ]);
+
+        return [
+            [
+                'allowLargeResults',
+                true
+            ],
+            [
+                'createDisposition',
+                'CREATE_NEVER'
+            ],
+            [
+                'defaultDataset',
+                [
+                    'projectId' => self::PROJECT_ID,
+                    'datasetId' => self::DATASET_ID
+                ],
+                $bq
+            ],
+            [
+                'destinationEncryptionConfiguration',
+                [
+                    'kmsKeyName' => 'my_key'
+                ]
+            ],
+            [
+                'destinationTable',
+                [
+                    'projectId' => self::PROJECT_ID,
+                    'datasetId' => self::DATASET_ID,
+                    'tableId' => self::TABLE_ID
+                ],
+                $bq
+            ],
+            [
+                'flattenResults',
+                true
+            ],
+            [
+                'maximumBillingTier',
+                1
+            ],
+            [
+                'maximumBytesBilled',
+                3000
+            ],
+            [
+                'priority',
+                'BATCH'
+            ],
+            [
+                'query',
+                'SELECT commit FROM `bigquery-public-data.github_repos.commits` LIMIT 100',
+            ],
+            [
+                'schemaUpdateOptions',
+                ['ALLOW_FIELD_ADDITION']
+            ],
+            [
+                'tableDefinitions',
+                [
+                    'autodetect' => true,
+                    'sourceUris' => [
+                        'gs://my_bucket/table.json'
+                    ]
+                ]
+            ],
+            [
+                'timePartitioning',
+                ['type' => 'DAY']
+            ],
+            [
+                'useLegacySql',
+                true
+            ],
+            [
+                'useQueryCache',
+                true
+            ],
+            [
+                'userDefinedFunctionResources',
+                [['resourceUri' => 'gs://my_bucket/code_path']]
+            ],
+            [
+                'writeDisposition',
+                'WRITE_TRUNCATE'
+            ]
+        ];
+    }
+}

--- a/tests/snippets/BigQuery/TableTest.php
+++ b/tests/snippets/BigQuery/TableTest.php
@@ -19,8 +19,12 @@ namespace Google\Cloud\Tests\Snippets\BigQuery;
 
 use Google\Cloud\BigQuery\BigQueryClient;
 use Google\Cloud\BigQuery\Connection\ConnectionInterface;
+use Google\Cloud\BigQuery\CopyJobConfiguration;
+use Google\Cloud\BigQuery\ExtractJobConfiguration;
 use Google\Cloud\BigQuery\InsertResponse;
 use Google\Cloud\BigQuery\Job;
+use Google\Cloud\BigQuery\JobConfigurationInterface;
+use Google\Cloud\BigQuery\LoadJobConfiguration;
 use Google\Cloud\BigQuery\Table;
 use Google\Cloud\BigQuery\ValueMapper;
 use Google\Cloud\Core\Iterator\ItemIterator;
@@ -38,6 +42,7 @@ class TableTest extends SnippetTestCase
     const ID = 'foo';
     const DSID = 'bar';
     const PROJECT = 'my-awesome-project';
+    const JOB_ID = '123';
 
     private $info;
     private $connection;
@@ -137,102 +142,158 @@ class TableTest extends SnippetTestCase
         $this->assertEquals('abcd' . PHP_EOL, $res->output());
     }
 
+    public function testRunJob()
+    {
+        $jobConfig = $this->prophesize(JobConfigurationInterface::class);
+        $jobConfig->toArray()
+            ->willReturn([
+                'projectId' => self::PROJECT,
+                'jobReference' => [
+                    'jobId' => self::JOB_ID,
+                    'projectId' => self::PROJECT
+                ]
+            ]);
+        $snippet = $this->snippetFromMethod(Table::class, 'runJob');
+        $snippet->addLocal('table', $this->table);
+        $snippet->addLocal('jobConfig', $jobConfig->reveal());
+        $this->connection->insertJob(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                'jobReference' => [
+                    'jobId' => self::JOB_ID
+                ],
+                'status' => [
+                    'state' => 'DONE'
+                ]
+            ]);
+        $this->table->___setProperty('connection', $this->connection->reveal());
+        $res = $snippet->invoke('job');
+
+        $this->assertInstanceOf(Job::class, $res->returnVal());
+        $this->assertEquals('1', $res->output());
+    }
+
+    public function testStartJob()
+    {
+        $jobConfig = $this->prophesize(JobConfigurationInterface::class);
+        $jobConfig->toArray()
+            ->willReturn([
+                'projectId' => self::PROJECT,
+                'jobReference' => [
+                    'jobId' => self::JOB_ID,
+                    'projectId' => self::PROJECT
+                ]
+            ]);
+        $snippet = $this->snippetFromMethod(Table::class, 'startJob');
+        $snippet->addLocal('table', $this->table);
+        $snippet->addLocal('jobConfig', $jobConfig->reveal());
+        $this->connection->insertJob(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                'jobReference' => [
+                    'jobId' => self::JOB_ID
+                ]
+            ]);
+        $this->table->___setProperty('connection', $this->connection->reveal());
+        $res = $snippet->invoke('job');
+
+        $this->assertInstanceOf(Job::class, $res->returnVal());
+    }
+
     public function testCopy()
     {
         $bq = \Google\Cloud\Dev\stub(BigQueryClient::class);
         $snippet = $this->snippetFromMethod(Table::class, 'copy');
         $snippet->addLocal('bigQuery', $bq);
-
         $bq->___setProperty('connection', $this->connection->reveal());
+        $config = $snippet->invoke('copyJobConfig')
+            ->returnVal();
 
-        $this->connection->insertJob(Argument::any())
-            ->shouldBeCalled()
-            ->willReturn([
-                'jobReference' => [
-                    'jobId' => '123'
+        $this->assertInstanceOf(CopyJobConfiguration::class, $config);
+        $this->assertEquals(
+            [
+                'destinationTable' => [
+                    'projectId' => self::PROJECT,
+                    'datasetId' => 'myDataset',
+                    'tableId' => 'myDestinationTable'
+                ],
+                'sourceTable' => [
+                    'projectId' => self::PROJECT,
+                    'datasetId' => 'myDataset',
+                    'tableId' => 'mySourceTable'
                 ]
-            ]);
-
-        $this->table->___setProperty('connection', $this->connection->reveal());
-
-        $res = $snippet->invoke('job');
-        $this->assertInstanceOf(Job::class, $res->returnVal());
+            ],
+            $config->toArray()['configuration']['copy']
+        );
     }
 
-    public function testExport()
+    public function testExtract()
     {
         $storage = \Google\Cloud\Dev\stub(StorageClient::class);
         $storage->___setProperty('connection', $this->prophesize(StorageConnectionInterface::class)->reveal());
-
-        $snippet = $this->snippetFromMethod(Table::class, 'export');
+        $snippet = $this->snippetFromMethod(Table::class, 'extract');
         $snippet->addLocal('storage', $storage);
         $snippet->addLocal('table', $this->table);
+        $config = $snippet->invoke('extractJobConfig')
+            ->returnVal();
 
-        $this->connection->insertJob(Argument::any())
-            ->shouldBeCalled()
-            ->willReturn([
-                'jobReference' => [
-                    'jobId' => '123'
+        $this->assertInstanceOf(ExtractJobConfiguration::class, $config);
+        $this->assertEquals(
+            [
+                'destinationUris' => ['gs://myBucket/tableOutput'],
+                'sourceTable' => [
+                    'projectId' => self::PROJECT,
+                    'datasetId' => self::DSID,
+                    'tableId' => self::ID
                 ]
-            ]);
-
-        $this->table->___setProperty('connection', $this->connection->reveal());
-
-        $res = $snippet->invoke('job');
-        $this->assertInstanceOf(Job::class, $res->returnVal());
+            ],
+            $config->toArray()['configuration']['extract']
+        );
     }
 
     public function testLoad()
     {
         $snippet = $this->snippetFromMethod(Table::class, 'load');
         $snippet->addLocal('table', $this->table);
-        $snippet->replace('/path/to/my/data.csv', 'php://temp');
+        $snippet->replace('fopen(\'/path/to/my/data.csv\', \'r\')', '123');
+        $config = $snippet->invoke('loadJobConfig')
+            ->returnVal();
 
-        $uploader = $this->prophesize(MultipartUploader::class);
-        $uploader->upload()
-            ->shouldBeCalled()
-            ->willReturn([
-                'jobReference' => [
-                    'jobId' => '123'
+        $this->assertInstanceOf(LoadJobConfiguration::class, $config);
+        $this->assertEquals(
+            [
+                'destinationTable' => [
+                    'projectId' => self::PROJECT,
+                    'datasetId' => self::DSID,
+                    'tableId' => self::ID
                 ]
-            ]);
-
-        $this->connection->insertJobUpload(Argument::any())
-            ->shouldBeCalled()
-            ->willReturn($uploader->reveal());
-
-        $this->table->___setProperty('connection', $this->connection->reveal());
-
-        $res = $snippet->invoke('job');
-        $this->assertInstanceOf(Job::class, $res->returnVal());
+            ],
+            $config->toArray()['configuration']['load']
+        );
     }
 
     public function testLoadFromStorage()
     {
         $storage = \Google\Cloud\Dev\stub(StorageClient::class);
         $storage->___setProperty('connection', $this->prophesize(StorageConnectionInterface::class)->reveal());
-
         $snippet = $this->snippetFromMethod(Table::class, 'loadFromStorage');
         $snippet->addLocal('storage', $storage);
         $snippet->addLocal('table', $this->table);
+        $config = $snippet->invoke('loadJobConfig')
+            ->returnVal();
 
-        $uploader = $this->prophesize(MultipartUploader::class);
-        $uploader->upload()
-            ->shouldBeCalled()
-            ->willReturn([
-                'jobReference' => [
-                    'jobId' => '123'
+        $this->assertInstanceOf(LoadJobConfiguration::class, $config);
+        $this->assertEquals(
+            [
+                'sourceUris' => ['gs://myBucket/important-data.csv'],
+                'destinationTable' => [
+                    'projectId' => self::PROJECT,
+                    'datasetId' => self::DSID,
+                    'tableId' => self::ID
                 ]
-            ]);
-
-        $this->connection->insertJobUpload(Argument::any())
-            ->shouldBeCalled()
-            ->willReturn($uploader->reveal());
-
-        $this->table->___setProperty('connection', $this->connection->reveal());
-
-        $res = $snippet->invoke('job');
-        $this->assertInstanceOf(Job::class, $res->returnVal());
+            ],
+            $config->toArray()['configuration']['load']
+        );
     }
 
     public function testInsertRow()

--- a/tests/system/BigQuery/LoadDataAndQueryTest.php
+++ b/tests/system/BigQuery/LoadDataAndQueryTest.php
@@ -430,4 +430,33 @@ class LoadDataAndQueryTest extends BigQueryTestCase
         $this->assertTrue($insertResponse->isSuccessful());
         $this->assertEquals(self::$expectedRows, $actualRows);
     }
+
+    public function testInsertRowsToTableWithAutoCreate()
+    {
+        $tName = uniqid(BigQueryTestCase::TESTING_PREFIX);
+        $rows = [
+            ['data' => ['hello' => 'world']]
+        ];
+        $insertResponse = self::$dataset->table($tName)
+            ->insertRows($rows, [
+                'autoCreate' => true,
+                'tableMetadata' => [
+                    'schema' => [
+                        'fields' => [
+                            [
+                                'name' => 'hello',
+                                'type' => 'STRING'
+                            ]
+                        ]
+                    ]
+                ]
+            ]);
+        $results = self::$dataset
+            ->table($tName)
+            ->rows();
+        $actualRows = count(iterator_to_array($results));
+
+        $this->assertTrue($insertResponse->isSuccessful());
+        $this->assertEquals(count($rows), $actualRows);
+    }
 }

--- a/tests/system/BigQuery/ManageJobsTest.php
+++ b/tests/system/BigQuery/ManageJobsTest.php
@@ -27,13 +27,12 @@ class ManageJobsTest extends BigQueryTestCase
 {
     public function testListJobs()
     {
-        self::$client->runQueryAsJob(
-            sprintf(
-                'SELECT * FROM [%s.%s]',
-                self::$dataset->id(),
-                self::$table->id()
-            )
-        );
+        $query = self::$client->query(sprintf(
+            'SELECT * FROM [%s.%s]',
+            self::$dataset->id(),
+            self::$table->id()
+        ));
+        self::$client->startQuery($query);
         $jobs = self::$client->jobs();
         $job = null;
 
@@ -59,13 +58,12 @@ class ManageJobsTest extends BigQueryTestCase
 
     public function testCancelsJob()
     {
-        $job = self::$client->runQueryAsJob(
-            sprintf(
-                'SELECT * FROM [%s.%s]',
-                self::$dataset->id(),
-                self::$table->id()
-            )
-        );
+        $query = self::$client->query(sprintf(
+            'SELECT * FROM [%s.%s]',
+            self::$dataset->id(),
+            self::$table->id()
+        ));
+        $job = self::$client->startQuery($query);
         $job->cancel();
     }
 

--- a/tests/system/BigQuery/ManageTablesTest.php
+++ b/tests/system/BigQuery/ManageTablesTest.php
@@ -74,7 +74,8 @@ class ManageTablesTest extends BigQueryTestCase
      */
     public function testCopiesTable($table)
     {
-        $job = self::$table->copy($table);
+        $copyJobConfig = self::$table->copy($table);
+        $job = self::$table->startJob($copyJobConfig);
         $backoff = new ExponentialBackoff(8);
         $backoff->execute(function () use ($job) {
             $job->reload();
@@ -91,17 +92,15 @@ class ManageTablesTest extends BigQueryTestCase
         $this->assertArrayNotHasKey('errorResult', $job->info()['status']);
     }
 
-    public function testExportsTable()
+    public function testExtractsTable()
     {
         $object = self::$bucket->object(
             uniqid(self::TESTING_PREFIX)
         );
 
-        $job = self::$table->export($object, [
-            'jobConfig' => [
-                'destinationFormat' => 'NEWLINE_DELIMITED_JSON'
-            ]
-        ]);
+        $extractJobConfig = self::$table->extract($object)
+            ->destinationFormat('NEWLINE_DELIMITED_JSON');
+        $job = self::$table->startJob($extractJobConfig);
 
         $backoff = new ExponentialBackoff(8);
         $backoff->execute(function () use ($job) {

--- a/tests/unit/BigQuery/BigQueryClientTest.php
+++ b/tests/unit/BigQuery/BigQueryClientTest.php
@@ -23,6 +23,7 @@ use Google\Cloud\BigQuery\Connection\ConnectionInterface;
 use Google\Cloud\BigQuery\Dataset;
 use Google\Cloud\BigQuery\Date;
 use Google\Cloud\BigQuery\Job;
+use Google\Cloud\BigQuery\QueryJobConfiguration;
 use Google\Cloud\BigQuery\QueryResults;
 use Google\Cloud\BigQuery\Time;
 use Google\Cloud\BigQuery\Timestamp;
@@ -34,69 +35,78 @@ use Prophecy\Argument;
  */
 class BigQueryClientTest extends \PHPUnit_Framework_TestCase
 {
-    const JOBID = 'myJobId';
+    const JOB_ID = 'myJobId';
+    const PROJECT_ID = 'myProjectId';
+    const DATASET_ID = 'myDatasetId';
+    const QUERY_STRING = 'someQuery';
 
     public $connection;
-    public $projectId = 'myProjectId';
-    public $datasetId = 'myDatasetId';
     public $client;
 
     public function setUp()
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
-        $this->client = \Google\Cloud\Dev\stub(BigQueryTestClient::class, ['options' => ['projectId' => $this->projectId]]);
+        $this->client = \Google\Cloud\Dev\stub(BigQueryClient::class, ['options' => ['projectId' => self::PROJECT_ID]]);
     }
 
-    /**
-     * @dataProvider queryDataProvider
-     */
-    public function testRunsQuery($query, $options, $expected)
+    public function testRunsQuery()
     {
-        $projectId = $expected['projectId'];
-        unset($expected['projectId']);
+        $query = $this->client->query(self::QUERY_STRING, [
+            'jobReference' => ['jobId' => self::JOB_ID]
+        ]);
         $this->connection->insertJob([
-            'projectId' => $projectId,
+            'projectId' => self::PROJECT_ID,
             'configuration' => [
-                'query' => $expected
+                'query' => [
+                    'query' => self::QUERY_STRING,
+                    'useLegacySql' => false
+                ]
             ],
-            'jobReference' => ['projectId' => $projectId, 'jobId' => self::JOBID]
+            'jobReference' => [
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
+            ]
         ])
             ->willReturn([
-                'jobReference' => ['jobId' => self::JOBID]
+                'jobReference' => ['jobId' => self::JOB_ID]
             ])
             ->shouldBeCalledTimes(1);
         $this->connection->getQueryResults(Argument::any())
             ->willReturn([
                 'jobReference' => [
-                    'jobId' => self::JOBID
+                    'jobId' => self::JOB_ID
                 ],
                 'jobComplete' => true
             ])
             ->shouldBeCalledTimes(1);
         $this->client->___setProperty('connection', $this->connection->reveal());
-        $queryResults = $this->client->runQuery($query, $options);
+        $queryResults = $this->client->runQuery($query);
 
         $this->assertInstanceOf(QueryResults::class, $queryResults);
-        $this->assertEquals(self::JOBID, $queryResults->identity()['jobId']);
+        $this->assertEquals(self::JOB_ID, $queryResults->identity()['jobId']);
     }
 
-    /**
-     * @dataProvider queryDataProvider
-     */
-    public function testRunsQueryWithRetry($query, $options, $expected)
+    public function testRunsQueryWithRetry()
     {
-        $projectId = $expected['projectId'];
-        unset($expected['projectId']);
+        $query = $this->client->query(self::QUERY_STRING, [
+            'jobReference' => ['jobId' => self::JOB_ID]
+        ]);
         $this->connection->insertJob([
-            'projectId' => $projectId,
+            'projectId' => self::PROJECT_ID,
             'configuration' => [
-                'query' => $expected
+                'query' => [
+                    'query' => self::QUERY_STRING,
+                    'useLegacySql' => false
+                ]
             ],
-            'jobReference' => ['projectId' => $projectId, 'jobId' => self::JOBID]
+            'jobReference' => [
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
+            ]
         ])
             ->willReturn([
                 'jobReference' => [
-                    'jobId' => self::JOBID
+                    'jobId' => self::JOB_ID
                 ],
                 'jobComplete' => false
             ])
@@ -104,129 +114,58 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
         $this->connection->getQueryResults(Argument::any())
             ->willReturn([
                 'jobReference' => [
-                    'jobId' => self::JOBID
+                    'jobId' => self::JOB_ID
                 ],
                 'jobComplete' => true
             ])
             ->shouldBeCalledTimes(1);
 
         $this->client->___setProperty('connection', $this->connection->reveal());
-        $queryResults = $this->client->runQuery($query, $options);
+        $queryResults = $this->client->runQuery($query);
 
         $this->assertInstanceOf(QueryResults::class, $queryResults);
-        $this->assertEquals(self::JOBID, $queryResults->identity()['jobId']);
+        $this->assertEquals(self::JOB_ID, $queryResults->identity()['jobId']);
     }
 
-    /**
-     * @dataProvider queryDataProvider
-     */
-    public function testRunsQueryAsJob($query, $options, $expected)
+    public function testStartQuery()
     {
-        $projectId = $expected['projectId'];
-        unset($expected['projectId']);
+        $query = $this->client->query(self::QUERY_STRING, [
+            'jobReference' => ['jobId' => self::JOB_ID]
+        ]);
         $this->connection->insertJob([
-            'projectId' => $projectId,
+            'projectId' => self::PROJECT_ID,
             'configuration' => [
-                'query' => $expected
+                'query' => [
+                    'query' => self::QUERY_STRING,
+                    'useLegacySql' => false
+                ]
             ],
             'jobReference' => [
-                'projectId' => $projectId,
-                'jobId' => self::JOBID
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
             ]
         ])
             ->willReturn([
-                'jobReference' => ['jobId' => self::JOBID]
+                'jobReference' => ['jobId' => self::JOB_ID]
             ])
             ->shouldBeCalledTimes(1);
 
         $this->client->___setProperty('connection', $this->connection->reveal());
-        $job = $this->client->runQueryAsJob($query, $options);
+        $job = $this->client->startQuery($query);
 
         $this->assertInstanceOf(Job::class, $job);
-        $this->assertEquals(self::JOBID, $job->id());
-    }
-
-    public function queryDataProvider()
-    {
-        $query = 'someQuery';
-
-        return [
-            [
-                $query,
-                [],
-                [
-                    'projectId' => $this->projectId,
-                    'query' => $query,
-                    'useLegacySql' => false
-                ]
-            ],
-            [
-                $query,
-                [
-                    'parameters' => [
-                        'test' => 'parameter'
-                    ]
-                ],
-                [
-                    'projectId' => $this->projectId,
-                    'query' => $query,
-                    'parameterMode' => 'named',
-                    'useLegacySql' => false,
-                    'queryParameters' => [
-                        [
-                            'name' => 'test',
-                            'parameterType' => [
-                                'type' => 'STRING'
-                            ],
-                            'parameterValue' => [
-                                'value' => 'parameter'
-                            ]
-                        ]
-                    ]
-                ]
-            ],
-            [
-                $query,
-                [
-                    'parameters' => [1, 2]
-                ],
-                [
-                    'projectId' => $this->projectId,
-                    'query' => 'someQuery',
-                    'parameterMode' => 'positional',
-                    'useLegacySql' => false,
-                    'queryParameters' => [
-                        [
-                            'parameterType' => [
-                                'type' => 'INT64'
-                            ],
-                            'parameterValue' => [
-                                'value' => 1
-                            ]
-                        ],
-                        [
-                            'parameterType' => [
-                                'type' => 'INT64'
-                            ],
-                            'parameterValue' => [
-                                'value' => 2
-                            ]
-                        ]
-                    ]
-                ]
-            ]
-        ];
+        $this->assertEquals(self::JOB_ID, $job->id());
     }
 
     public function testGetsJob()
     {
         $this->client->___setProperty('connection', $this->connection->reveal());
-        $this->assertInstanceOf(Job::class, $this->client->job(self::JOBID));
+        $this->assertInstanceOf(Job::class, $this->client->job(self::JOB_ID));
     }
 
     public function testGetsJobsWithNoResults()
     {
-        $this->connection->listJobs(['projectId' => $this->projectId])
+        $this->connection->listJobs(['projectId' => self::PROJECT_ID])
             ->willReturn([])
             ->shouldBeCalledTimes(1);
 
@@ -238,10 +177,10 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
 
     public function testGetsJobsWithoutToken()
     {
-        $this->connection->listJobs(['projectId' => $this->projectId])
+        $this->connection->listJobs(['projectId' => self::PROJECT_ID])
             ->willReturn([
                 'jobs' => [
-                    ['jobReference' => ['jobId' => self::JOBID]]
+                    ['jobReference' => ['jobId' => self::JOB_ID]]
                 ]
             ])
             ->shouldBeCalledTimes(1);
@@ -249,13 +188,13 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
         $this->client->___setProperty('connection', $this->connection->reveal());
         $jobs = iterator_to_array($this->client->jobs());
 
-        $this->assertEquals(self::JOBID, $jobs[0]->id());
+        $this->assertEquals(self::JOB_ID, $jobs[0]->id());
     }
 
     public function testGetsJobsWithToken()
     {
         $token = 'token';
-        $this->connection->listJobs(['projectId' => $this->projectId])
+        $this->connection->listJobs(['projectId' => self::PROJECT_ID])
             ->willReturn([
                 'nextPageToken' => $token,
                 'jobs' => [
@@ -263,25 +202,25 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
                 ]
             ])->shouldBeCalledTimes(1);
         $this->connection->listJobs([
-            'projectId' => $this->projectId,
+            'projectId' => self::PROJECT_ID,
             'pageToken' => $token
         ])
             ->willReturn([
                 'jobs' => [
-                    ['jobReference' => ['jobId' => self::JOBID]]
+                    ['jobReference' => ['jobId' => self::JOB_ID]]
                 ]
             ])->shouldBeCalledTimes(1);
 
         $this->client->___setProperty('connection', $this->connection->reveal());
         $job = iterator_to_array($this->client->jobs());
 
-        $this->assertEquals(self::JOBID, $job[1]->id());
+        $this->assertEquals(self::JOB_ID, $job[1]->id());
     }
 
     public function testGetsDataset()
     {
         $this->client->___setProperty('connection', $this->connection->reveal());
-        $this->assertInstanceOf(Dataset::class, $this->client->dataset($this->datasetId));
+        $this->assertInstanceOf(Dataset::class, $this->client->dataset(self::DATASET_ID));
     }
 
     public function testGetsDatasetsWithNoResults()
@@ -301,7 +240,7 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
         $this->connection->listDatasets(Argument::any())
             ->willReturn([
                 'datasets' => [
-                    ['datasetReference' => ['datasetId' => $this->datasetId]]
+                    ['datasetReference' => ['datasetId' => self::DATASET_ID]]
                 ]
             ])
             ->shouldBeCalledTimes(1);
@@ -309,7 +248,7 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
         $this->client->___setProperty('connection', $this->connection->reveal());
         $datasets = iterator_to_array($this->client->datasets());
 
-        $this->assertEquals($this->datasetId, $datasets[0]->id());
+        $this->assertEquals(self::DATASET_ID, $datasets[0]->id());
     }
 
     public function testGetsDatasetsWithToken()
@@ -324,7 +263,7 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
                 ],
                     [
                     'datasets' => [
-                        ['datasetReference' => ['datasetId' => $this->datasetId]]
+                        ['datasetReference' => ['datasetId' => self::DATASET_ID]]
                     ]
                 ]
             )
@@ -333,7 +272,7 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
         $this->client->___setProperty('connection', $this->connection->reveal());
         $dataset = iterator_to_array($this->client->datasets());
 
-        $this->assertEquals($this->datasetId, $dataset[1]->id());
+        $this->assertEquals(self::DATASET_ID, $dataset[1]->id());
     }
 
     public function testCreatesDataset()
@@ -341,13 +280,13 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
         $this->connection->insertDataset(Argument::any())
             ->willReturn([
                 'datasetReference' => [
-                    'datasetId' => $this->datasetId
+                    'datasetId' => self::DATASET_ID
                 ]
             ])
             ->shouldBeCalledTimes(1);
         $this->client->___setProperty('connection', $this->connection->reveal());
 
-        $dataset = $this->client->createDataset($this->datasetId, [
+        $dataset = $this->client->createDataset(self::DATASET_ID, [
             'metadata' => [
                 'friendlyName' => 'A dataset.'
             ]
@@ -382,13 +321,5 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
         $bytes = $this->client->timestamp(new \DateTime());
 
         $this->assertInstanceOf(Timestamp::class, $bytes);
-    }
-}
-
-class BigQueryTestClient extends BigQueryClient
-{
-    protected function generateJobId($jobIdPrefix = null)
-    {
-        return $jobIdPrefix ? $jobIdPrefix . '-' . BigQueryClientTest::JOBID : BigQueryClientTest::JOBID;
     }
 }

--- a/tests/unit/BigQuery/Connection/RestTest.php
+++ b/tests/unit/BigQuery/Connection/RestTest.php
@@ -98,6 +98,9 @@ class RestTest extends \PHPUnit_Framework_TestCase
     {
         $actualRequest = null;
         $config = [
+            'labels' => [],
+            'dryRun' => false,
+            'jobReference' => [],
             'configuration' => [
                 'load' => [
                     'destinationTable' => [

--- a/tests/unit/BigQuery/CopyJobConfigurationTest.php
+++ b/tests/unit/BigQuery/CopyJobConfigurationTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\BigQuery;
+
+use Google\Cloud\BigQuery\Dataset;
+use Google\Cloud\BigQuery\CopyJobConfiguration;
+use Google\Cloud\BigQuery\Table;
+
+/**
+ * @group bigquery
+ */
+class CopyJobConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const TABLE_ID = 'my_table';
+    const JOB_ID = '1234';
+
+    private $config;
+    private $tableIdentity = [
+        'projectId' => self::PROJECT_ID,
+        'datasetId' => self::DATASET_ID,
+        'tableId' => self::TABLE_ID
+    ];
+    private $expectedConfig;
+
+    public function setUp()
+    {
+        $this->expectedConfig = [
+            'projectId' => self::PROJECT_ID,
+            'jobReference' => [
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
+            ],
+            'configuration' => [
+                'copy' => []
+            ]
+        ];
+        $this->config = new CopyJobConfiguration(
+            self::PROJECT_ID,
+            ['jobReference' => ['jobId' => self::JOB_ID]]
+        );
+    }
+
+    public function testFluentSetters()
+    {
+        $destinationTable = $this->prophesize(Table::class);
+        $destinationTable->identity()
+            ->willReturn($this->tableIdentity);
+        $sourceTable = $this->prophesize(Table::class);
+        $sourceTable->identity()
+            ->willReturn($this->tableIdentity);
+        $copy = [
+            'createDisposition' => 'CREATE_NEVER',
+            'destinationEncryptionConfiguration' => [
+                'kmsKeyName' => 'my_key'
+            ],
+            'destinationTable' => $this->tableIdentity,
+            'sourceTable' => $this->tableIdentity,
+            'writeDisposition' => 'WRITE_TRUNCATE'
+        ];
+        $this->expectedConfig['configuration']['copy'] = $copy
+            + $this->expectedConfig['configuration']['copy'];
+        $this->config
+            ->createDisposition($copy['createDisposition'])
+            ->destinationEncryptionConfiguration($copy['destinationEncryptionConfiguration'])
+            ->destinationTable($destinationTable->reveal())
+            ->sourceTable($sourceTable->reveal())
+            ->writeDisposition($copy['writeDisposition']);
+
+        $this->assertEquals(
+            $this->expectedConfig,
+            $this->config->toArray()
+        );
+    }
+}

--- a/tests/unit/BigQuery/ExtractJobConfigurationTest.php
+++ b/tests/unit/BigQuery/ExtractJobConfigurationTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\BigQuery;
+
+use Google\Cloud\BigQuery\Dataset;
+use Google\Cloud\BigQuery\ExtractJobConfiguration;
+use Google\Cloud\BigQuery\Table;
+
+/**
+ * @group bigquery
+ */
+class ExtractJobConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const TABLE_ID = 'my_table';
+    const JOB_ID = '1234';
+
+    private $config;
+    private $tableIdentity = [
+        'projectId' => self::PROJECT_ID,
+        'datasetId' => self::DATASET_ID,
+        'tableId' => self::TABLE_ID
+    ];
+    private $expectedConfig;
+
+    public function setUp()
+    {
+        $this->expectedConfig = [
+            'projectId' => self::PROJECT_ID,
+            'jobReference' => [
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
+            ],
+            'configuration' => [
+                'extract' => []
+            ]
+        ];
+        $this->config = new ExtractJobConfiguration(
+            self::PROJECT_ID,
+            ['jobReference' => ['jobId' => self::JOB_ID]]
+        );
+    }
+
+    public function testFluentSetters()
+    {
+        $sourceTable = $this->prophesize(Table::class);
+        $sourceTable->identity()
+            ->willReturn($this->tableIdentity);
+        $extract = [
+            'compression' => 'GZIP',
+            'destinationFormat' => 'CSV',
+            'destinationUris' => ['gs://my_bucket/destination.csv'],
+            'fieldDelimiter' => ',',
+            'printHeader' => true,
+            'sourceTable' => $this->tableIdentity
+        ];
+        $this->expectedConfig['configuration']['extract'] = $extract
+            + $this->expectedConfig['configuration']['extract'];
+        $this->config
+            ->compression($extract['compression'])
+            ->destinationFormat($extract['destinationFormat'])
+            ->destinationUris($extract['destinationUris'])
+            ->fieldDelimiter($extract['fieldDelimiter'])
+            ->printHeader($extract['printHeader'])
+            ->sourceTable($sourceTable->reveal());
+
+        $this->assertEquals(
+            $this->expectedConfig,
+            $this->config->toArray()
+        );
+    }
+}

--- a/tests/unit/BigQuery/LoadJobConfigurationTest.php
+++ b/tests/unit/BigQuery/LoadJobConfigurationTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\BigQuery;
+
+use Google\Cloud\BigQuery\LoadJobConfiguration;
+use Google\Cloud\BigQuery\Table;
+
+/**
+ * @group bigquery
+ */
+class LoadJobConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const TABLE_ID = 'my_table';
+    const JOB_ID = '1234';
+
+    private $config;
+    private $tableIdentity = [
+        'projectId' => self::PROJECT_ID,
+        'datasetId' => self::DATASET_ID,
+        'tableId' => self::TABLE_ID
+    ];
+    private $expectedConfig;
+
+    public function setUp()
+    {
+        $this->expectedConfig = [
+            'projectId' => self::PROJECT_ID,
+            'jobReference' => [
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
+            ],
+            'configuration' => [
+                'load' => []
+            ]
+        ];
+        $this->config = new LoadJobConfiguration(
+            self::PROJECT_ID,
+            ['jobReference' => ['jobId' => self::JOB_ID]]
+        );
+    }
+
+    public function testFluentSetters()
+    {
+        $destinationTable = $this->prophesize(Table::class);
+        $destinationTable->identity()
+            ->willReturn($this->tableIdentity);
+        $data = '1234';
+        $load = [
+            'allowJaggedRows' => true,
+            'allowQuotedNewlines' => true,
+            'autodetect' => true,
+            'createDisposition' => 'CREATE_NEVER',
+            'destinationEncryptionConfiguration' => [
+                'kmsKeyName' => 'my_key'
+            ],
+            'destinationTable' => $this->tableIdentity,
+            'encoding' => 'UTF-8',
+            'fieldDelimiter' => '\t',
+            'ignoreUnknownValues' => true,
+            'maxBadRecords' => 10,
+            'nullMarker' => '\N',
+            'projectionFields' => ['field_name'],
+            'quote' => '"',
+            'schema' => ['fields' => [['name' => 'col1', 'type' => 'STRING']]],
+            'schemaUpdateOptions' => ['ALLOW_FIELD_ADDITION'],
+            'skipLeadingRows' => 10,
+            'sourceFormat' => 'CSV',
+            'sourceUris' => ['gs://my_bucket/source.csv'],
+            'timePartitioning' => [
+                'type' => 'DAY'
+            ],
+            'writeDisposition' => 'WRITE_TRUNCATE'
+        ];
+        $this->expectedConfig['configuration']['load'] = $load
+            + $this->expectedConfig['configuration']['load'];
+        $this->config
+            ->allowJaggedRows($load['allowJaggedRows'])
+            ->allowQuotedNewlines($load['allowQuotedNewlines'])
+            ->autodetect($load['autodetect'])
+            ->createDisposition($load['createDisposition'])
+            ->destinationEncryptionConfiguration($load['destinationEncryptionConfiguration'])
+            ->data($data)
+            ->destinationTable($destinationTable->reveal())
+            ->encoding($load['encoding'])
+            ->fieldDelimiter($load['fieldDelimiter'])
+            ->ignoreUnknownValues($load['ignoreUnknownValues'])
+            ->maxBadRecords($load['maxBadRecords'])
+            ->nullMarker($load['nullMarker'])
+            ->projectionFields($load['projectionFields'])
+            ->quote($load['quote'])
+            ->schema($load['schema'])
+            ->schemaUpdateOptions($load['schemaUpdateOptions'])
+            ->skipLeadingRows($load['skipLeadingRows'])
+            ->sourceFormat($load['sourceFormat'])
+            ->sourceUris($load['sourceUris'])
+            ->timePartitioning($load['timePartitioning'])
+            ->writeDisposition($load['writeDisposition']);
+
+        $this->assertEquals(
+            $this->expectedConfig + ['data' => $data],
+            $this->config->toArray()
+        );
+    }
+}

--- a/tests/unit/BigQuery/QueryJobConfigurationTest.php
+++ b/tests/unit/BigQuery/QueryJobConfigurationTest.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\BigQuery;
+
+use Google\Cloud\BigQuery\Dataset;
+use Google\Cloud\BigQuery\QueryJobConfiguration;
+use Google\Cloud\BigQuery\Table;
+use Google\Cloud\BigQuery\ValueMapper;
+
+/**
+ * @group bigquery
+ */
+class QueryJobConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    const PROJECT_ID = 'my_project';
+    const DATASET_ID = 'my_dataset';
+    const TABLE_ID = 'my_table';
+    const JOB_ID = '1234';
+
+    private $config;
+    private $datasetIdentity = [
+        'projectId' => self::PROJECT_ID,
+        'datasetId' => self::DATASET_ID
+    ];
+    private $tableIdentity = [
+        'projectId' => self::PROJECT_ID,
+        'datasetId' => self::DATASET_ID,
+        'tableId' => self::TABLE_ID
+    ];
+    private $expectedConfig;
+
+    public function setUp()
+    {
+        $this->expectedConfig = [
+            'projectId' => self::PROJECT_ID,
+            'jobReference' => [
+                'projectId' => self::PROJECT_ID,
+                'jobId' => self::JOB_ID
+            ],
+            'configuration' => [
+                'query' => [
+                    'useLegacySql' => false
+                ]
+            ]
+        ];
+        $this->config = new QueryJobConfiguration(
+            new ValueMapper(false),
+            self::PROJECT_ID,
+            ['jobReference' => ['jobId' => self::JOB_ID]]
+        );
+    }
+
+    public function testFluentSetters()
+    {
+        $defaultDataset = $this->prophesize(Dataset::class);
+        $defaultDataset->identity()
+            ->willReturn($this->datasetIdentity);
+        $destinationTable = $this->prophesize(Table::class);
+        $destinationTable->identity()
+            ->willReturn($this->tableIdentity);
+        $query = [
+            'allowLargeResults' => true,
+            'createDisposition' => 'CREATE_NEVER',
+            'defaultDataset' => $this->datasetIdentity,
+            'destinationEncryptionConfiguration' => [
+                'kmsKeyName' => 'my_key'
+            ],
+            'destinationTable' => $this->tableIdentity,
+            'flattenResults' => true,
+            'maximumBillingTier' => 1,
+            'maximumBytesBilled' => 100,
+            'priority' => 'BATCH',
+            'query' => 'SELECT * FROM test',
+            'schemaUpdateOptions' => ['ALLOW_FIELD_ADDITION'],
+            'tableDefinitions' => [
+                'autodetect' => true,
+                'sourceUris' => [
+                    'gs://my_bucket/table.json'
+                ]
+            ],
+            'timePartitioning' => [
+                'type' => 'DAY'
+            ],
+            'useLegacySql' => true,
+            'useQueryCache' => true,
+            'userDefinedFunctionResources' => [
+                ['resourceUri' => 'gs://my_bucket/code_path']
+            ],
+            'writeDisposition' => 'WRITE_TRUNCATE'
+        ];
+        $this->expectedConfig['configuration']['query'] = $query
+            + $this->expectedConfig['configuration']['query'];
+        $this->config
+            ->allowLargeResults($query['allowLargeResults'])
+            ->createDisposition($query['createDisposition'])
+            ->defaultDataset($defaultDataset->reveal())
+            ->destinationEncryptionConfiguration($query['destinationEncryptionConfiguration'])
+            ->destinationTable($destinationTable->reveal())
+            ->flattenResults($query['flattenResults'])
+            ->maximumBillingTier($query['maximumBillingTier'])
+            ->maximumBytesBilled($query['maximumBytesBilled'])
+            ->priority($query['priority'])
+            ->query($query['query'])
+            ->schemaUpdateOptions($query['schemaUpdateOptions'])
+            ->tableDefinitions($query['tableDefinitions'])
+            ->timePartitioning($query['timePartitioning'])
+            ->useLegacySql($query['useLegacySql'])
+            ->useQueryCache($query['useQueryCache'])
+            ->userDefinedFunctionResources($query['userDefinedFunctionResources'])
+            ->writeDisposition($query['writeDisposition']);
+
+        $this->assertEquals($this->expectedConfig, $this->config->toArray());
+    }
+
+    /**
+     * @dataProvider parameterDataProvider
+     */
+    public function testParameters($args, $expectedQuery)
+    {
+        $this->expectedConfig['configuration']['query'] = $expectedQuery
+            + $this->expectedConfig['configuration']['query'];
+        $this->config
+            ->parameters($args);
+
+        $this->assertEquals($this->expectedConfig, $this->config->toArray());
+    }
+
+    public function parameterDataProvider()
+    {
+        return [
+            [
+                ['test' => 'parameter'],
+                [
+                    'parameterMode' => 'named',
+                    'queryParameters' => [
+                        [
+                            'name' => 'test',
+                            'parameterType' => [
+                                'type' => 'STRING'
+                            ],
+                            'parameterValue' => [
+                                'value' => 'parameter'
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                [1, 2],
+                [
+                    'parameterMode' => 'positional',
+                    'queryParameters' => [
+                        [
+                            'parameterType' => [
+                                'type' => 'INT64'
+                            ],
+                            'parameterValue' => [
+                                'value' => 1
+                            ]
+                        ],
+                        [
+                            'parameterType' => [
+                                'type' => 'INT64'
+                            ],
+                            'parameterValue' => [
+                                'value' => 2
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+}

--- a/tests/unit/Core/RetryDeciderTraitTest.php
+++ b/tests/unit/Core/RetryDeciderTraitTest.php
@@ -34,6 +34,18 @@ class RetryDeciderTraitTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider retryProvider
      */
+    public function testDisableRetry($exception)
+    {
+        $this->implementation->call('setHttpRetryCodes', [[]]);
+        $this->implementation->call('setHttpRetryMessages', [[]]);
+        $retryFunction = $this->implementation->call('getRetryFunction');
+
+        $this->assertFalse($retryFunction($exception));
+    }
+
+    /**
+     * @dataProvider retryProvider
+     */
     public function testShouldRetry($exception, $shouldRetryMessage, $expected)
     {
         $retryFunction = $this->implementation->call('getRetryFunction', [$shouldRetryMessage]);


### PR DESCRIPTION
Closes: https://github.com/GoogleCloudPlatform/google-cloud-php/issues/354, https://github.com/GoogleCloudPlatform/google-cloud-php/issues/622

The following items are included in this PR:

- Job configuration classes have been introduced. https://github.com/GoogleCloudPlatform/google-cloud-php/pull/686/commits/beba45d3cca0435d18c812928918c793dfe79eec / https://github.com/GoogleCloudPlatform/google-cloud-php/pull/686/commits/bbc6c7c5b57d348b3967b9a96c136e1b8689304e
    - Support for dry run.
    - Ability to set labels on a job.
    - More clear configuration of jobs (~~I hope! Would love some feedback on this before finishing up the rest of the tests/docs~~).
- Updates to retry logic. https://github.com/GoogleCloudPlatform/google-cloud-php/pull/686/commits/81315f096e254308a6fe8dcd076ea2ace0c84941
- Optionally create a table if it does not exist while inserting rows. https://github.com/GoogleCloudPlatform/google-cloud-php/pull/686/commits/59dc30fa03e5da9e6c8d9b78180b01d707770b2d

/cc @bencromwell Given the issue found before with the way jobs were configured, your feedback on this item would be really wonderful :).

Todos (based on feedback):
- ~~Update tests~~
- ~~Update docs~~
- ~~Add load/copy job configuration classes~~