### PR TITLE
Fix tests timezone issues

### DIFF
--- a/src/Core/GrpcTrait.php
+++ b/src/Core/GrpcTrait.php
@@ -251,7 +251,7 @@ trait GrpcTrait
     {
         preg_match('/\.(\d{1,9})Z/', $value, $matches);
         $value = preg_replace('/\.(\d{1,9})Z/', '.000000Z', $value);
-        $dt = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u\Z', $value);
+        $dt = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u\Z', $value, new \DateTimeZone('UTC'));
         $nanos = (isset($matches[1])) ? str_pad($matches[1], 9, '0') : 0;
 
         return [

--- a/tests/unit/BigQuery/ValueMapperTest.php
+++ b/tests/unit/BigQuery/ValueMapperTest.php
@@ -141,7 +141,7 @@ class ValueMapperTest extends \PHPUnit_Framework_TestCase
             [
                 ['v' => '2678400.0'],
                 ['type' => 'TIMESTAMP'],
-                new Timestamp(new \DateTime('1970-02-01'))
+                new Timestamp(new \DateTime('1970-02-01', new \DateTimeZone('UTC')))
             ],
             [
                 ['v' => '-3.1561919984985E8'],

--- a/tests/unit/Logging/LoggerTest.php
+++ b/tests/unit/Logging/LoggerTest.php
@@ -159,7 +159,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 $this->textPayload,
-                ['timestamp' => new Timestamp(new \DateTime('1980-01-01'))],
+                ['timestamp' => new Timestamp(new \DateTime('1980-01-01', new \DateTimeZone('UTC')))],
                 [
                     'textPayload' => $this->textPayload,
                     'timestamp' => $this->formattedTimestamp,
@@ -169,7 +169,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 $this->textPayload,
-                ['timestamp' => new \DateTime('1980-01-01')],
+                ['timestamp' => new \DateTime('1980-01-01', new \DateTimeZone('UTC'))],
                 [
                     'textPayload' => $this->textPayload,
                     'timestamp' => $this->formattedTimestamp,


### PR DESCRIPTION
Also enforce UTC timezone for `GrpcTrait::formatTimestampForApi()`.