### PR TITLE
Benchmark: comparison cloud Logging latency between the pure gRPC/REST and the veneer gRPC/REST

### DIFF
--- a/tests/perf/LoggingLatency/LoggingCompare.php
+++ b/tests/perf/LoggingLatency/LoggingCompare.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require 'vendor/autoload.php';
+require_once('createLogEntry.php');
+use Google\Cloud\Logging\LoggingClient;
+use Google\Logging\V2\WriteLogEntriesRequest;
+use Google\Logging\V2\DeleteLogRequest;
+use Google\Logging\V2\ListLogEntriesRequest;
+use Google\Logging\V2\LoggingServiceV2GrpcClient;
+use Google\Cloud\Logging\Logger;
+use Google\Cloud\Logging\Entry;
+use Google\Logging\V2\LogEntry;
+use Google\Cloud\Logging\PsrLogger;
+
+function listlogs($stub, $metadata, $call_options, $project_id){
+        $request = new \Google\Logging\V2\ListLogsRequest();
+        $request->setParent('projects/'.$project_id);
+        list($reply, $status) = $stub->ListLogs($request, $metadata, $call_options)->wait();
+        hardAssertIfGRPCStatusOk($status);
+        $iter = $reply->getLogNames()->getIterator();
+        while ($iter->valid()){
+                print_r($iter->current());
+                echo "\n";
+                $iter->next();
+        }
+}
+
+function deletelogs($stub, $metadata, $call_options, $project_id){
+        $request = new DeleteLogRequest();
+        $request->setLogName('projects/'.$project_id.'/logs/perf-rest');
+        list($reply, $status) = $stub->DeleteLog($request, $metadata, $call_options)->wait();
+        hardAssertIfGRPCStatusOk($status);
+        print_r($reply);
+}
+
+function listLogEntries($stub, $metadata, $call_options, $project_id){
+        $request = new ListLogEntriesRequest();
+        $request->setResourceNames(['projects/'.$project_id]);
+        $request->setFilter('logName = projects/'.$project_id.'/logs/perf-rest');
+        list($reply, $status) = $stub->ListLogEntries($request, $metadata, $call_options)->wait();
+        hardAssertIfGRPCStatusOk($status);
+        $iter = $reply->getEntries()->getIterator();
+        while($iter->valid()){
+                $cur = $iter->current();
+                print_r($cur->getJsonPayload()->getFields()->getIterator()->current()->getStringValue());
+                $iter->next();
+        }
+}
+
+function createGrpcRequest($grpc, $entry_gen, $message, $project_id){
+        $new_entry = $entry_gen->entry(['message' => $message], ['severity' => 200]);
+        $args = [$new_entry];
+        foreach ($args as &$entry) {
+                $entry = $entry->info();
+        }
+        $pbEntries = [];
+        foreach ($args as $entry) {
+                $pbEntries[] = $grpc->buildEntry($entry);
+        }
+        $request = new WriteLogEntriesRequest();
+        $request->setEntries($pbEntries);
+        $request->setLogName('projects'.$project_id.'logs/perf-rest');
+        return $request;
+}
+
+function createRestRequest($entry_gen, $message, $project_id) {
+        $new_entry = $entry_gen->entry(['message' => $message], ['severity' => 200]);
+        $args = [$new_entry];
+        foreach ($args as &$entry) {
+                $entry = $entry->info();
+        }
+        $entries = ['entries' => $args,
+                'logName' => 'projects'.$project_id.'logs/perf-rest'
+        ];
+        $fields = json_encode($entries);
+        return $fields;
+}
+
+function hardAssertIfGRPCStatusOk($status) {
+            if ($status->code !== Grpc\STATUS_OK) {
+                    var_dump($status);
+            }
+}
+
+function hardAssertIfRESTStatusOk($status) {
+        if ((int)$status != 200){
+                var_dump($status);
+        }
+}
+
+// Two value should be set before the benchmark. Credential file path and API key which is for pure REST.
+$keyFilePath = getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH');
+$keyAPI = getenv('GOOGLE_CLOUD_PHP_TESTS_API_KEY');
+$scopes = ['https://www.googleapis.com/auth/logging.admin'];
+$keyFile = json_decode(file_get_contents($keyFilePath), true);
+$project_ID = $keyFile['project_id'];
+// buildEntry is used to convert Entry to LogEntry. It does the same thing Veneer gRPC does converting Entryi,
+// which makes the comparison more fair.
+$buildEntry = new createLogEntry();
+
+// create pure gRPC stub
+$fetcher = Google\Auth\CredentialsLoader::makeCredentials($scopes, $keyFile);
+$authCache = new Google\Auth\Cache\MemoryCacheItemPool();
+$credentialsLoader = new Google\Auth\FetchAuthTokenCache($fetcher, [], $authCache);
+$callback = function () use ($credentialsLoader) {
+        $token = $credentialsLoader->fetchAuthToken();
+        return ['authorization' => array('Bearer ' . $token['access_token'])];
+};
+$credentials = Grpc\ChannelCredentials::createSsl();
+$call_credentials = Grpc\CallCredentials::createFromPlugin($callback);
+$cred = Grpc\ChannelCredentials::createComposite($credentials,$call_credentials);
+$stub = new LoggingServiceV2GrpcClient('logging.googleapis.com:443', [
+        'credentials' => $cred,
+        'grpc.ssl_target_name_override' => 'logging.googleapis.com:443'
+]);
+$get_auth = $callback();
+$Bearer = $get_auth['authorization'][0];
+$metadata = ['x-goog-api-client' => ['gl-php/7.0.22-0ubuntu0.17.04.1 gccl/1.5.0 gapic/1.5.0 gax/0.24.0 grpc/1.6.0']];
+$call_options = ['timeout' => 30000000];
+// create Veneer gRPC; batchSize = 1 to disable the batch so that writing each log entry
+// will be an unary ping-pong
+$grpcLogger = LoggingClient::psrBatchLogger(
+        'perf-rest',
+        [
+                'clientConfig' => [
+                        'keyFilePath' => $keyFilePath,
+                        'transport' => 'grpc'
+                ],
+                'batchOptions' => ['batchSize' => 1]
+        ]
+);
+// create Veneer REST
+$restLogger = LoggingClient::psrBatchLogger(
+        'perf-rest',
+        [
+                'clientConfig' => [
+                        'keyFilePath' => $keyFilePath,
+                        'transport' => 'rest'
+                ],
+                'batchOptions' => ['batchSize' => 1]
+        ]
+);
+// entry_gen is used to generate log entry with timestamp
+$entry_gen = new Logger(new Google\Cloud\Logging\Connection\Rest(), 'perf-rest', $project_ID, [], []);
+// create pure REST client
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, "https://logging.googleapis.com/v2/entries:write?key=".$keyAPI);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+$headers = array();
+$headers[] = "Authorization: ".$Bearer;
+$headers[] = "Content-Type: application/json";
+$headers[] = "User-Agent: gcloud-php/1.5.0";
+$headers[] = "x-goog-api-client: gl-php/7.0.22-0ubuntu0.17.04.1 gccl/1.5.0";
+$headers[] = "Host: logging.googleapis.com" ;
+curl_setopt($ch, CURLOPT_HEADER, TRUE);
+curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+curl_setopt($ch, CURLOPT_POST, TRUE);
+$warmup_num = 30;
+$num = 1000;
+deletelogs($stub, $metadata, $call_options, $project_ID);
+sleep(1);
+echo "start warmup";
+for ($i=0; $i<$warmup_num; $i++){
+        $grpcLogger->info('b');
+        $request = createGrpcRequest($buildEntry, $entry_gen, 'a', $project_ID);
+        list($reply, $status) = $stub->WriteLogEntries($request, $metadata, $call_options, $project_ID)->wait();
+        hardAssertIfGRPCStatusOk($status);
+        $fields = createRestRequest($entry_gen, 'c', $project_ID);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $fields);
+        $restLogger->info('d');
+        $data = curl_exec($ch);
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        hardAssertIfRESTStatusOk($status);
+}
+// listLogEntries should list entries order as ‘bacdbacdbacd…’
+sleep(1);
+listLogEntries($stub, $metadata, $call_options, $project_ID);
+$pure_grpc_time = 0;
+$vene_grpc_time = 0;
+$pure_rest_time = 0;
+$vene_rest_time = 0;
+$start = microtime(true);
+echo "start benchmark";
+listlogs($stub, $metadata, $call_options, $project_ID);
+for($i=0; $i<$num; $i++){
+        echo "$i ";
+        $start = microtime(true);
+        $request = createGrpcRequest($buildEntry, $entry_gen, 'x', $project_ID);
+        $stub->WriteLogEntries($request, $metadata, $call_options, $project_ID)->wait();
+        $end = microtime(true);
+        $pure_grpc_time += ($end - $start);
+
+        $start = microtime(true);
+        $grpcLogger->info('x');
+        $end = microtime(true);
+        $vene_grpc_time += ($end - $start);
+
+        $start = microtime(true);
+        $fields = createRestRequest($entry_gen, 'x', $project_ID);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $fields);
+         curl_exec($ch);
+        $end = microtime(true);
+        $pure_rest_time += ($end - $start);
+
+        $start = microtime(true);
+        $restLogger->info('x');
+        $end = microtime(true);
+        $vene_rest_time += ($end - $start);
+}
+echo PHP_EOL . 'pure_grpc took ' . $pure_grpc_time . ' seconds for sending '.
+        $num . ' logs';
+
+echo PHP_EOL . 'vene_grpc took ' . $vene_grpc_time . ' seconds for sending '.
+        $num . ' logs';
+
+echo PHP_EOL . 'pure_rest took ' . $pure_rest_time . ' seconds for sending '.
+        $num . ' logs';
+
+echo PHP_EOL . 'vene_rest took ' . $vene_rest_time . ' seconds for sending '.
+        $num . ' logs';
+

