### PR TITLE
renames psrBatchLogger to psrLogger

### DIFF
--- a/src/ErrorReporting/Bootstrap.php
+++ b/src/ErrorReporting/Bootstrap.php
@@ -13,18 +13,18 @@ class Bootstrap
     const DEFAULT_LOGNAME = 'app-error';
 
     /** @var PsrLogger */
-    public static $psrBatchLogger;
+    public static $psrLogger;
 
     /**
      * Register hooks for error reporting.
      *
-     * @param PsrLogger $psrBatchLogger
+     * @param PsrLogger $psrLogger
      * @return void
      * @codeCoverageIgnore
      */
-    public static function init(PsrLogger $psrBatchLogger = null)
+    public static function init(PsrLogger $psrLogger = null)
     {
-        self::$psrBatchLogger = $psrBatchLogger ?: (new LoggingClient())
+        self::$psrLogger = $psrLogger ?: (new LoggingClient())
             ->psrLogger(self::DEFAULT_LOGNAME, [
                 'batchEnabled' => true,
                 'debugOutput' => true,
@@ -116,8 +116,8 @@ class Bootstrap
     public static function exceptionHandler($ex)
     {
         $message = sprintf('PHP Notice: %s', (string)$ex);
-        if (self::$psrBatchLogger) {
-            self::$psrBatchLogger->error($message);
+        if (self::$psrLogger) {
+            self::$psrLogger->error($message);
         } else {
             fwrite(STDERR, $message . PHP_EOL);
         }
@@ -141,11 +141,11 @@ class Bootstrap
             $file,
             $line
         );
-        if (!self::$psrBatchLogger) {
+        if (!self::$psrLogger) {
             return false;
         }
-        $service = self::$psrBatchLogger->getMetadataProvider()->serviceId();
-        $version = self::$psrBatchLogger->getMetadataProvider()->versionId();
+        $service = self::$psrLogger->getMetadataProvider()->serviceId();
+        $version = self::$psrLogger->getMetadataProvider()->versionId();
         $context = [
             'context' => [
                 'reportLocation' => [
@@ -159,7 +159,7 @@ class Bootstrap
                 'version' => $version
             ]
         ];
-        self::$psrBatchLogger->log(
+        self::$psrLogger->log(
             self::getErrorLevelString($level),
             $message,
             $context
@@ -178,10 +178,10 @@ class Bootstrap
                 case E_PARSE:
                 case E_COMPILE_ERROR:
                 case E_CORE_ERROR:
-                    $service = self::$psrBatchLogger
+                    $service = self::$psrLogger
                         ->getMetadataProvider()
                         ->serviceId();
-                    $version = self::$psrBatchLogger
+                    $version = self::$psrLogger
                         ->getMetadataProvider()
                         ->versionId();
                     $message = sprintf(
@@ -204,8 +204,8 @@ class Bootstrap
                             'version' => $version
                         ]
                     ];
-                    if (self::$psrBatchLogger) {
-                        self::$psrBatchLogger->log(
+                    if (self::$psrLogger) {
+                        self::$psrLogger->log(
                             self::getErrorLevelString($err['type']),
                             $message,
                             $context

--- a/tests/unit/ErrorReporting/BootstrapTest.php
+++ b/tests/unit/ErrorReporting/BootstrapTest.php
@@ -106,7 +106,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
         $expectedMessage = sprintf('PHP Notice: %s', (string)$exception);
         $this->psrBatchLogger->error($expectedMessage)
             ->shouldBeCalledTimes(1);
-        Bootstrap::$psrBatchLogger = $this->psrBatchLogger->reveal();
+        Bootstrap::$psrLogger = $this->psrBatchLogger->reveal();
         Bootstrap::exceptionHandler($exception);
     }
 
@@ -117,7 +117,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
         $exception
     ) {
         $expectedMessage = sprintf('PHP Notice: %s', (string)$exception);
-        Bootstrap::$psrBatchLogger = null;
+        Bootstrap::$psrLogger = null;
         Bootstrap::exceptionHandler($exception);
         $this->assertEquals($expectedMessage . PHP_EOL, MockValues::$stderr);
     }
@@ -173,7 +173,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
             $expectedMessage,
             $expectedContext
         )->shouldBeCalledTimes(1);
-        Bootstrap::$psrBatchLogger = $this->psrBatchLogger->reveal();
+        Bootstrap::$psrLogger = $this->psrBatchLogger->reveal();
         MockValues::$errorReporting = $error['type']; // always match
         BootStrap::errorHandler(
             $error['type'],
@@ -185,7 +185,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
 
     public function testErrorHandlerWithMinorError()
     {
-        Bootstrap::$psrBatchLogger = null;
+        Bootstrap::$psrLogger = null;
         MockValues::$errorReporting = 0;
         $result = BootStrap::errorHandler(
             E_ERROR,
@@ -197,7 +197,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testErrorHandlerWithoutLogger() {
-        Bootstrap::$psrBatchLogger = null;
+        Bootstrap::$psrLogger = null;
         MockValues::$errorReporting = E_ERROR;
         $result = BootStrap::errorHandler(
             E_ERROR,
@@ -234,7 +234,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
         if (!in_array($error['type'], $fatalErrors, true)) {
             // The shutdownHandler should not do anything, so it should pass
             // with the empty psrBatchLogger mock.
-            Bootstrap::$psrBatchLogger = $this->psrBatchLogger->reveal();
+            Bootstrap::$psrLogger = $this->psrBatchLogger->reveal();
             $this->assertNull(BootStrap::shutdownHandler());
             return;
         }
@@ -266,7 +266,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
             $expectedMessage,
             $expectedContext
         )->shouldBeCalledTimes(1);
-        Bootstrap::$psrBatchLogger = $this->psrBatchLogger->reveal();
+        Bootstrap::$psrLogger = $this->psrBatchLogger->reveal();
         BootStrap::shutdownHandler();
     }
 


### PR DESCRIPTION
The `Bootstrap` function can be used to hook into error reporting w/o requiring batch processing. This PR renames the logger's property to make this clear.