### PR TITLE
Set a default httpHandler at the construct level in FetchAuthTokenCache

### DIFF
--- a/src/Core/RequestWrapperTrait.php
+++ b/src/Core/RequestWrapperTrait.php
@@ -149,7 +149,8 @@ trait RequestWrapperTrait
         return new FetchAuthTokenCache(
             $fetcher,
             $this->authCacheOptions,
-            $this->authCache
+            $this->authCache,
+            $this->authHttpHandler
         );
     }
 }


### PR DESCRIPTION
See https://github.com/google/google-auth-library-php/pull/172 for context. Also a dependency for this change