### PR TITLE
Fix generated PHP GAPIC classes

### DIFF
--- a/src/Dlp/V2beta1/Gapic/DlpServiceGapicClient.php
+++ b/src/Dlp/V2beta1/Gapic/DlpServiceGapicClient.php
@@ -77,10 +77,19 @@ use Google\Privacy\Dlp\V2beta1\StorageConfig;
  * ```
  * try {
  *     $dlpServiceClient = new DlpServiceClient();
- *     $deidentifyConfig = new DeidentifyConfig();
+ *     $name = 'EMAIL_ADDRESS';
+ *     $infoTypesElement = new InfoType();
+ *     $infoTypesElement->setName($name);
+ *     $infoTypes = [$infoTypesElement];
  *     $inspectConfig = new InspectConfig();
- *     $items = [];
- *     $response = $dlpServiceClient->deidentifyContent($deidentifyConfig, $inspectConfig, $items);
+ *     $inspectConfig->setInfoTypes($infoTypes);
+ *     $type = 'text/plain';
+ *     $value = 'My email is example@example.com.';
+ *     $itemsElement = new ContentItem();
+ *     $itemsElement->setType($type);
+ *     $itemsElement->setValue($value);
+ *     $items = [$itemsElement];
+ *     $response = $dlpServiceClient->inspectContent($inspectConfig, $items);
  * } finally {
  *     $dlpServiceClient->close();
  * }
@@ -181,7 +190,7 @@ class DlpServiceGapicClient
      *
      * @param string $result
      *
-     * @return string the formatted result resource
+     * @return string The formatted result resource.
      * @experimental
      */
     public static function resultName($result)
@@ -205,9 +214,9 @@ class DlpServiceGapicClient
      * @param string $formattedName The formatted name string
      * @param string $template      Optional name of template to match
      *
-     * @return array an associative array from name component IDs to component values
+     * @return array An associative array from name component IDs to component values.
      *
-     * @throws ValidationException if $formattedName could not be matched
+     * @throws ValidationException If $formattedName could not be matched.
      * @experimental
      */
     public static function parseName($formattedName, $template = null)
@@ -345,10 +354,10 @@ class DlpServiceGapicClient
 
         $defaultDescriptors = ['headerDescriptor' => $headerDescriptor];
         $this->descriptors = [
-            'deidentifyContent' => $defaultDescriptors,
-            'analyzeDataSourceRisk' => $defaultDescriptors,
             'inspectContent' => $defaultDescriptors,
             'redactContent' => $defaultDescriptors,
+            'deidentifyContent' => $defaultDescriptors,
+            'analyzeDataSourceRisk' => $defaultDescriptors,
             'createInspectOperation' => $defaultDescriptors,
             'listInspectFindings' => $defaultDescriptors,
             'listInfoTypes' => $defaultDescriptors,
@@ -386,6 +395,162 @@ class DlpServiceGapicClient
     }
 
     /**
+     * Finds potentially sensitive info in a list of strings.
+     * This method has limits on input size, processing time, and output size.
+     *
+     * Sample code:
+     * ```
+     * try {
+     *     $dlpServiceClient = new DlpServiceClient();
+     *     $name = 'EMAIL_ADDRESS';
+     *     $infoTypesElement = new InfoType();
+     *     $infoTypesElement->setName($name);
+     *     $infoTypes = [$infoTypesElement];
+     *     $inspectConfig = new InspectConfig();
+     *     $inspectConfig->setInfoTypes($infoTypes);
+     *     $type = 'text/plain';
+     *     $value = 'My email is example@example.com.';
+     *     $itemsElement = new ContentItem();
+     *     $itemsElement->setType($type);
+     *     $itemsElement->setValue($value);
+     *     $items = [$itemsElement];
+     *     $response = $dlpServiceClient->inspectContent($inspectConfig, $items);
+     * } finally {
+     *     $dlpServiceClient->close();
+     * }
+     * ```
+     *
+     * @param InspectConfig $inspectConfig Configuration for the inspector.
+     * @param ContentItem[] $items         The list of items to inspect. Items in a single request are
+     *                                     considered "related" unless inspect_config.independent_inputs is true.
+     *                                     Up to 100 are allowed per request.
+     * @param array         $optionalArgs  {
+     *                                     Optional.
+     *
+     *     @type \Google\GAX\RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\GAX\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\GAX\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Privacy\Dlp\V2beta1\InspectContentResponse
+     *
+     * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
+     */
+    public function inspectContent($inspectConfig, $items, $optionalArgs = [])
+    {
+        $request = new InspectContentRequest();
+        $request->setInspectConfig($inspectConfig);
+        $request->setItems($items);
+
+        $defaultCallSettings = $this->defaultCallSettings['inspectContent'];
+        if (isset($optionalArgs['retrySettings']) && is_array($optionalArgs['retrySettings'])) {
+            $optionalArgs['retrySettings'] = $defaultCallSettings->getRetrySettings()->with(
+                $optionalArgs['retrySettings']
+            );
+        }
+        $mergedSettings = $defaultCallSettings->merge(new CallSettings($optionalArgs));
+        $callable = ApiCallable::createApiCall(
+            $this->dlpServiceStub,
+            'InspectContent',
+            $mergedSettings,
+            $this->descriptors['inspectContent']
+        );
+
+        return $callable(
+            $request,
+            [],
+            ['call_credentials_callback' => $this->createCredentialsCallback()]);
+    }
+
+    /**
+     * Redacts potentially sensitive info from a list of strings.
+     * This method has limits on input size, processing time, and output size.
+     *
+     * Sample code:
+     * ```
+     * try {
+     *     $dlpServiceClient = new DlpServiceClient();
+     *     $name = 'EMAIL_ADDRESS';
+     *     $infoTypesElement = new InfoType();
+     *     $infoTypesElement->setName($name);
+     *     $infoTypes = [$infoTypesElement];
+     *     $inspectConfig = new InspectConfig();
+     *     $inspectConfig->setInfoTypes($infoTypes);
+     *     $type = 'text/plain';
+     *     $value = 'My email is example@example.com.';
+     *     $itemsElement = new ContentItem();
+     *     $itemsElement->setType($type);
+     *     $itemsElement->setValue($value);
+     *     $items = [$itemsElement];
+     *     $name2 = 'EMAIL_ADDRESS';
+     *     $infoType = new InfoType();
+     *     $infoType->setName($name2);
+     *     $replaceWith = 'REDACTED';
+     *     $replaceConfigsElement = new ReplaceConfig();
+     *     $replaceConfigsElement->setInfoType($infoType);
+     *     $replaceConfigsElement->setReplaceWith($replaceWith);
+     *     $replaceConfigs = [$replaceConfigsElement];
+     *     $response = $dlpServiceClient->redactContent($inspectConfig, $items, $replaceConfigs);
+     * } finally {
+     *     $dlpServiceClient->close();
+     * }
+     * ```
+     *
+     * @param InspectConfig   $inspectConfig  Configuration for the inspector.
+     * @param ContentItem[]   $items          The list of items to inspect. Up to 100 are allowed per request.
+     * @param ReplaceConfig[] $replaceConfigs The strings to replace findings text findings with. Must specify at least
+     *                                        one of these or one ImageRedactionConfig if redacting images.
+     * @param array           $optionalArgs   {
+     *                                        Optional.
+     *
+     *     @type ImageRedactionConfig[] $imageRedactionConfigs
+     *          The configuration for specifying what content to redact from images.
+     *     @type \Google\GAX\RetrySettings|array $retrySettings
+     *          Retry settings to use for this call. Can be a
+     *          {@see Google\GAX\RetrySettings} object, or an associative array
+     *          of retry settings parameters. See the documentation on
+     *          {@see Google\GAX\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Privacy\Dlp\V2beta1\RedactContentResponse
+     *
+     * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
+     */
+    public function redactContent($inspectConfig, $items, $replaceConfigs, $optionalArgs = [])
+    {
+        $request = new RedactContentRequest();
+        $request->setInspectConfig($inspectConfig);
+        $request->setItems($items);
+        $request->setReplaceConfigs($replaceConfigs);
+        if (isset($optionalArgs['imageRedactionConfigs'])) {
+            $request->setImageRedactionConfigs($optionalArgs['imageRedactionConfigs']);
+        }
+
+        $defaultCallSettings = $this->defaultCallSettings['redactContent'];
+        if (isset($optionalArgs['retrySettings']) && is_array($optionalArgs['retrySettings'])) {
+            $optionalArgs['retrySettings'] = $defaultCallSettings->getRetrySettings()->with(
+                $optionalArgs['retrySettings']
+            );
+        }
+        $mergedSettings = $defaultCallSettings->merge(new CallSettings($optionalArgs));
+        $callable = ApiCallable::createApiCall(
+            $this->dlpServiceStub,
+            'RedactContent',
+            $mergedSettings,
+            $this->descriptors['redactContent']
+        );
+
+        return $callable(
+            $request,
+            [],
+            ['call_credentials_callback' => $this->createCredentialsCallback()]);
+    }
+
+    /**
      * De-identifies potentially sensitive info from a list of strings.
      * This method has limits on input size and output size.
      *
@@ -402,12 +567,12 @@ class DlpServiceGapicClient
      * }
      * ```
      *
