### PR TITLE
LoggingPerfTestCase.php: fix rest start grpc client

### DIFF
--- a/tests/perf/LoggingPerfTestCase.php
+++ b/tests/perf/LoggingPerfTestCase.php
@@ -34,7 +34,8 @@ class LoggingPerfTestCase extends \PHPUnit_Framework_TestCase
             'perf-rest',
             [
                 'clientConfig' => [
-                    'keyFilePath' => $keyFilePath
+                    'keyFilePath' => $keyFilePath,
+                    'transport' => 'rest'
                 ]
             ]
         );


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/google-cloud-php/blob/master/src/Core/ClientTrait.php#L52
When the transport doesn't set, and the grpc extension is loaded, it will return "grpc" as the connection type.