--- a/tests/perf/LoggingLatency/composer.json
+++ b/tests/perf/LoggingLatency/composer.json
@@ -1,0 +1,6 @@
+{
+	"require": {
+		"google/cloud": "^0.24.0"
+	}
+}
+

--- a/tests/perf/LoggingLatency/createLogEntry.php
+++ b/tests/perf/LoggingLatency/createLogEntry.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require 'vendor/autoload.php';
+
+use Google\Cloud\Core\GrpcTrait;
+use Google\GAX\Serializer;
+use Google\Logging\V2\LogEntry;
+use Google\Logging\V2\LogSink_VersionFormat;
+
+/**
+ * Implementation of the
+ * [Google Stackdriver Logging gRPC API](https://cloud.google.com/logging/docs/).
+ */
+class createLogEntry
+{
+    use GrpcTrait;
+
+    private static $versionFormatMap = [
+        LogSink_VersionFormat::VERSION_FORMAT_UNSPECIFIED => 'VERSION_FORMAT_UNSPECIFIED',
+        LogSink_VersionFormat::V1 => 'V1',
+        LogSink_VersionFormat::V2 => 'V2'
+      ];
+
+
+    /**
+     * @var Serializer
+     */
+    private $serializer;
+
+    public function __construct()
+    {
+        $this->serializer = new Serializer([
+            'timestamp' => function ($v) {
+                return $this->formatTimestampFromApi($v);
+            },
+            'severity' => function ($v) {
+                return Logger::getLogLevelMap()[$v];
+            },
+            'output_version_format' => function ($v) {
+                return self::$versionFormatMap[$v];
+            },
+            'json_payload' => function ($v) {
+                return $this->unpackStructFromApi($v);
+            }
+        ]);
+    }
+   /**
+     * @param array $entry
+     * @return LogEntry
+     */
+    public function buildEntry(array $entry)
+    {
+        if (isset($entry['jsonPayload'])) {
+            $entry['jsonPayload'] = $this->formatStructForApi($entry['jsonPayload']);
+        }
+
+        if (isset($entry['timestamp'])) {
+            $entry['timestamp'] = $this->formatTimestampForApi($entry['timestamp']);
+        } else {
+            unset($entry['timestamp']);
+        }
+
+        if (isset($entry['severity']) && is_string($entry['severity'])) {
+            $entry['severity'] = array_flip(Logger::getLogLevelMap())[strtoupper($entry['severity'])];
+        }
+
+        return $this->serializer->decodeMessage(new LogEntry(), $entry);
+    }
+}


### PR DESCRIPTION
Hi. Recently I created gRPC stub directly from Google\Logging\V2\LoggingServiceV2GrpcClient and used curl as pure REST to test the cloud Logging. It compared the unary ping-pong against Veneer version I copied from test/perf/LoggingPerfTest.php while setting the batchSize to 1 to make sure every log entry uses one unray ping-pong.

I got the result with 50 ping-pong warm-up and 1000 ping-pong benchmark on 1 core and 8 cores GCE VM and saved it in a doc. The result seems make sense to me. Do I need to post them here or share the link?

Also, I am a beginner of php and don't know the right place to place this code. I can push it to gRPC repo instead, but can you have a look at it? I am trying to make the comparison as fair as possible(like introduce buildEntry method which are done by Veneer). I hope I can get the some suggestions about the correctness of this benchmark.

Thank you!.