-     * @param DeidentifyConfig $deidentifyConfig configuration for the de-identification of the list of content items
-     * @param InspectConfig    $inspectConfig    configuration for the inspector
+     * @param DeidentifyConfig $deidentifyConfig Configuration for the de-identification of the list of content items.
+     * @param InspectConfig    $inspectConfig    Configuration for the inspector.
      * @param ContentItem[]    $items            The list of items to inspect. Up to 100 are allowed per request.
      *                                           All items will be treated as text/*.
      * @param array            $optionalArgs     {
-     *                                           Optional
+     *                                           Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -489,10 +654,10 @@ class DlpServiceGapicClient
      * }
      * ```
      *
-     * @param PrivacyMetric $privacyMetric privacy metric to compute
-     * @param BigQueryTable $sourceTable   input dataset to compute metrics over
+     * @param PrivacyMetric $privacyMetric Privacy metric to compute.
+     * @param BigQueryTable $sourceTable   Input dataset to compute metrics over.
      * @param array         $optionalArgs  {
-     *                                     Optional
+     *                                     Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -524,162 +689,6 @@ class DlpServiceGapicClient
             'AnalyzeDataSourceRisk',
             $mergedSettings,
             $this->descriptors['analyzeDataSourceRisk']
-        );
-
-        return $callable(
-            $request,
-            [],
-            ['call_credentials_callback' => $this->createCredentialsCallback()]);
-    }
-
-    /**
-     * Finds potentially sensitive info in a list of strings.
-     * This method has limits on input size, processing time, and output size.
-     *
-     * Sample code:
-     * ```
-     * try {
-     *     $dlpServiceClient = new DlpServiceClient();
-     *     $name = 'EMAIL_ADDRESS';
-     *     $infoTypesElement = new InfoType();
-     *     $infoTypesElement->setName($name);
-     *     $infoTypes = [$infoTypesElement];
-     *     $inspectConfig = new InspectConfig();
-     *     $inspectConfig->setInfoTypes($infoTypes);
-     *     $type = 'text/plain';
-     *     $value = 'My email is example@example.com.';
-     *     $itemsElement = new ContentItem();
-     *     $itemsElement->setType($type);
-     *     $itemsElement->setValue($value);
-     *     $items = [$itemsElement];
-     *     $response = $dlpServiceClient->inspectContent($inspectConfig, $items);
-     * } finally {
-     *     $dlpServiceClient->close();
-     * }
-     * ```
-     *
-     * @param InspectConfig $inspectConfig configuration for the inspector
-     * @param ContentItem[] $items         The list of items to inspect. Items in a single request are
-     *                                     considered "related" unless inspect_config.independent_inputs is true.
-     *                                     Up to 100 are allowed per request.
-     * @param array         $optionalArgs  {
-     *                                     Optional
-     *
-     *     @type \Google\GAX\RetrySettings|array $retrySettings
-     *          Retry settings to use for this call. Can be a
-     *          {@see Google\GAX\RetrySettings} object, or an associative array
-     *          of retry settings parameters. See the documentation on
-     *          {@see Google\GAX\RetrySettings} for example usage.
-     * }
-     *
-     * @return \Google\Privacy\Dlp\V2beta1\InspectContentResponse
-     *
-     * @throws \Google\GAX\ApiException if the remote call fails
-     * @experimental
-     */
-    public function inspectContent($inspectConfig, $items, $optionalArgs = [])
-    {
-        $request = new InspectContentRequest();
-        $request->setInspectConfig($inspectConfig);
-        $request->setItems($items);
-
-        $defaultCallSettings = $this->defaultCallSettings['inspectContent'];
-        if (isset($optionalArgs['retrySettings']) && is_array($optionalArgs['retrySettings'])) {
-            $optionalArgs['retrySettings'] = $defaultCallSettings->getRetrySettings()->with(
-                $optionalArgs['retrySettings']
-            );
-        }
-        $mergedSettings = $defaultCallSettings->merge(new CallSettings($optionalArgs));
-        $callable = ApiCallable::createApiCall(
-            $this->dlpServiceStub,
-            'InspectContent',
-            $mergedSettings,
-            $this->descriptors['inspectContent']
-        );
-
-        return $callable(
-            $request,
-            [],
-            ['call_credentials_callback' => $this->createCredentialsCallback()]);
-    }
-
-    /**
-     * Redacts potentially sensitive info from a list of strings.
-     * This method has limits on input size, processing time, and output size.
-     *
-     * Sample code:
-     * ```
-     * try {
-     *     $dlpServiceClient = new DlpServiceClient();
-     *     $name = 'EMAIL_ADDRESS';
-     *     $infoTypesElement = new InfoType();
-     *     $infoTypesElement->setName($name);
-     *     $infoTypes = [$infoTypesElement];
-     *     $inspectConfig = new InspectConfig();
-     *     $inspectConfig->setInfoTypes($infoTypes);
-     *     $type = 'text/plain';
-     *     $value = 'My email is example@example.com.';
-     *     $itemsElement = new ContentItem();
-     *     $itemsElement->setType($type);
-     *     $itemsElement->setValue($value);
-     *     $items = [$itemsElement];
-     *     $name2 = 'EMAIL_ADDRESS';
-     *     $infoType = new InfoType();
-     *     $infoType->setName($name2);
-     *     $replaceWith = 'REDACTED';
-     *     $replaceConfigsElement = new ReplaceConfig();
-     *     $replaceConfigsElement->setInfoType($infoType);
-     *     $replaceConfigsElement->setReplaceWith($replaceWith);
-     *     $replaceConfigs = [$replaceConfigsElement];
-     *     $response = $dlpServiceClient->redactContent($inspectConfig, $items, $replaceConfigs);
-     * } finally {
-     *     $dlpServiceClient->close();
-     * }
-     * ```
-     *
-     * @param InspectConfig   $inspectConfig  configuration for the inspector
-     * @param ContentItem[]   $items          The list of items to inspect. Up to 100 are allowed per request.
-     * @param ReplaceConfig[] $replaceConfigs The strings to replace findings text findings with. Must specify at least
-     *                                        one of these or one ImageRedactionConfig if redacting images.
-     * @param array           $optionalArgs   {
-     *                                        Optional
-     *
-     *     @type ImageRedactionConfig[] $imageRedactionConfigs
-     *          The configuration for specifying what content to redact from images.
-     *     @type \Google\GAX\RetrySettings|array $retrySettings
-     *          Retry settings to use for this call. Can be a
-     *          {@see Google\GAX\RetrySettings} object, or an associative array
-     *          of retry settings parameters. See the documentation on
-     *          {@see Google\GAX\RetrySettings} for example usage.
-     * }
-     *
-     * @return \Google\Privacy\Dlp\V2beta1\RedactContentResponse
-     *
-     * @throws \Google\GAX\ApiException if the remote call fails
-     * @experimental
-     */
-    public function redactContent($inspectConfig, $items, $replaceConfigs, $optionalArgs = [])
-    {
-        $request = new RedactContentRequest();
-        $request->setInspectConfig($inspectConfig);
-        $request->setItems($items);
-        $request->setReplaceConfigs($replaceConfigs);
-        if (isset($optionalArgs['imageRedactionConfigs'])) {
-            $request->setImageRedactionConfigs($optionalArgs['imageRedactionConfigs']);
-        }
-
-        $defaultCallSettings = $this->defaultCallSettings['redactContent'];
-        if (isset($optionalArgs['retrySettings']) && is_array($optionalArgs['retrySettings'])) {
-            $optionalArgs['retrySettings'] = $defaultCallSettings->getRetrySettings()->with(
-                $optionalArgs['retrySettings']
-            );
-        }
-        $mergedSettings = $defaultCallSettings->merge(new CallSettings($optionalArgs));
-        $callable = ApiCallable::createApiCall(
-            $this->dlpServiceStub,
-            'RedactContent',
-            $mergedSettings,
-            $this->descriptors['redactContent']
         );
 
         return $callable(
@@ -741,11 +750,11 @@ class DlpServiceGapicClient
      * }
      * ```
      *
-     * @param InspectConfig       $inspectConfig configuration for the inspector
-     * @param StorageConfig       $storageConfig specification of the data set to process
-     * @param OutputStorageConfig $outputConfig  optional location to store findings
+     * @param InspectConfig       $inspectConfig Configuration for the inspector.
+     * @param StorageConfig       $storageConfig Specification of the data set to process.
+     * @param OutputStorageConfig $outputConfig  Optional location to store findings.
      * @param array               $optionalArgs  {
-     *                                           Optional
+     *                                           Optional.
      *
      *     @type OperationConfig $operationConfig
      *          Additional configuration settings for long running operations.
@@ -809,7 +818,7 @@ class DlpServiceGapicClient
      *                             the longrunning operation created by a call to InspectDataSource.
      *                             Should be in the format of `inspect/results/{id}`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type int $pageSize
      *          Maximum number of results to return.
@@ -889,12 +898,12 @@ class DlpServiceGapicClient
      * }
      * ```
      *
-     * @param string $category     category name as returned by ListRootCategories
+     * @param string $category     Category name as returned by ListRootCategories.
      * @param string $languageCode Optional BCP-47 language code for localized info type friendly
      *                             names. If omitted, or if localized strings are not available,
      *                             en-US strings will be returned.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -952,7 +961,7 @@ class DlpServiceGapicClient
      *                             If omitted or if localized strings are not available,
      *                             en-US strings will be returned.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a

--- a/src/Dlp/V2beta1/resources/dlp_service_client_config.json
+++ b/src/Dlp/V2beta1/resources/dlp_service_client_config.json
@@ -20,16 +20,6 @@
         }
       },
       "methods": {
-        "DeidentifyContent": {
-          "timeout_millis": 60000,
-          "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
-        },
-        "AnalyzeDataSourceRisk": {
-          "timeout_millis": 60000,
-          "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
-        },
         "InspectContent": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
@@ -38,6 +28,16 @@
         "RedactContent": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "DeidentifyContent": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "AnalyzeDataSourceRisk": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "CreateInspectOperation": {

--- a/src/ErrorReporting/V1beta1/Gapic/ErrorGroupServiceGapicClient.php
+++ b/src/ErrorReporting/V1beta1/Gapic/ErrorGroupServiceGapicClient.php
@@ -143,7 +143,7 @@ class ErrorGroupServiceGapicClient
      * @param string $project
      * @param string $group
      *
-     * @return string the formatted group resource
+     * @return string The formatted group resource.
      * @experimental
      */
     public static function groupName($project, $group)
@@ -168,9 +168,9 @@ class ErrorGroupServiceGapicClient
      * @param string $formattedName The formatted name string
      * @param string $template      Optional name of template to match
      *
-     * @return array an associative array from name component IDs to component values
+     * @return array An associative array from name component IDs to component values.
      *
-     * @throws ValidationException if $formattedName could not be matched
+     * @throws ValidationException If $formattedName could not be matched.
      * @experimental
      */
     public static function parseName($formattedName, $template = null)
@@ -314,7 +314,7 @@ class ErrorGroupServiceGapicClient
      *
      * Example: <code>projects/my-project-123/groups/my-group</code>
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -368,9 +368,9 @@ class ErrorGroupServiceGapicClient
      * }
      * ```
      *
-     * @param errorGroup $group        [Required] The group which replaces the resource on the server
+     * @param ErrorGroup $group        [Required] The group which replaces the resource on the server.
      * @param array      $optionalArgs {
-     *                                 Optional
+     *                                 Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a

--- a/src/ErrorReporting/V1beta1/Gapic/ErrorStatsServiceGapicClient.php
+++ b/src/ErrorReporting/V1beta1/Gapic/ErrorStatsServiceGapicClient.php
@@ -190,7 +190,7 @@ class ErrorStatsServiceGapicClient
      *
      * @param string $project
      *
-     * @return string the formatted project resource
+     * @return string The formatted project resource.
      * @experimental
      */
     public static function projectName($project)
@@ -214,9 +214,9 @@ class ErrorStatsServiceGapicClient
      * @param string $formattedName The formatted name string
      * @param string $template      Optional name of template to match
      *
-     * @return array an associative array from name component IDs to component values
+     * @return array An associative array from name component IDs to component values.
      *
-     * @throws ValidationException if $formattedName could not be matched
+     * @throws ValidationException If $formattedName could not be matched.
      * @experimental
      */
     public static function parseName($formattedName, $template = null)
@@ -383,7 +383,7 @@ class ErrorStatsServiceGapicClient
      *                                     If a group_id list is given, also <code>ErrorGroupStats</code> with zero
      *                                     occurrences are returned.
      * @param array          $optionalArgs {
-     *                                     Optional
+     *                                     Optional.
      *
      *     @type string[] $groupId
      *          [Optional] List all <code>ErrorGroupStats</code> with these IDs.
@@ -508,9 +508,9 @@ class ErrorStatsServiceGapicClient
      *                             [Google Cloud Platform project
      *                             ID](https://support.google.com/cloud/answer/6158840).
      *                             Example: `projects/my-project-123`.
-     * @param string $groupId      [Required] The group for which events shall be returned
+     * @param string $groupId      [Required] The group for which events shall be returned.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type ServiceContextFilter $serviceFilter
      *          [Optional] List only ErrorGroups which belong to a service context that
@@ -599,7 +599,7 @@ class ErrorStatsServiceGapicClient
      *                             ID](https://support.google.com/cloud/answer/6158840).
      *                             Example: `projects/my-project-123`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a

--- a/src/ErrorReporting/V1beta1/Gapic/ReportErrorsServiceGapicClient.php
+++ b/src/ErrorReporting/V1beta1/Gapic/ReportErrorsServiceGapicClient.php
@@ -142,7 +142,7 @@ class ReportErrorsServiceGapicClient
      *
      * @param string $project
      *
-     * @return string the formatted project resource
+     * @return string The formatted project resource.
      * @experimental
      */
     public static function projectName($project)
@@ -166,9 +166,9 @@ class ReportErrorsServiceGapicClient
      * @param string $formattedName The formatted name string
      * @param string $template      Optional name of template to match
      *
-     * @return array an associative array from name component IDs to component values
+     * @return array An associative array from name component IDs to component values.
      *
-     * @throws ValidationException if $formattedName could not be matched
+     * @throws ValidationException If $formattedName could not be matched.
      * @experimental
      */
     public static function parseName($formattedName, $template = null)
@@ -314,9 +314,9 @@ class ReportErrorsServiceGapicClient
      *                                         as `projects/` plus the
      *                                         [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
      *                                         Example: `projects/my-project-123`.
-     * @param reportedErrorEvent $event        [Required] The error event to be reported
+     * @param ReportedErrorEvent $event        [Required] The error event to be reported.
      * @param array              $optionalArgs {
-     *                                         Optional
+     *                                         Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a

--- a/src/Language/V1beta2/Gapic/LanguageServiceGapicClient.php
+++ b/src/Language/V1beta2/Gapic/LanguageServiceGapicClient.php
@@ -228,9 +228,9 @@ class LanguageServiceGapicClient
      * }
      * ```
      *
-     * @param Document $document     input document
+     * @param Document $document     Input document.
      * @param array    $optionalArgs {
-     *                               Optional
+     *                               Optional.
      *
      *     @type int $encodingType
      *          The encoding type used by the API to calculate sentence offsets for the
@@ -292,9 +292,9 @@ class LanguageServiceGapicClient
      * }
      * ```
      *
-     * @param Document $document     input document
+     * @param Document $document     Input document.
      * @param array    $optionalArgs {
-     *                               Optional
+     *                               Optional.
      *
      *     @type int $encodingType
      *          The encoding type used by the API to calculate offsets.
@@ -354,9 +354,9 @@ class LanguageServiceGapicClient
      * }
      * ```
      *
-     * @param Document $document     input document
+     * @param Document $document     Input document.
      * @param array    $optionalArgs {
-     *                               Optional
+     *                               Optional.
      *
      *     @type int $encodingType
      *          The encoding type used by the API to calculate offsets.
@@ -417,9 +417,9 @@ class LanguageServiceGapicClient
      * }
      * ```
      *
-     * @param Document $document     input document
+     * @param Document $document     Input document.
      * @param array    $optionalArgs {
-     *                               Optional
+     *                               Optional.
      *
      *     @type int $encodingType
      *          The encoding type used by the API to calculate offsets.
@@ -478,9 +478,9 @@ class LanguageServiceGapicClient
      * }
      * ```
      *
-     * @param Document $document     input document
+     * @param Document $document     Input document.
      * @param array    $optionalArgs {
-     *                               Optional
+     *                               Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -535,10 +535,10 @@ class LanguageServiceGapicClient
      * }
      * ```
      *
-     * @param Document $document     input document
-     * @param Features $features     the enabled features
+     * @param Document $document     Input document.
+     * @param Features $features     The enabled features.
      * @param array    $optionalArgs {
-     *                               Optional
+     *                               Optional.
      *
      *     @type int $encodingType
      *          The encoding type used by the API to calculate offsets.

--- a/src/Logging/V2/Gapic/ConfigServiceV2GapicClient.php
+++ b/src/Logging/V2/Gapic/ConfigServiceV2GapicClient.php
@@ -217,7 +217,7 @@ class ConfigServiceV2GapicClient
      *
      * @param string $project
      *
-     * @return string the formatted project resource
+     * @return string The formatted project resource.
      * @experimental
      */
     public static function projectName($project)
@@ -234,7 +234,7 @@ class ConfigServiceV2GapicClient
      * @param string $project
      * @param string $sink
      *
-     * @return string the formatted sink resource
+     * @return string The formatted sink resource.
      * @experimental
      */
     public static function sinkName($project, $sink)
@@ -252,7 +252,7 @@ class ConfigServiceV2GapicClient
      * @param string $project
      * @param string $exclusion
      *
-     * @return string the formatted exclusion resource
+     * @return string The formatted exclusion resource.
      * @experimental
      */
     public static function exclusionName($project, $exclusion)
@@ -279,9 +279,9 @@ class ConfigServiceV2GapicClient
      * @param string $formattedName The formatted name string
      * @param string $template      Optional name of template to match
      *
-     * @return array an associative array from name component IDs to component values
+     * @return array An associative array from name component IDs to component values.
      *
-     * @throws ValidationException if $formattedName could not be matched
+     * @throws ValidationException If $formattedName could not be matched.
      * @experimental
      */
     public static function parseName($formattedName, $template = null)
@@ -451,7 +451,7 @@ class ConfigServiceV2GapicClient
      *     "billingAccounts/[BILLING_ACCOUNT_ID]"
      *     "folders/[FOLDER_ID]"
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type string $pageToken
      *          A page token is used to specify a page of values to be returned.
@@ -528,7 +528,7 @@ class ConfigServiceV2GapicClient
      *
      * Example: `"projects/my-project-id/sinks/my-sink-id"`.
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -597,7 +597,7 @@ class ConfigServiceV2GapicClient
      * @param LogSink $sink         Required. The new sink, whose `name` parameter is a sink identifier that
      *                              is not already in use.
      * @param array   $optionalArgs {
-     *                              Optional
+     *                              Optional.
      *
      *     @type bool $uniqueWriterIdentity
      *          Optional. Determines the kind of IAM identity returned as `writer_identity`
@@ -683,7 +683,7 @@ class ConfigServiceV2GapicClient
      * @param LogSink $sink         Required. The updated sink, whose name is the same identifier that appears
      *                              as part of `sink_name`.
      * @param array   $optionalArgs {
-     *                              Optional
+     *                              Optional.
      *
      *     @type bool $uniqueWriterIdentity
      *          Optional. See
@@ -764,7 +764,7 @@ class ConfigServiceV2GapicClient
      *
      * Example: `"projects/my-project-id/sinks/my-sink-id"`.
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -834,7 +834,7 @@ class ConfigServiceV2GapicClient
      *     "billingAccounts/[BILLING_ACCOUNT_ID]"
      *     "folders/[FOLDER_ID]"
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type string $pageToken
      *          A page token is used to specify a page of values to be returned.
@@ -911,7 +911,7 @@ class ConfigServiceV2GapicClient
      *
      * Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -978,7 +978,7 @@ class ConfigServiceV2GapicClient
      * @param LogExclusion $exclusion    Required. The new exclusion, whose `name` parameter is an exclusion name
      *                                   that is not already used in the parent resource.
      * @param array        $optionalArgs {
-     *                                   Optional
+     *                                   Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1052,7 +1052,7 @@ class ConfigServiceV2GapicClient
      * For example, to change the filter and description of an exclusion,
      * specify an `update_mask` of `"filter,description"`.
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1116,7 +1116,7 @@ class ConfigServiceV2GapicClient
      *
      * Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a

--- a/src/Logging/V2/Gapic/LoggingServiceV2GapicClient.php
+++ b/src/Logging/V2/Gapic/LoggingServiceV2GapicClient.php
@@ -197,7 +197,7 @@ class LoggingServiceV2GapicClient
      *
      * @param string $project
      *
-     * @return string the formatted project resource
+     * @return string The formatted project resource.
      * @experimental
      */
     public static function projectName($project)
@@ -214,7 +214,7 @@ class LoggingServiceV2GapicClient
      * @param string $project
      * @param string $log
      *
-     * @return string the formatted log resource
+     * @return string The formatted log resource.
      * @experimental
      */
     public static function logName($project, $log)
@@ -240,9 +240,9 @@ class LoggingServiceV2GapicClient
      * @param string $formattedName The formatted name string
      * @param string $template      Optional name of template to match
      *
-     * @return array an associative array from name component IDs to component values
+     * @return array An associative array from name component IDs to component values.
      *
-     * @throws ValidationException if $formattedName could not be matched
+     * @throws ValidationException If $formattedName could not be matched.
      * @experimental
      */
     public static function parseName($formattedName, $template = null)
@@ -404,7 +404,7 @@ class LoggingServiceV2GapicClient
      * For more information about log names, see
      * [LogEntry][google.logging.v2.LogEntry].
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -483,7 +483,7 @@ class LoggingServiceV2GapicClient
      * you should try to include several log entries in this list,
      * rather than calling this method for each individual log entry.
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type string $logName
      *          Optional. A default log resource name that is assigned to all log entries
@@ -606,7 +606,7 @@ class LoggingServiceV2GapicClient
      *
      * Projects listed in the `project_ids` field are added to this list.
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type string[] $projectIds
      *          Deprecated. Use `resource_names` instead.  One or more project identifiers
@@ -718,7 +718,7 @@ class LoggingServiceV2GapicClient
      * ```
      *
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type int $pageSize
      *          The maximum number of resources contained in the underlying API
@@ -805,7 +805,7 @@ class LoggingServiceV2GapicClient
      *     "billingAccounts/[BILLING_ACCOUNT_ID]"
      *     "folders/[FOLDER_ID]"
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type int $pageSize
      *          The maximum number of resources contained in the underlying API

--- a/src/Logging/V2/Gapic/MetricsServiceV2GapicClient.php
+++ b/src/Logging/V2/Gapic/MetricsServiceV2GapicClient.php
@@ -188,7 +188,7 @@ class MetricsServiceV2GapicClient
      *
      * @param string $project
      *
-     * @return string the formatted project resource
+     * @return string The formatted project resource.
      * @experimental
      */
     public static function projectName($project)
@@ -205,7 +205,7 @@ class MetricsServiceV2GapicClient
      * @param string $project
      * @param string $metric
      *
-     * @return string the formatted metric resource
+     * @return string The formatted metric resource.
      * @experimental
      */
     public static function metricName($project, $metric)
@@ -231,9 +231,9 @@ class MetricsServiceV2GapicClient
      * @param string $formattedName The formatted name string
      * @param string $template      Optional name of template to match
      *
-     * @return array an associative array from name component IDs to component values
+     * @return array An associative array from name component IDs to component values.
      *
-     * @throws ValidationException if $formattedName could not be matched
+     * @throws ValidationException If $formattedName could not be matched.
      * @experimental
      */
     public static function parseName($formattedName, $template = null)
@@ -395,7 +395,7 @@ class MetricsServiceV2GapicClient
      *
      *     "projects/[PROJECT_ID]"
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type string $pageToken
      *          A page token is used to specify a page of values to be returned.
@@ -467,7 +467,7 @@ class MetricsServiceV2GapicClient
      *
      *     "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -521,15 +521,15 @@ class MetricsServiceV2GapicClient
      * }
      * ```
      *
-     * @param string $parent the resource name of the project in which to create the metric:
+     * @param string $parent The resource name of the project in which to create the metric:
      *
      *     "projects/[PROJECT_ID]"
      *
-     * The new metric must be provided in the request
-     * @param LogMetric $metric       the new logs-based metric, which must not have an identifier that
-     *                                already exists
+     * The new metric must be provided in the request.
+     * @param LogMetric $metric       The new logs-based metric, which must not have an identifier that
+     *                                already exists.
      * @param array     $optionalArgs {
-     *                                Optional
+     *                                Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -584,16 +584,16 @@ class MetricsServiceV2GapicClient
      * }
      * ```
      *
