### PR TITLE
Add system test coverage for storage userProject

### DIFF
--- a/src/Storage/Bucket.php
+++ b/src/Storage/Bucket.php
@@ -767,14 +767,10 @@ class Bucket
      *           `"STANDARD"` and `"DURABLE_REDUCED_AVAILABILITY"`.
      *     @type array $versioning The bucket's versioning configuration.
      *     @type array $website The bucket's website configuration.
-     *     @type array $billing The bucket's billing configuration. **Whitelist
-     *           Warning:** At the time of publication, this argument is subject
-     *           to a feature whitelist and may not be available in your project.
+     *     @type array $billing The bucket's billing configuration.
      *     @type bool $billing['requesterPays'] When `true`, requests to this bucket
      *           and objects within it must provide a project ID to which the
-     *           request will be billed. **Whitelist Warning:** At the time of
-     *           publication, this argument is subject to a feature whitelist
-     *           and may not be available in your project.
+     *           request will be billed.
      *     @type array $labels The Bucket labels. Labels are represented as an
      *           array of keys and values. To remove an existing label, set its
      *           value to `null`.

--- a/src/Storage/StorageClient.php
+++ b/src/Storage/StorageClient.php
@@ -265,14 +265,10 @@ class StorageClient
      *           **Defaults to** `STANDARD`.
      *     @type array $versioning The bucket's versioning configuration.
      *     @type array $website The bucket's website configuration.
-     *     @type array $billing The bucket's billing configuration. **Whitelist
-     *           Warning:** At the time of publication, this argument is subject
-     *           to a feature whitelist and may not be available in your project.
+     *     @type array $billing The bucket's billing configuration.
      *     @type bool $billing['requesterPays'] When `true`, requests to this bucket
      *           and objects within it must provide a project ID to which the
-     *           request will be billed. **Whitelist Warning:** At the time of
-     *           publication, this argument is subject to a feature whitelist
-     *           and may not be available in your project.
+     *           request will be billed.
      *     @type array $labels The Bucket labels. Labels are represented as an
      *           array of keys and values. To remove an existing label, set its
      *           value to `null`.

--- a/tests/system/Storage/RequesterPaysTest.php
+++ b/tests/system/Storage/RequesterPaysTest.php
@@ -161,7 +161,6 @@ class RequesterPaysTest extends StorageTestCase
     }
 
     /**
-     * @group foo
      * @dataProvider requesterPaysMethods
      */
     public function testRequesterPaysWithUserProject(callable $call)
@@ -347,6 +346,15 @@ class RequesterPaysTest extends StorageTestCase
     public function testDeleteNotification()
     {
         $bucket = $this->requesterPaysClient->bucket(self::$bucketName, $this->requesterProject);
+        $bucket->notification(self::$notificationId)->delete();
+    }
+
+    /**
+     * @expectedException Google\Cloud\Core\Exception\BadRequestException
+     */
+    public function testDeleteNotificationFails()
+    {
+        $bucket = $this->requesterPaysClient->bucket(self::$bucketName);
         $bucket->notification(self::$notificationId)->delete();
     }
 }

--- a/tests/system/Storage/RequesterPaysTest.php
+++ b/tests/system/Storage/RequesterPaysTest.php
@@ -168,6 +168,8 @@ class RequesterPaysTest extends StorageTestCase
         $bucket = $this->requesterPaysClient->bucket(self::$bucketName, $this->requesterProject);
         $object = $bucket->object(self::$object1->name());
 
+        $this->assertEquals($this->requesterProject, $object->identity()['userProject']);
+
         $call($bucket, $object);
     }
 
@@ -332,7 +334,6 @@ class RequesterPaysTest extends StorageTestCase
                 }
             ], [
                 function (Bucket $bucket, StorageObject $object) {
-                    // broke!
                     $bucket->iam()->testPermissions(['storage.objects.create', 'storage.objects.delete']);
                 }
             ], [
@@ -347,6 +348,10 @@ class RequesterPaysTest extends StorageTestCase
     {
         $bucket = $this->requesterPaysClient->bucket(self::$bucketName, $this->requesterProject);
         $bucket->notification(self::$notificationId)->delete();
+
+        // test that the userProject is right through the object (since no access on bucket).
+        $object = $bucket->object(self::$object1->name());
+        $this->assertEquals($this->requesterProject, $object->identity()['userProject']);
     }
 
     /**


### PR DESCRIPTION
Each of the callables in `requesterPaysMethods` is invoked twice -- once with a bucket without `userProject` (this case expects an exception), and once with a bucket with `userProject` (this case should succeed without an exception).

Delete notification is tested separately, because if there is no userProject, the create operation fails, which in turn will cause the delete to fail due to a NotFoundException, which is not expected.

This change also removes the whitelist notification.

/cc @frankyn 