-     * @param string $metricName the resource name of the metric to update:
+     * @param string $metricName The resource name of the metric to update:
      *
      *     "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
      *
      * The updated metric must be provided in the request and it's
      * `name` field must be the same as `[METRIC_ID]` If the metric
-     * does not exist in `[PROJECT_ID]`, then a new metric is created
-     * @param LogMetric $metric       the updated metric
+     * does not exist in `[PROJECT_ID]`, then a new metric is created.
+     * @param LogMetric $metric       The updated metric.
      * @param array     $optionalArgs {
-     *                                Optional
+     *                                Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -651,7 +651,7 @@ class MetricsServiceV2GapicClient
      *
      *     "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a

--- a/src/Monitoring/V3/Gapic/GroupServiceGapicClient.php
+++ b/src/Monitoring/V3/Gapic/GroupServiceGapicClient.php
@@ -211,7 +211,7 @@ class GroupServiceGapicClient
      *
      * @param string $project
      *
-     * @return string the formatted project resource
+     * @return string The formatted project resource.
      * @experimental
      */
     public static function projectName($project)
@@ -228,7 +228,7 @@ class GroupServiceGapicClient
      * @param string $project
      * @param string $group
      *
-     * @return string the formatted group resource
+     * @return string The formatted group resource.
      * @experimental
      */
     public static function groupName($project, $group)
@@ -254,9 +254,9 @@ class GroupServiceGapicClient
      * @param string $formattedName The formatted name string
      * @param string $template      Optional name of template to match
      *
-     * @return array an associative array from name component IDs to component values
+     * @return array An associative array from name component IDs to component values.
      *
-     * @throws ValidationException if $formattedName could not be matched
+     * @throws ValidationException If $formattedName could not be matched.
      * @experimental
      */
     public static function parseName($formattedName, $template = null)
@@ -417,7 +417,7 @@ class GroupServiceGapicClient
      * @param string $name         The project whose groups are to be listed. The format is
      *                             `"projects/{project_id_or_number}"`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type string $childrenOfGroup
      *          A group name: `"projects/{project_id_or_number}/groups/{group_id}"`.
@@ -512,7 +512,7 @@ class GroupServiceGapicClient
      * @param string $name         The group to retrieve. The format is
      *                             `"projects/{project_id_or_number}/groups/{group_id}"`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -571,7 +571,7 @@ class GroupServiceGapicClient
      * @param Group  $group        A group definition. It is an error to define the `name` field because
      *                             the system assigns the name.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type bool $validateOnly
      *          If true, validate this request but do not create the group.
@@ -634,7 +634,7 @@ class GroupServiceGapicClient
      * @param Group $group        The new definition of the group.  All fields of the existing group,
      *                            excepting `name`, are replaced with the corresponding fields of this group.
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type bool $validateOnly
      *          If true, validate this request but do not update the existing group.
@@ -695,7 +695,7 @@ class GroupServiceGapicClient
      * @param string $name         The group to delete. The format is
      *                             `"projects/{project_id_or_number}/groups/{group_id}"`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -761,7 +761,7 @@ class GroupServiceGapicClient
      * @param string $name         The group whose members are listed. The format is
      *                             `"projects/{project_id_or_number}/groups/{group_id}"`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type int $pageSize
      *          The maximum number of resources contained in the underlying API

--- a/src/Monitoring/V3/Gapic/MetricServiceGapicClient.php
+++ b/src/Monitoring/V3/Gapic/MetricServiceGapicClient.php
@@ -227,7 +227,7 @@ class MetricServiceGapicClient
      *
      * @param string $project
      *
-     * @return string the formatted project resource
+     * @return string The formatted project resource.
      * @experimental
      */
     public static function projectName($project)
@@ -244,7 +244,7 @@ class MetricServiceGapicClient
      * @param string $project
      * @param string $metricDescriptor
      *
-     * @return string the formatted metric_descriptor resource
+     * @return string The formatted metric_descriptor resource.
      * @experimental
      */
     public static function metricDescriptorName($project, $metricDescriptor)
@@ -262,7 +262,7 @@ class MetricServiceGapicClient
      * @param string $project
      * @param string $monitoredResourceDescriptor
      *
-     * @return string the formatted monitored_resource_descriptor resource
+     * @return string The formatted monitored_resource_descriptor resource.
      * @experimental
      */
     public static function monitoredResourceDescriptorName($project, $monitoredResourceDescriptor)
@@ -289,9 +289,9 @@ class MetricServiceGapicClient
      * @param string $formattedName The formatted name string
      * @param string $template      Optional name of template to match
      *
-     * @return array an associative array from name component IDs to component values
+     * @return array An associative array from name component IDs to component values.
      *
-     * @throws ValidationException if $formattedName could not be matched
+     * @throws ValidationException If $formattedName could not be matched.
      * @experimental
      */
     public static function parseName($formattedName, $template = null)
@@ -454,7 +454,7 @@ class MetricServiceGapicClient
      * @param string $name         The project on which to execute the request. The format is
      *                             `"projects/{project_id_or_number}"`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type string $filter
      *          An optional [filter](https://cloud.google.com/monitoring/api/v3/filters) describing
@@ -538,7 +538,7 @@ class MetricServiceGapicClient
      *                             The `{resource_type}` is a predefined type, such as
      *                             `cloudsql_database`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -606,7 +606,7 @@ class MetricServiceGapicClient
      * @param string $name         The project on which to execute the request. The format is
      *                             `"projects/{project_id_or_number}"`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type string $filter
      *          If this field is empty, all custom and
@@ -691,7 +691,7 @@ class MetricServiceGapicClient
      *                             An example value of `{metric_id}` is
      *                             `"compute.googleapis.com/instance/disk/read_bytes_count"`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -752,7 +752,7 @@ class MetricServiceGapicClient
      * @param MetricDescriptor $metricDescriptor The new [custom metric](https://cloud.google.com/monitoring/custom-metrics)
      *                                           descriptor.
      * @param array            $optionalArgs     {
-     *                                           Optional
+     *                                           Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -812,7 +812,7 @@ class MetricServiceGapicClient
      *                             An example of `{metric_id}` is:
      *                             `"custom.googleapis.com/my_test_metric"`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -893,7 +893,7 @@ class MetricServiceGapicClient
      * @param int          $view         Specifies which information is returned about the time series.
      *                                   For allowed values, use constants defined on {@see \Google\Monitoring\V3\ListTimeSeriesRequest_TimeSeriesView}
      * @param array        $optionalArgs {
-     *                                   Optional
+     *                                   Optional.
      *
      *     @type Aggregation $aggregation
      *          By default, the raw time series data is returned.
@@ -990,7 +990,7 @@ class MetricServiceGapicClient
      *                                   `TimeSeries` value must fully specify a unique time series by supplying
      *                                   all label values for the metric and the monitored resource.
      * @param array        $optionalArgs {
-     *                                   Optional
+     *                                   Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a

--- a/src/PubSub/V1/Gapic/PublisherGapicClient.php
+++ b/src/PubSub/V1/Gapic/PublisherGapicClient.php
@@ -196,7 +196,7 @@ class PublisherGapicClient
      *
      * @param string $project
      *
-     * @return string the formatted project resource
+     * @return string The formatted project resource.
      * @experimental
      */
     public static function projectName($project)
@@ -213,7 +213,7 @@ class PublisherGapicClient
      * @param string $project
      * @param string $topic
      *
-     * @return string the formatted topic resource
+     * @return string The formatted topic resource.
      * @experimental
      */
     public static function topicName($project, $topic)
@@ -239,9 +239,9 @@ class PublisherGapicClient
      * @param string $formattedName The formatted name string
      * @param string $template      Optional name of template to match
      *
-     * @return array an associative array from name component IDs to component values
+     * @return array An associative array from name component IDs to component values.
      *
-     * @throws ValidationException if $formattedName could not be matched
+     * @throws ValidationException If $formattedName could not be matched.
      * @experimental
      */
     public static function parseName($formattedName, $template = null)
@@ -403,7 +403,7 @@ class PublisherGapicClient
      *                             signs (`%`). It must be between 3 and 255 characters in length, and it
      *                             must not start with `"goog"`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type array $labels
      *          User labels.
@@ -467,11 +467,11 @@ class PublisherGapicClient
      * }
      * ```
      *
-     * @param Topic     $topic        the topic to update
+     * @param Topic     $topic        The topic to update.
      * @param FieldMask $updateMask   Indicates which fields in the provided topic to update.
      *                                Must be specified and non-empty.
      * @param array     $optionalArgs {
-     *                                Optional
+     *                                Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -533,9 +533,9 @@ class PublisherGapicClient
      *
      * @param string          $topic        The messages in the request will be published on this topic.
      *                                      Format is `projects/{project}/topics/{topic}`.
-     * @param PubsubMessage[] $messages     the messages to publish
+     * @param PubsubMessage[] $messages     The messages to publish.
      * @param array           $optionalArgs {
-     *                                      Optional
+     *                                      Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -592,7 +592,7 @@ class PublisherGapicClient
      * @param string $topic        The name of the topic to get.
      *                             Format is `projects/{project}/topics/{topic}`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -660,7 +660,7 @@ class PublisherGapicClient
      * @param string $project      The name of the cloud project that topics belong to.
      *                             Format is `projects/{project}`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type int $pageSize
      *          The maximum number of resources contained in the underlying API
@@ -743,7 +743,7 @@ class PublisherGapicClient
      * @param string $topic        The name of the topic that subscriptions are attached to.
      *                             Format is `projects/{project}/topics/{topic}`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type int $pageSize
      *          The maximum number of resources contained in the underlying API
@@ -818,7 +818,7 @@ class PublisherGapicClient
      * @param string $topic        Name of the topic to delete.
      *                             Format is `projects/{project}/topics/{topic}`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -879,7 +879,7 @@ class PublisherGapicClient
      *                             valid policy but certain Cloud Platform services (such as Projects)
      *                             might reject them.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -939,7 +939,7 @@ class PublisherGapicClient
      *                             `resource` is usually specified as a path. For example, a Project
      *                             resource is specified as `projects/{project}`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1003,7 +1003,7 @@ class PublisherGapicClient
      *                               information see
      *                               [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
      * @param array    $optionalArgs {
-     *                               Optional
+     *                               Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a

--- a/src/PubSub/V1/Gapic/SubscriberGapicClient.php
+++ b/src/PubSub/V1/Gapic/SubscriberGapicClient.php
@@ -240,7 +240,7 @@ class SubscriberGapicClient
      *
      * @param string $project
      *
-     * @return string the formatted project resource
+     * @return string The formatted project resource.
      * @experimental
      */
     public static function projectName($project)
@@ -257,7 +257,7 @@ class SubscriberGapicClient
      * @param string $project
      * @param string $snapshot
      *
-     * @return string the formatted snapshot resource
+     * @return string The formatted snapshot resource.
      * @experimental
      */
     public static function snapshotName($project, $snapshot)
@@ -275,7 +275,7 @@ class SubscriberGapicClient
      * @param string $project
      * @param string $subscription
      *
-     * @return string the formatted subscription resource
+     * @return string The formatted subscription resource.
      * @experimental
      */
     public static function subscriptionName($project, $subscription)
@@ -293,7 +293,7 @@ class SubscriberGapicClient
      * @param string $project
      * @param string $topic
      *
-     * @return string the formatted topic resource
+     * @return string The formatted topic resource.
      * @experimental
      */
     public static function topicName($project, $topic)
@@ -321,9 +321,9 @@ class SubscriberGapicClient
      * @param string $formattedName The formatted name string
      * @param string $template      Optional name of template to match
      *
-     * @return array an associative array from name component IDs to component values
+     * @return array An associative array from name component IDs to component values.
      *
-     * @throws ValidationException if $formattedName could not be matched
+     * @throws ValidationException If $formattedName could not be matched.
      * @experimental
      */
     public static function parseName($formattedName, $template = null)
@@ -511,7 +511,7 @@ class SubscriberGapicClient
      *                             The value of this field will be `_deleted-topic_` if the topic has been
      *                             deleted.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type PushConfig $pushConfig
      *          If push delivery is used with this subscription, this field is
@@ -621,7 +621,7 @@ class SubscriberGapicClient
      * @param string $subscription The name of the subscription to get.
      *                             Format is `projects/{project}/subscriptions/{sub}`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -680,11 +680,11 @@ class SubscriberGapicClient
      * }
      * ```
      *
-     * @param Subscription $subscription the updated subscription object
+     * @param Subscription $subscription The updated subscription object.
      * @param FieldMask    $updateMask   Indicates which fields in the provided subscription to update.
      *                                   Must be specified and non-empty.
      * @param array        $optionalArgs {
-     *                                   Optional
+     *                                   Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -753,7 +753,7 @@ class SubscriberGapicClient
      * @param string $project      The name of the cloud project that subscriptions belong to.
      *                             Format is `projects/{project}`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type int $pageSize
      *          The maximum number of resources contained in the underlying API
@@ -828,7 +828,7 @@ class SubscriberGapicClient
      * @param string $subscription The subscription to delete.
      *                             Format is `projects/{project}/subscriptions/{sub}`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -887,7 +887,7 @@ class SubscriberGapicClient
      *
      * @param string   $subscription       The name of the subscription.
      *                                     Format is `projects/{project}/subscriptions/{sub}`.
-     * @param string[] $ackIds             list of acknowledgment IDs
+     * @param string[] $ackIds             List of acknowledgment IDs.
      * @param int      $ackDeadlineSeconds The new ack deadline with respect to the time this request was sent to
      *                                     the Pub/Sub system. For example, if the value is 10, the new
      *                                     ack deadline will expire 10 seconds after the `ModifyAckDeadline` call
@@ -896,7 +896,7 @@ class SubscriberGapicClient
      *                                     The minimum deadline you can specify is 0 seconds.
      *                                     The maximum deadline you can specify is 600 seconds (10 minutes).
      * @param array    $optionalArgs       {
-     *                                     Optional
+     *                                     Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -961,7 +961,7 @@ class SubscriberGapicClient
      * @param string[] $ackIds       The acknowledgment ID for the messages being acknowledged that was returned
      *                               by the Pub/Sub system in the `Pull` response. Must not be empty.
      * @param array    $optionalArgs {
-     *                               Optional
+     *                               Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1022,7 +1022,7 @@ class SubscriberGapicClient
      * @param int    $maxMessages  The maximum number of messages returned for this request. The Pub/Sub
      *                             system may return fewer than the number specified.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type bool $returnImmediately
      *          If this field set to true, the system will respond immediately even if
@@ -1127,7 +1127,7 @@ class SubscriberGapicClient
      * ```
      *
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type int $timeoutMillis
      *          Timeout to use for this call.
@@ -1196,7 +1196,7 @@ class SubscriberGapicClient
      * messages to be pulled and acknowledged - effectively pausing
      * the subscription if `Pull` is not called.
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1263,7 +1263,7 @@ class SubscriberGapicClient
      * @param string $project      The name of the cloud project that snapshots belong to.
      *                             Format is `projects/{project}`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type int $pageSize
      *          The maximum number of resources contained in the underlying API
@@ -1356,7 +1356,7 @@ class SubscriberGapicClient
      *                             successful completion of the CreateSnapshot request.
      *                             Format is `projects/{project}/subscriptions/{sub}`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1416,11 +1416,11 @@ class SubscriberGapicClient
      * }
      * ```
      *
-     * @param Snapshot  $snapshot     the updated snpashot object
+     * @param Snapshot  $snapshot     The updated snpashot object.
      * @param FieldMask $updateMask   Indicates which fields in the provided snapshot to update.
      *                                Must be specified and non-empty.
      * @param array     $optionalArgs {
-     *                                Optional
+     *                                Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1480,7 +1480,7 @@ class SubscriberGapicClient
      * @param string $snapshot     The name of the snapshot to delete.
      *                             Format is `projects/{project}/snapshots/{snap}`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1532,9 +1532,9 @@ class SubscriberGapicClient
      * }
      * ```
      *
-     * @param string $subscription the subscription to affect
+     * @param string $subscription The subscription to affect.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type Timestamp $time
      *          The time to seek to.
@@ -1619,7 +1619,7 @@ class SubscriberGapicClient
      *                             valid policy but certain Cloud Platform services (such as Projects)
      *                             might reject them.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1679,7 +1679,7 @@ class SubscriberGapicClient
      *                             `resource` is usually specified as a path. For example, a Project
      *                             resource is specified as `projects/{project}`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1743,7 +1743,7 @@ class SubscriberGapicClient
      *                               information see
      *                               [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
      * @param array    $optionalArgs {
-     *                               Optional
+     *                               Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a

--- a/src/Spanner/Admin/Database/V1/Gapic/DatabaseAdminGapicClient.php
+++ b/src/Spanner/Admin/Database/V1/Gapic/DatabaseAdminGapicClient.php
@@ -217,7 +217,7 @@ class DatabaseAdminGapicClient
      * @param string $project
      * @param string $instance
      *
-     * @return string the formatted instance resource
+     * @return string The formatted instance resource.
      * @experimental
      */
     public static function instanceName($project, $instance)
@@ -236,7 +236,7 @@ class DatabaseAdminGapicClient
      * @param string $instance
      * @param string $database
      *
-     * @return string the formatted database resource
+     * @return string The formatted database resource.
      * @experimental
      */
     public static function databaseName($project, $instance, $database)
@@ -263,9 +263,9 @@ class DatabaseAdminGapicClient
      * @param string $formattedName The formatted name string
      * @param string $template      Optional name of template to match
      *
-     * @return array an associative array from name component IDs to component values
+     * @return array An associative array from name component IDs to component values.
      *
-     * @throws ValidationException if $formattedName could not be matched
+     * @throws ValidationException If $formattedName could not be matched.
      * @experimental
      */
     public static function parseName($formattedName, $template = null)
@@ -478,7 +478,7 @@ class DatabaseAdminGapicClient
      * @param string $parent       Required. The instance whose databases should be listed.
      *                             Values are of the form `projects/<project>/instances/<instance>`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type int $pageSize
      *          The maximum number of resources contained in the underlying API
@@ -587,7 +587,7 @@ class DatabaseAdminGapicClient
      *                                If the database ID is a reserved word or if it contains a hyphen, the
      *                                database ID must be enclosed in backticks (`` ` ``).
      * @param array  $optionalArgs    {
-     *                                Optional
+     *                                Optional.
      *
      *     @type string[] $extraStatements
      *          An optional list of DDL statements to run inside the newly created
@@ -652,7 +652,7 @@ class DatabaseAdminGapicClient
      * @param string $name         Required. The name of the requested database. Values are of the form
      *                             `projects/<project>/instances/<instance>/databases/<database>`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -736,9 +736,9 @@ class DatabaseAdminGapicClient
      * ```
      *
      * @param string   $database     Required. The database to update.
-     * @param string[] $statements   DDL statements to be applied to the database
+     * @param string[] $statements   DDL statements to be applied to the database.
      * @param array    $optionalArgs {
-     *                               Optional
+     *                               Optional.
      *
      *     @type string $operationId
      *          If empty, the new update request is assigned an
@@ -817,7 +817,7 @@ class DatabaseAdminGapicClient
      *
      * @param string $database     Required. The database to be dropped.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -872,7 +872,7 @@ class DatabaseAdminGapicClient
      *
      * @param string $database     Required. The database whose schema we wish to get.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -938,7 +938,7 @@ class DatabaseAdminGapicClient
      *                             valid policy but certain Cloud Platform services (such as Projects)
      *                             might reject them.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1000,7 +1000,7 @@ class DatabaseAdminGapicClient
      *                             `resource` is usually specified as a path. For example, a Project
      *                             resource is specified as `projects/{project}`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1067,7 +1067,7 @@ class DatabaseAdminGapicClient
      *                               information see
      *                               [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
      * @param array    $optionalArgs {
-     *                               Optional
+     *                               Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a

--- a/src/Spanner/Admin/Instance/V1/Gapic/InstanceAdminGapicClient.php
+++ b/src/Spanner/Admin/Instance/V1/Gapic/InstanceAdminGapicClient.php
@@ -255,7 +255,7 @@ class InstanceAdminGapicClient
      *
      * @param string $project
      *
-     * @return string the formatted project resource
+     * @return string The formatted project resource.
      * @experimental
      */
     public static function projectName($project)
@@ -272,7 +272,7 @@ class InstanceAdminGapicClient
      * @param string $project
      * @param string $instanceConfig
      *
-     * @return string the formatted instance_config resource
+     * @return string The formatted instance_config resource.
      * @experimental
      */
     public static function instanceConfigName($project, $instanceConfig)
@@ -290,7 +290,7 @@ class InstanceAdminGapicClient
      * @param string $project
      * @param string $instance
      *
-     * @return string the formatted instance resource
+     * @return string The formatted instance resource.
      * @experimental
      */
     public static function instanceName($project, $instance)
@@ -317,9 +317,9 @@ class InstanceAdminGapicClient
      * @param string $formattedName The formatted name string
      * @param string $template      Optional name of template to match
      *
-     * @return array an associative array from name component IDs to component values
+     * @return array An associative array from name component IDs to component values.
      *
-     * @throws ValidationException if $formattedName could not be matched
+     * @throws ValidationException If $formattedName could not be matched.
      * @experimental
      */
     public static function parseName($formattedName, $template = null)
@@ -534,7 +534,7 @@ class InstanceAdminGapicClient
      *                             configurations is requested. Values are of the form
      *                             `projects/<project>`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type int $pageSize
      *          The maximum number of resources contained in the underlying API
@@ -605,7 +605,7 @@ class InstanceAdminGapicClient
      * @param string $name         Required. The name of the requested instance configuration. Values are of
      *                             the form `projects/<project>/instanceConfigs/<config>`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -673,7 +673,7 @@ class InstanceAdminGapicClient
      * @param string $parent       Required. The name of the project for which a list of instances is
      *                             requested. Values are of the form `projects/<project>`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type int $pageSize
      *          The maximum number of resources contained in the underlying API
@@ -767,7 +767,7 @@ class InstanceAdminGapicClient
      * @param string $name         Required. The name of the requested instance. Values are of the form
      *                             `projects/<project>/instances/<instance>`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -888,7 +888,7 @@ class InstanceAdminGapicClient
      * @param Instance $instance     Required. The instance to create.  The name may be omitted, but if
      *                               specified must be `<parent>/instances/<instance_id>`.
      * @param array    $optionalArgs {
-     *                               Optional
+     *                               Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1015,7 +1015,7 @@ class InstanceAdminGapicClient
      *                                [][google.spanner.admin.instance.v1.Instance] from being erased accidentally by clients that do not know
      *                                about them.
      * @param array     $optionalArgs {
-     *                                Optional
+     *                                Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1082,7 +1082,7 @@ class InstanceAdminGapicClient
      * @param string $name         Required. The name of the instance to be deleted. Values are of the form
      *                             `projects/<project>/instances/<instance>`
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1146,7 +1146,7 @@ class InstanceAdminGapicClient
      *                             valid policy but certain Cloud Platform services (such as Projects)
      *                             might reject them.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1208,7 +1208,7 @@ class InstanceAdminGapicClient
      *                             `resource` is usually specified as a path. For example, a Project
      *                             resource is specified as `projects/{project}`.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1275,7 +1275,7 @@ class InstanceAdminGapicClient
      *                               information see
      *                               [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
      * @param array    $optionalArgs {
-     *                               Optional
+     *                               Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a

--- a/src/Spanner/V1/Gapic/SpannerGapicClient.php
+++ b/src/Spanner/V1/Gapic/SpannerGapicClient.php
@@ -203,7 +203,7 @@ class SpannerGapicClient
      * @param string $instance
      * @param string $database
      *
-     * @return string the formatted database resource
+     * @return string The formatted database resource.
      * @experimental
      */
     public static function databaseName($project, $instance, $database)
@@ -224,7 +224,7 @@ class SpannerGapicClient
      * @param string $database
      * @param string $session
      *
-     * @return string the formatted session resource
+     * @return string The formatted session resource.
      * @experimental
      */
     public static function sessionName($project, $instance, $database, $session)
@@ -252,9 +252,9 @@ class SpannerGapicClient
      * @param string $formattedName The formatted name string
      * @param string $template      Optional name of template to match
      *
-     * @return array an associative array from name component IDs to component values
+     * @return array An associative array from name component IDs to component values.
      *
-     * @throws ValidationException if $formattedName could not be matched
+     * @throws ValidationException If $formattedName could not be matched.
      * @experimental
      */
     public static function parseName($formattedName, $template = null)
@@ -427,7 +427,7 @@ class SpannerGapicClient
      *
      * @param string $database     Required. The database in which the new session is created.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type Session $session
      *          The session to create.
@@ -489,7 +489,7 @@ class SpannerGapicClient
      *
      * @param string $name         Required. The name of the session to retrieve.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -556,7 +556,7 @@ class SpannerGapicClient
      *
      * @param string $database     Required. The database in which to list sessions.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type int $pageSize
      *          The maximum number of resources contained in the underlying API
@@ -640,7 +640,7 @@ class SpannerGapicClient
      *
      * @param string $name         Required. The name of the session to delete.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -705,7 +705,7 @@ class SpannerGapicClient
      * @param string $session      Required. The session in which the SQL query should be performed.
      * @param string $sql          Required. The SQL query string.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type TransactionSelector $transaction
      *          The transaction to use. If none is provided, the default is a
@@ -824,7 +824,7 @@ class SpannerGapicClient
      * @param string $session      Required. The session in which the SQL query should be performed.
      * @param string $sql          Required. The SQL query string.
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type TransactionSelector $transaction
      *          The transaction to use. If none is provided, the default is a
@@ -965,7 +965,7 @@ class SpannerGapicClient
      * It is not an error for the `key_set` to name rows that do not
      * exist in the database. Read yields nothing for nonexistent rows.
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type TransactionSelector $transaction
      *          The transaction to use. If none is provided, the default is a
@@ -1076,7 +1076,7 @@ class SpannerGapicClient
      * It is not an error for the `key_set` to name rows that do not
      * exist in the database. Read yields nothing for nonexistent rows.
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type TransactionSelector $transaction
      *          The transaction to use. If none is provided, the default is a
@@ -1172,7 +1172,7 @@ class SpannerGapicClient
      * @param string             $session      Required. The session in which the transaction runs.
      * @param TransactionOptions $options      Required. Options for the new transaction.
      * @param array              $optionalArgs {
-     *                                         Optional
+     *                                         Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -1239,7 +1239,7 @@ class SpannerGapicClient
      *                                 mutations are applied atomically, in the order they appear in
      *                                 this list.
      * @param array      $optionalArgs {
-     *                                 Optional
+     *                                 Optional.
      *
      *     @type string $transactionId
      *          Commit a previously-started transaction.
@@ -1322,7 +1322,7 @@ class SpannerGapicClient
      * @param string $session       Required. The session in which the transaction to roll back is running.
      * @param string $transactionId Required. The transaction to roll back.
      * @param array  $optionalArgs  {
-     *                              Optional
+     *                              Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a

--- a/src/Speech/V1/Gapic/SpeechGapicClient.php
+++ b/src/Speech/V1/Gapic/SpeechGapicClient.php
@@ -317,11 +317,11 @@ class SpeechGapicClient
      * }
      * ```
      *
-     * @param recognitionConfig $config       *Required* Provides information to the recognizer that specifies how to
-     *                                        process the request
-     * @param recognitionAudio  $audio        *Required* The audio data to be recognized
+     * @param RecognitionConfig $config       *Required* Provides information to the recognizer that specifies how to
+     *                                        process the request.
+     * @param RecognitionAudio  $audio        *Required* The audio data to be recognized.
      * @param array             $optionalArgs {
-     *                                        Optional
+     *                                        Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -412,11 +412,11 @@ class SpeechGapicClient
      * }
      * ```
      *
-     * @param recognitionConfig $config       *Required* Provides information to the recognizer that specifies how to
-     *                                        process the request
-     * @param recognitionAudio  $audio        *Required* The audio data to be recognized
+     * @param RecognitionConfig $config       *Required* Provides information to the recognizer that specifies how to
+     *                                        process the request.
+     * @param RecognitionAudio  $audio        *Required* The audio data to be recognized.
      * @param array             $optionalArgs {
-     *                                        Optional
+     *                                        Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -497,7 +497,7 @@ class SpeechGapicClient
      * ```
      *
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type int $timeoutMillis
      *          Timeout to use for this call.

--- a/src/Speech/V1beta1/Gapic/SpeechGapicClient.php
+++ b/src/Speech/V1beta1/Gapic/SpeechGapicClient.php
@@ -313,11 +313,11 @@ class SpeechGapicClient
      * }
      * ```
      *
-     * @param recognitionConfig $config       *Required* Provides information to the recognizer that specifies how to
-     *                                        process the request
-     * @param recognitionAudio  $audio        *Required* The audio data to be recognized
+     * @param RecognitionConfig $config       *Required* Provides information to the recognizer that specifies how to
+     *                                        process the request.
+     * @param RecognitionAudio  $audio        *Required* The audio data to be recognized.
      * @param array             $optionalArgs {
-     *                                        Optional
+     *                                        Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -408,11 +408,11 @@ class SpeechGapicClient
      * }
      * ```
      *
-     * @param recognitionConfig $config       *Required* Provides information to the recognizer that specifies how to
-     *                                        process the request
-     * @param recognitionAudio  $audio        *Required* The audio data to be recognized
+     * @param RecognitionConfig $config       *Required* Provides information to the recognizer that specifies how to
+     *                                        process the request.
+     * @param RecognitionAudio  $audio        *Required* The audio data to be recognized.
      * @param array             $optionalArgs {
-     *                                        Optional
+     *                                        Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
@@ -493,7 +493,7 @@ class SpeechGapicClient
      * ```
      *
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type int $timeoutMillis
      *          Timeout to use for this call.

--- a/src/VideoIntelligence/V1beta1/Gapic/VideoIntelligenceServiceGapicClient.php
+++ b/src/VideoIntelligence/V1beta1/Gapic/VideoIntelligenceServiceGapicClient.php
@@ -352,7 +352,7 @@ class VideoIntelligenceServiceGapicClient
      * @param int[]  $features     Requested video annotation features.
      *                             For allowed values, use constants defined on {@see \Google\Cloud\Videointelligence\V1beta1\Feature}
      * @param array  $optionalArgs {
-     *                             Optional
+     *                             Optional.
      *
      *     @type string $inputContent
      *          The video data bytes. Encoding: base64. If unset, the input video(s)

--- a/src/VideoIntelligence/V1beta2/Gapic/VideoIntelligenceServiceGapicClient.php
+++ b/src/VideoIntelligence/V1beta2/Gapic/VideoIntelligenceServiceGapicClient.php
@@ -336,7 +336,7 @@ class VideoIntelligenceServiceGapicClient
      * ```
      *
      * @param array $optionalArgs {
-     *                            Optional
+     *                            Optional.
      *
      *     @type string $inputUri
      *          Input video location. Currently, only

--- a/src/Vision/V1/Gapic/ImageAnnotatorGapicClient.php
+++ b/src/Vision/V1/Gapic/ImageAnnotatorGapicClient.php
@@ -217,9 +217,9 @@ class ImageAnnotatorGapicClient
      * }
      * ```
      *
-     * @param AnnotateImageRequest[] $requests     individual image annotation requests for this batch
+     * @param AnnotateImageRequest[] $requests     Individual image annotation requests for this batch.
      * @param array                  $optionalArgs {
-     *                                             Optional
+     *                                             Optional.
      *
      *     @type \Google\GAX\RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a


### PR DESCRIPTION
1) Fix php-cs-fixer phpdoc_annotation_without_dot issue
2) Put back dlp gapic client class example