### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "google/gax": "^0.25"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.*",
+        "phpunit/phpunit": "^4.8.36",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "symfony/console": "^3.0",

--- a/dev/src/Snippet/SnippetTestCase.php
+++ b/dev/src/Snippet/SnippetTestCase.php
@@ -18,13 +18,14 @@
 namespace Google\Cloud\Dev\Snippet;
 
 use Google\Cloud\Dev\Snippet\Container;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Provide helpers for Snippet tests.
  *
  * Snippet test cases should extend this class.
  */
-class SnippetTestCase extends \PHPUnit_Framework_TestCase
+class SnippetTestCase extends TestCase
 {
     private static $coverage;
     private static $parser;

--- a/tests/perf/BigQueryTest.php
+++ b/tests/perf/BigQueryTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Perf;
 
 use Google\Cloud\BigQuery\BigQueryClient;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class BigQueryPerfTest extends \PHPUnit_Framework_TestCase
+class BigQueryPerfTest extends TestCase
 {
     const SOURCE = 'bigquery.json';
 

--- a/tests/perf/LoggingPerfTest.php
+++ b/tests/perf/LoggingPerfTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Perf;
 
 use Google\Cloud\Logging\LoggingClient;
 use Google\Cloud\Logging\PsrLogger;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group logging
  */
-class LoggingPerfTest extends \PHPUnit_Framework_TestCase
+class LoggingPerfTest extends TestCase
 {
     /* @var PsrLogger */
     private $restClient;

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -25,5 +25,5 @@ immediately before the class declaration:
 /**
  * @group bigquery
  */
-class BigQueryTest extends \PHPUnit_Framework_TestCase
+class BigQueryTest extends TestCase
 ```

--- a/tests/system/Core/Batch/BatchRunnerTest.php
+++ b/tests/system/Core/Batch/BatchRunnerTest.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Tests\System\Core\Batch;
 
 use Google\Cloud\Core\Batch\BatchRunner;
 use Google\Cloud\Core\Batch\Retry;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
@@ -28,7 +29,7 @@ use Google\Cloud\Core\Batch\Retry;
  * this system test. You can run the tests with the in-memory implementation
  * by setting `GOOGLE_CLOUD_PHP_TESTS_WITHOUT_DAEMON` environment variable.
  */
-class BatchRunnerTest extends \PHPUnit_Framework_TestCase
+class BatchRunnerTest extends TestCase
 {
     private $items;
     private $runner;

--- a/tests/system/Datastore/DatastoreTestCase.php
+++ b/tests/system/Datastore/DatastoreTestCase.php
@@ -20,13 +20,14 @@ namespace Google\Cloud\Tests\System\Datastore;
 use Google\Cloud\Core\ExponentialBackoff;
 use Google\Cloud\Datastore\DatastoreClient;
 use Google\Cloud\Tests\System\DeletionQueue;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Datastore does not use the default deletion queue. Because of the way
  * datastore entities are deleted, a local queue is required.
  * Be sure to use `self::$localDeletionQueue` for all datastore entities.
  */
-class DatastoreTestCase extends \PHPUnit_Framework_TestCase
+class DatastoreTestCase extends TestCase
 {
     const TESTING_PREFIX = 'gcloud_testing_';
 
@@ -71,5 +72,3 @@ class DatastoreTestCase extends \PHPUnit_Framework_TestCase
         });
     }
 }
-
-

--- a/tests/system/Language/LanguageTestCase.php
+++ b/tests/system/Language/LanguageTestCase.php
@@ -22,8 +22,9 @@ use Google\Cloud\BigQuery\BigQueryClient;
 use Google\Cloud\Language\LanguageClient;
 use Google\Cloud\PubSub\PubSubClient;
 use Google\Cloud\Storage\StorageClient;
+use PHPUnit\Framework\TestCase;
 
-class LanguageTestCase extends \PHPUnit_Framework_TestCase
+class LanguageTestCase extends TestCase
 {
     protected static $client;
     private static $hasSetUp = false;
@@ -41,5 +42,3 @@ class LanguageTestCase extends \PHPUnit_Framework_TestCase
         self::$hasSetUp = true;
     }
 }
-
-

--- a/tests/system/SystemTestCase.php
+++ b/tests/system/SystemTestCase.php
@@ -22,8 +22,9 @@ use Google\Cloud\Core\ExponentialBackoff;
 use Google\Cloud\PubSub\PubSubClient;
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Tests\System\DeletionQueue;
+use PHPUnit\Framework\TestCase;
 
-class SystemTestCase extends \PHPUnit_Framework_TestCase
+class SystemTestCase extends TestCase
 {
     protected static $deletionQueue;
 

--- a/tests/system/Trace/BasicTest.php
+++ b/tests/system/Trace/BasicTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\Core\ExponentialBackoff;
 use Google\Cloud\Trace\TraceClient;
 use Google\Cloud\Trace\TraceSpan;
 use Google\Cloud\Trace\Trace;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class BasicTest extends \PHPUnit_Framework_TestCase
+class BasicTest extends TestCase
 {
     private $traceClient;
 

--- a/tests/system/Translate/TranslateTestCase.php
+++ b/tests/system/Translate/TranslateTestCase.php
@@ -18,8 +18,9 @@
 namespace Google\Cloud\Tests\System\Translate;
 
 use Google\Cloud\Translate\TranslateClient;
+use PHPUnit\Framework\TestCase;
 
-class TranslateTestCase extends \PHPUnit_Framework_TestCase
+class TranslateTestCase extends TestCase
 {
     protected static $hasSetUp = false;
     protected static $client;

--- a/tests/system/Vision/VisionTestCase.php
+++ b/tests/system/Vision/VisionTestCase.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\System\Vision;
 
 use Google\Cloud\Vision\VisionClient;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group vision
  */
-class VisionTestCase extends \PHPUnit_Framework_TestCase
+class VisionTestCase extends TestCase
 {
     protected static $vision;
     private static $hasSetUp = false;

--- a/tests/unit/BigQuery/BigQueryClientTest.php
+++ b/tests/unit/BigQuery/BigQueryClientTest.php
@@ -29,11 +29,12 @@ use Google\Cloud\BigQuery\Time;
 use Google\Cloud\BigQuery\Timestamp;
 use Google\Cloud\Core\Iterator\ItemIterator;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class BigQueryClientTest extends \PHPUnit_Framework_TestCase
+class BigQueryClientTest extends TestCase
 {
     const JOB_ID = 'myJobId';
     const PROJECT_ID = 'myProjectId';

--- a/tests/unit/BigQuery/BytesTest.php
+++ b/tests/unit/BigQuery/BytesTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\BigQuery;
 
 use Google\Cloud\BigQuery\Bytes;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class BytesTest extends \PHPUnit_Framework_TestCase
+class BytesTest extends TestCase
 {
     public $value = '1234';
 

--- a/tests/unit/BigQuery/Connection/RestTest.php
+++ b/tests/unit/BigQuery/Connection/RestTest.php
@@ -27,11 +27,12 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class RestTest extends \PHPUnit_Framework_TestCase
+class RestTest extends TestCase
 {
     private $requestWrapper;
     private $successBody;

--- a/tests/unit/BigQuery/CopyJobConfigurationTest.php
+++ b/tests/unit/BigQuery/CopyJobConfigurationTest.php
@@ -20,11 +20,12 @@ namespace Google\Cloud\Tests\Unit\BigQuery;
 use Google\Cloud\BigQuery\Dataset;
 use Google\Cloud\BigQuery\CopyJobConfiguration;
 use Google\Cloud\BigQuery\Table;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class CopyJobConfigurationTest extends \PHPUnit_Framework_TestCase
+class CopyJobConfigurationTest extends TestCase
 {
     const PROJECT_ID = 'my_project';
     const DATASET_ID = 'my_dataset';

--- a/tests/unit/BigQuery/DatasetTest.php
+++ b/tests/unit/BigQuery/DatasetTest.php
@@ -23,11 +23,12 @@ use Google\Cloud\BigQuery\Table;
 use Google\Cloud\BigQuery\ValueMapper;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class DatasetTest extends \PHPUnit_Framework_TestCase
+class DatasetTest extends TestCase
 {
     public $connection;
     public $mapper;

--- a/tests/unit/BigQuery/DateTest.php
+++ b/tests/unit/BigQuery/DateTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\BigQuery;
 
 use Google\Cloud\BigQuery\Date;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class DateTest extends \PHPUnit_Framework_TestCase
+class DateTest extends TestCase
 {
     public function testGet()
     {

--- a/tests/unit/BigQuery/Exception/JobExceptionTest.php
+++ b/tests/unit/BigQuery/Exception/JobExceptionTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\BigQuery\Exception;
 
 use Google\Cloud\BigQuery\Exception\JobException;
 use Google\Cloud\BigQuery\Job;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class JobExceptionTest extends \PHPUnit_Framework_TestCase
+class JobExceptionTest extends TestCase
 {
     public function testGetsJob()
     {

--- a/tests/unit/BigQuery/ExtractJobConfigurationTest.php
+++ b/tests/unit/BigQuery/ExtractJobConfigurationTest.php
@@ -20,11 +20,12 @@ namespace Google\Cloud\Tests\Unit\BigQuery;
 use Google\Cloud\BigQuery\Dataset;
 use Google\Cloud\BigQuery\ExtractJobConfiguration;
 use Google\Cloud\BigQuery\Table;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class ExtractJobConfigurationTest extends \PHPUnit_Framework_TestCase
+class ExtractJobConfigurationTest extends TestCase
 {
     const PROJECT_ID = 'my_project';
     const DATASET_ID = 'my_dataset';

--- a/tests/unit/BigQuery/InsertResponseTest.php
+++ b/tests/unit/BigQuery/InsertResponseTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\BigQuery;
 
 use Google\Cloud\BigQuery\InsertResponse;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class InsertResponseTest extends \PHPUnit_Framework_TestCase
+class InsertResponseTest extends TestCase
 {
     public function testSuccess()
     {

--- a/tests/unit/BigQuery/JobConfigurationTraitTest.php
+++ b/tests/unit/BigQuery/JobConfigurationTraitTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\BigQuery;
 
 use Google\Cloud\BigQuery\JobConfigurationTrait;
 use Ramsey\Uuid\Uuid;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class JobConfigurationTraitTest extends \PHPUnit_Framework_TestCase
+class JobConfigurationTraitTest extends TestCase
 {
     const PROJECT_ID = 'project-id';
     const JOB_ID = '1234';

--- a/tests/unit/BigQuery/JobTest.php
+++ b/tests/unit/BigQuery/JobTest.php
@@ -23,11 +23,12 @@ use Google\Cloud\BigQuery\QueryResults;
 use Google\Cloud\BigQuery\ValueMapper;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class JobTest extends \PHPUnit_Framework_TestCase
+class JobTest extends TestCase
 {
     public $connection;
     public $projectId = 'myProjectId';

--- a/tests/unit/BigQuery/JobWaitTraitTest.php
+++ b/tests/unit/BigQuery/JobWaitTraitTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\BigQuery;
 
 use Google\Cloud\BigQuery\Job;
 use Google\Cloud\BigQuery\JobWaitTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class JobWaitTraitTest extends \PHPUnit_Framework_TestCase
+class JobWaitTraitTest extends TestCase
 {
     private $trait;
     private $job;

--- a/tests/unit/BigQuery/LoadJobConfigurationTest.php
+++ b/tests/unit/BigQuery/LoadJobConfigurationTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\BigQuery;
 
 use Google\Cloud\BigQuery\LoadJobConfiguration;
 use Google\Cloud\BigQuery\Table;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class LoadJobConfigurationTest extends \PHPUnit_Framework_TestCase
+class LoadJobConfigurationTest extends TestCase
 {
     const PROJECT_ID = 'my_project';
     const DATASET_ID = 'my_dataset';

--- a/tests/unit/BigQuery/QueryJobConfigurationTest.php
+++ b/tests/unit/BigQuery/QueryJobConfigurationTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\BigQuery\Dataset;
 use Google\Cloud\BigQuery\QueryJobConfiguration;
 use Google\Cloud\BigQuery\Table;
 use Google\Cloud\BigQuery\ValueMapper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class QueryJobConfigurationTest extends \PHPUnit_Framework_TestCase
+class QueryJobConfigurationTest extends TestCase
 {
     const PROJECT_ID = 'my_project';
     const DATASET_ID = 'my_dataset';

--- a/tests/unit/BigQuery/QueryResultsTest.php
+++ b/tests/unit/BigQuery/QueryResultsTest.php
@@ -22,11 +22,12 @@ use Google\Cloud\BigQuery\Job;
 use Google\Cloud\BigQuery\QueryResults;
 use Google\Cloud\BigQuery\ValueMapper;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class QueryResultsTest extends \PHPUnit_Framework_TestCase
+class QueryResultsTest extends TestCase
 {
     public $connection;
     public $projectId = 'myProjectId';

--- a/tests/unit/BigQuery/TableTest.php
+++ b/tests/unit/BigQuery/TableTest.php
@@ -32,11 +32,12 @@ use Google\Cloud\Core\Upload\AbstractUploader;
 use Google\Cloud\Storage\Connection\ConnectionInterface as StorageConnectionInterface;
 use Google\Cloud\Storage\StorageObject;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class TableTest extends \PHPUnit_Framework_TestCase
+class TableTest extends TestCase
 {
     const JOB_ID = 'myJobId';
     const PROJECT_ID = 'myProjectId';

--- a/tests/unit/BigQuery/TimeTest.php
+++ b/tests/unit/BigQuery/TimeTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\BigQuery;
 
 use Google\Cloud\BigQuery\Time;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class TimeTest extends \PHPUnit_Framework_TestCase
+class TimeTest extends TestCase
 {
     public function testGet()
     {

--- a/tests/unit/BigQuery/TimestampTest.php
+++ b/tests/unit/BigQuery/TimestampTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\BigQuery;
 
 use Google\Cloud\BigQuery\Timestamp;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class TimestampTest extends \PHPUnit_Framework_TestCase
+class TimestampTest extends TestCase
 {
     public function testGet()
     {

--- a/tests/unit/BigQuery/ValueMapperTest.php
+++ b/tests/unit/BigQuery/ValueMapperTest.php
@@ -23,11 +23,12 @@ use Google\Cloud\BigQuery\Time;
 use Google\Cloud\BigQuery\Timestamp;
 use Google\Cloud\BigQuery\ValueMapper;
 use Google\Cloud\Core\Int64;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group bigquery
  */
-class ValueMapperTest extends \PHPUnit_Framework_TestCase
+class ValueMapperTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/unit/Core/ArrayTraitTest.php
+++ b/tests/unit/Core/ArrayTraitTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Core;
 
 use Google\Cloud\Core\ArrayTrait;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class ArrayTraitTest extends \PHPUnit_Framework_TestCase
+class ArrayTraitTest extends TestCase
 {
     private $implementation;
 

--- a/tests/unit/Core/Batch/BatchConfigTest.php
+++ b/tests/unit/Core/Batch/BatchConfigTest.php
@@ -18,12 +18,13 @@
 namespace Google\Cloud\Tests\Unit\Core\Batch;
 
 use Google\Cloud\Core\Batch\BatchConfig;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group batch
  */
-class BatchConfigTest extends \PHPUnit_Framework_TestCase
+class BatchConfigTest extends TestCase
 {
     private $config;
     private $identifier;

--- a/tests/unit/Core/Batch/BatchDaemonTraitTest.php
+++ b/tests/unit/Core/Batch/BatchDaemonTraitTest.php
@@ -18,12 +18,13 @@
 namespace Google\Cloud\Tests\Unit\Core\Batch;
 
 use Google\Cloud\Core\Batch\BatchDaemonTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group batch
  */
-class BatchDaemonTraitTest extends \PHPUnit_Framework_TestCase
+class BatchDaemonTraitTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/unit/Core/Batch/BatchJobTest.php
+++ b/tests/unit/Core/Batch/BatchJobTest.php
@@ -18,12 +18,13 @@
 namespace Google\Cloud\Tests\Unit\Core\Batch;
 
 use Google\Cloud\Core\Batch\BatchJob;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group batch
  */
-class BatchJobTest extends \PHPUnit_Framework_TestCase
+class BatchJobTest extends TestCase
 {
     private $items = array();
 

--- a/tests/unit/Core/Batch/BatchRunnerTest.php
+++ b/tests/unit/Core/Batch/BatchRunnerTest.php
@@ -23,12 +23,13 @@ use Google\Cloud\Core\Batch\BatchRunner;
 use Google\Cloud\Core\Batch\ConfigStorageInterface;
 use Google\Cloud\Core\Batch\ProcessItemInterface;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group batch
  */
-class BatchRunnerTest extends \PHPUnit_Framework_TestCase
+class BatchRunnerTest extends TestCase
 {
     private $configStorage;
     private $processor;

--- a/tests/unit/Core/Batch/BatchTraitTest.php
+++ b/tests/unit/Core/Batch/BatchTraitTest.php
@@ -22,12 +22,13 @@ use Google\Cloud\Core\Batch\BatchRunner;
 use Google\Cloud\Core\Batch\BatchTrait;
 use Google\Cloud\Core\Batch\ProcessItemInterface;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group batch
  */
-class BatchTraitTest extends \PHPUnit_Framework_TestCase
+class BatchTraitTest extends TestCase
 {
     const ID = 'some-id';
     const BATCH_METHOD = 'doBatch';

--- a/tests/unit/Core/Batch/HandleFailureTraitTest.php
+++ b/tests/unit/Core/Batch/HandleFailureTraitTest.php
@@ -18,12 +18,13 @@
 namespace Google\Cloud\Tests\Unit\Core\Batch;
 
 use Google\Cloud\Core\Batch\HandleFailureTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group batch
  */
-class HandleFailureTraitTest extends \PHPUnit_Framework_TestCase
+class HandleFailureTraitTest extends TestCase
 {
 
     private $impl;

--- a/tests/unit/Core/Batch/InMemoryConfigStorageTest.php
+++ b/tests/unit/Core/Batch/InMemoryConfigStorageTest.php
@@ -19,12 +19,13 @@ namespace Google\Cloud\Tests\Unit\Core\Batch;
 
 use Google\Cloud\Core\Batch\BatchConfig;
 use Google\Cloud\Core\Batch\InMemoryConfigStorage;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group batch
  */
-class InMemoryConfigStorageTest extends \PHPUnit_Framework_TestCase
+class InMemoryConfigStorageTest extends TestCase
 {
     private $items;
 

--- a/tests/unit/Core/Batch/RetryTest.php
+++ b/tests/unit/Core/Batch/RetryTest.php
@@ -20,12 +20,13 @@ namespace Google\Cloud\Tests\Unit\Core\Batch;
 use Google\Cloud\Core\Batch\BatchJob;
 use Google\Cloud\Core\Batch\BatchRunner;
 use Google\Cloud\Core\Batch\Retry;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group batch
  */
-class RetryTest extends \PHPUnit_Framework_TestCase
+class RetryTest extends TestCase
 {
     private $runner;
     private $job;

--- a/tests/unit/Core/Batch/SysvConfigStorageTest.php
+++ b/tests/unit/Core/Batch/SysvConfigStorageTest.php
@@ -20,12 +20,13 @@ namespace Google\Cloud\Tests\Unit\Core\Batch;
 use Google\Cloud\Core\Batch\BatchConfig;
 use Google\Cloud\Core\Batch\SysvConfigStorage;
 use Google\Cloud\Core\SysvTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group batch
  */
-class SysvConfigStorageTest extends \PHPUnit_Framework_TestCase
+class SysvConfigStorageTest extends TestCase
 {
     use SysvTrait;
 

--- a/tests/unit/Core/Batch/SysvProcessorTest.php
+++ b/tests/unit/Core/Batch/SysvProcessorTest.php
@@ -20,12 +20,13 @@ namespace Google\Cloud\Tests\Unit\Core\Batch;
 use Google\Cloud\Core\Batch\BatchDaemonTrait;
 use Google\Cloud\Core\Batch\SysvProcessor;
 use Google\Cloud\Core\SysvTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group batch
  */
-class SysvProcessorTest extends \PHPUnit_Framework_TestCase
+class SysvProcessorTest extends TestCase
 {
     use BatchDaemonTrait;
     use SysvTrait;

--- a/tests/unit/Core/CallTraitTest.php
+++ b/tests/unit/Core/CallTraitTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Core;
 
 use Google\Cloud\Core\CallTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class CallTraitTest extends \PHPUnit_Framework_TestCase
+class CallTraitTest extends TestCase
 {
     public function testCall()
     {

--- a/tests/unit/Core/ClientTraitTest.php
+++ b/tests/unit/Core/ClientTraitTest.php
@@ -20,11 +20,12 @@ namespace Google\Cloud\Tests\Unit\Core;
 use Google\Cloud\Core\ClientTrait;
 use Google\Cloud\Core\Compute\Metadata;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class ClientTraitTest extends \PHPUnit_Framework_TestCase
+class ClientTraitTest extends TestCase
 {
     /**
      * @expectedException Google\Cloud\Core\Exception\GoogleException

--- a/tests/unit/Core/Compute/MetadataTest.php
+++ b/tests/unit/Core/Compute/MetadataTest.php
@@ -19,12 +19,13 @@ namespace Google\Cloud\Tests\Unit\Core\Compute;
 
 use Google\Cloud\Core\Compute\Metadata;
 use Google\Cloud\Core\Compute\Metadata\Readers\StreamReader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group compute
  */
-class MetadataTest extends \PHPUnit_Framework_TestCase
+class MetadataTest extends TestCase
 {
     protected $mock;
     protected $metadata;

--- a/tests/unit/Core/ConcurrencyControlTraitTest.php
+++ b/tests/unit/Core/ConcurrencyControlTraitTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Core;
 
 use Google\Cloud\Core\ConcurrencyControlTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class ConcurrencyControlTraitTest extends \PHPUnit_Framework_TestCase
+class ConcurrencyControlTraitTest extends TestCase
 {
     const ETAG = 'foobar';
 

--- a/tests/unit/Core/DurationTest.php
+++ b/tests/unit/Core/DurationTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Core;
 
 use Google\Cloud\Core\Duration;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class DurationTest extends \PHPUnit_Framework_TestCase
+class DurationTest extends TestCase
 {
     const SECONDS = 10;
     const NANOS = 1;

--- a/tests/unit/Core/EmulatorTraitTest.php
+++ b/tests/unit/Core/EmulatorTraitTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Core;
 
 use Google\Cloud\Core\EmulatorTrait;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class EmulatorTraitTest extends \PHPUnit_Framework_TestCase
+class EmulatorTraitTest extends TestCase
 {
     private $implementation;
 

--- a/tests/unit/Core/Exception/NotFoundExceptionTest.php
+++ b/tests/unit/Core/Exception/NotFoundExceptionTest.php
@@ -18,12 +18,13 @@
 namespace Google\Cloud\Tests\Unit\Core\Exception;
 
 use Google\Cloud\Core\Exception\NotFoundException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group exception
  */
-class NotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class NotFoundExceptionTest extends TestCase
 {
     public function testSetMessage()
     {

--- a/tests/unit/Core/Exception/ServiceExceptionTest.php
+++ b/tests/unit/Core/Exception/ServiceExceptionTest.php
@@ -18,12 +18,13 @@
 namespace Google\Cloud\Tests\Unit\Core\Exception;
 
 use Google\Cloud\Core\Exception\ServiceException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group exception
  */
-class ServiceExceptionTest extends \PHPUnit_Framework_TestCase
+class ServiceExceptionTest extends TestCase
 {
     public function testHasServiceException()
     {

--- a/tests/unit/Core/ExponentialBackoffTest.php
+++ b/tests/unit/Core/ExponentialBackoffTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Core;
 
 use Google\Cloud\Core\ExponentialBackoff;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class ExponentialBackoffTest extends \PHPUnit_Framework_TestCase
+class ExponentialBackoffTest extends TestCase
 {
     private $delayFunction;
 

--- a/tests/unit/Core/GrpcRequestWrapperTest.php
+++ b/tests/unit/Core/GrpcRequestWrapperTest.php
@@ -30,11 +30,12 @@ use Google\GAX\PagedListResponse;
 use Google\GAX\Serializer;
 use Google\Protobuf\Internal\Message;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class GrpcRequestWrapperTest extends \PHPUnit_Framework_TestCase
+class GrpcRequestWrapperTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Core/GrpcTraitTest.php
+++ b/tests/unit/Core/GrpcTraitTest.php
@@ -26,11 +26,12 @@ use Google\Cloud\Core\GrpcRequestWrapper;
 use Google\Cloud\Core\GrpcTrait;
 use google\protobuf;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class GrpcTraitTest extends \PHPUnit_Framework_TestCase
+class GrpcTraitTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Core/Iam/IamTest.php
+++ b/tests/unit/Core/Iam/IamTest.php
@@ -21,12 +21,13 @@ use Google\Cloud\Core\Iam\Iam;
 use Google\Cloud\Core\Iam\IamConnectionInterface;
 use Google\Cloud\Core\Iam\PolicyBuilder;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group iam
  */
-class IamTest extends \PHPUnit_Framework_TestCase
+class IamTest extends TestCase
 {
     const RESOURCE = 'projects/my-project/topics/my-topic';
 

--- a/tests/unit/Core/Iam/PolicyBuilderTest.php
+++ b/tests/unit/Core/Iam/PolicyBuilderTest.php
@@ -18,12 +18,13 @@
 namespace Google\Cloud\Tests\Unit\Core\Iam;
 
 use Google\Cloud\Core\Iam\PolicyBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group iam
  */
-class PolicyBuilderTest extends \PHPUnit_Framework_TestCase
+class PolicyBuilderTest extends TestCase
 {
     public function testBuilder()
     {

--- a/tests/unit/Core/Int64Test.php
+++ b/tests/unit/Core/Int64Test.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Core;
 
 use Google\Cloud\Core\Int64;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class Int64Test extends \PHPUnit_Framework_TestCase
+class Int64Test extends TestCase
 {
     public function testGetsValue()
     {

--- a/tests/unit/Core/Iterator/ItemIteratorTest.php
+++ b/tests/unit/Core/Iterator/ItemIteratorTest.php
@@ -19,12 +19,13 @@ namespace Google\Cloud\Tests\Unit\Core\Iterator;
 
 use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Core\Iterator\PageIterator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group iterator
  */
-class ItemIteratorTest extends \PHPUnit_Framework_TestCase
+class ItemIteratorTest extends TestCase
 {
     public function testIteratesData()
     {

--- a/tests/unit/Core/Iterator/PageIteratorTest.php
+++ b/tests/unit/Core/Iterator/PageIteratorTest.php
@@ -19,12 +19,13 @@ namespace Google\Cloud\Tests\Unit\Core\Iterator;
 
 use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Core\Iterator\PageIterator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group iterator
  */
-class PageIteratorTest extends \PHPUnit_Framework_TestCase
+class PageIteratorTest extends TestCase
 {
     private static $page1 = ['a', 'b', 'c'];
     private static $page2 = ['d', 'e', 'f'];

--- a/tests/unit/Core/JsonTraitTest.php
+++ b/tests/unit/Core/JsonTraitTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Core;
 
 use Google\Cloud\Core\JsonTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class JsonTraitTest extends \PHPUnit_Framework_TestCase
+class JsonTraitTest extends TestCase
 {
     private $implementation;
 

--- a/tests/unit/Core/Lock/FlockLockTest.php
+++ b/tests/unit/Core/Lock/FlockLockTest.php
@@ -21,12 +21,13 @@ require_once __DIR__ . '/MockGlobals.php';
 
 use Google\Cloud\Core\Lock\FlockLock;
 use Google\Cloud\Core\Lock\MockValues;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group lock
  */
-class FlockLockTest extends \PHPUnit_Framework_TestCase
+class FlockLockTest extends TestCase
 {
     use CommonLockTrait;
 

--- a/tests/unit/Core/Lock/SemaphoreLockTest.php
+++ b/tests/unit/Core/Lock/SemaphoreLockTest.php
@@ -22,12 +22,13 @@ require_once __DIR__ . '/MockGlobals.php';
 use Google\Cloud\Core\Lock\MockValues;
 use Google\Cloud\Core\Lock\SemaphoreLock;
 use Google\Cloud\Core\SysvTrait;;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group lock
  */
-class SemaphoreLockTest extends \PHPUnit_Framework_TestCase
+class SemaphoreLockTest extends TestCase
 {
     use CommonLockTrait;
     use SysvTrait;

--- a/tests/unit/Core/Logger/AppEngineFlexHandlerTest.php
+++ b/tests/unit/Core/Logger/AppEngineFlexHandlerTest.php
@@ -19,12 +19,13 @@ namespace Google\Cloud\Tests\Unit\Core\Logger;
 
 use Google\Cloud\Core\Logger\AppEngineFlexHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group logger
  */
-class AppEngineFlexHandlerTest extends \PHPUnit_Framework_TestCase
+class AppEngineFlexHandlerTest extends TestCase
 {
     private $stream;
     private $log;

--- a/tests/unit/Core/Report/EmptyMetadataProviderTest.php
+++ b/tests/unit/Core/Report/EmptyMetadataProviderTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Core\Report;
 
 use Google\Cloud\Core\Report\EmptyMetadataProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class EmptyMetadataProviderTest extends \PHPUnit_Framework_TestCase
+class EmptyMetadataProviderTest extends TestCase
 {
     private $metadataProvider;
 

--- a/tests/unit/Core/Report/GAEFlexMetadataProviderTest.php
+++ b/tests/unit/Core/Report/GAEFlexMetadataProviderTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Core\Report;
 
 use Google\Cloud\Core\Report\GAEFlexMetadataProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class GAEFlexMetadataProviderTest extends \PHPUnit_Framework_TestCase
+class GAEFlexMetadataProviderTest extends TestCase
 {
     private $envs = [
         'GAE_SERVICE' => 'my-service',

--- a/tests/unit/Core/Report/MetadataProviderUtilsTest.php
+++ b/tests/unit/Core/Report/MetadataProviderUtilsTest.php
@@ -20,11 +20,12 @@ namespace Google\Cloud\Tests\Unit\Core\Report;
 use Google\Cloud\Core\Report\EmptyMetadataProvider;
 use Google\Cloud\Core\Report\GAEFlexMetadataProvider;
 use Google\Cloud\Core\Report\MetadataProviderUtils;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class MetadataProviderUtilsTest extends \PHPUnit_Framework_TestCase
+class MetadataProviderUtilsTest extends TestCase
 {
     private $envs = ['GAE_SERVICE' => 'my-service'];
 

--- a/tests/unit/Core/Report/SimpleMetadataProviderTest.php
+++ b/tests/unit/Core/Report/SimpleMetadataProviderTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Core\Report;
 
 use Google\Cloud\Core\Report\SimpleMetadataProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class SimpleMetadataProviderTest extends \PHPUnit_Framework_TestCase
+class SimpleMetadataProviderTest extends TestCase
 {
     private $metadataProvider;
 

--- a/tests/unit/Core/RequestBuilderTest.php
+++ b/tests/unit/Core/RequestBuilderTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Core;
 
 use Google\Cloud\Core\RequestBuilder;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class RequestBuilderTest extends \PHPUnit_Framework_TestCase
+class RequestBuilderTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/unit/Core/RequestWrapperTest.php
+++ b/tests/unit/Core/RequestWrapperTest.php
@@ -24,11 +24,12 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class RequestWrapperTest extends \PHPUnit_Framework_TestCase
+class RequestWrapperTest extends TestCase
 {
     const VERSION = 'v0.1';
 

--- a/tests/unit/Core/RestTraitTest.php
+++ b/tests/unit/Core/RestTraitTest.php
@@ -25,11 +25,12 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class RestTraitTest extends \PHPUnit_Framework_TestCase
+class RestTraitTest extends TestCase
 {
     private $implementation;
     private $requestBuilder;

--- a/tests/unit/Core/RetryDeciderTraitTest.php
+++ b/tests/unit/Core/RetryDeciderTraitTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Core;
 
 use Google\Cloud\Core\RetryDeciderTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class RetryDeciderTraitTest extends \PHPUnit_Framework_TestCase
+class RetryDeciderTraitTest extends TestCase
 {
     private $implementation;
 

--- a/tests/unit/Core/ServiceBuilderTest.php
+++ b/tests/unit/Core/ServiceBuilderTest.php
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 namespace Google\Cloud\Tests\Unit;
 
 use Google\Cloud\BigQuery\BigQueryClient;
@@ -29,12 +28,14 @@ use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Tests\GrpcTestTrait;
 use Google\Cloud\Translate\TranslateClient;
 use Google\Cloud\Vision\VisionClient;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group servicebuilder
  */
-class ServiceBuilderTest extends \PHPUnit_Framework_TestCase
+class ServiceBuilderTest extends TestCase
 {
+
     use GrpcTestTrait;
 
     /**
@@ -42,7 +43,8 @@ class ServiceBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testBuildsClients($serviceName, $expectedClient, array $args = [], callable $beforeCallable = null)
     {
-        if ($beforeCallable) {
+        if ($beforeCallable)
+        {
             call_user_func($beforeCallable);
         }
 
@@ -53,7 +55,7 @@ class ServiceBuilderTest extends \PHPUnit_Framework_TestCase
             'httpHandler' => function() {
                 return;
             }
-        ] + $args;
+                ] + $args;
 
         $localConfigClient = $serviceBuilder->$serviceName($config);
 
@@ -105,4 +107,5 @@ class ServiceBuilderTest extends \PHPUnit_Framework_TestCase
             ]
         ];
     }
+
 }

--- a/tests/unit/Core/ServicesNotFoundTest.php
+++ b/tests/unit/Core/ServicesNotFoundTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Core;
 
 use Google\Cloud\Core\ServiceBuilder;
 use Composer\Autoload\ClassLoader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class ServicesNotFoundTest extends \PHPUnit_Framework_TestCase
+class ServicesNotFoundTest extends TestCase
 {
     private static $previousAutoloadFunc;
     private static $newAutoloadFunc;

--- a/tests/unit/Core/SysvTraitTest.php
+++ b/tests/unit/Core/SysvTraitTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Core;
 
 use Google\Cloud\Core\SysvTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class SysvTraitTest extends \PHPUnit_Framework_TestCase
+class SysvTraitTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/unit/Core/TimestampTest.php
+++ b/tests/unit/Core/TimestampTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Core;
 
 use Google\Cloud\Core\Timestamp;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class TimestampTest extends \PHPUnit_Framework_TestCase
+class TimestampTest extends TestCase
 {
     private $dt;
     private $ts;

--- a/tests/unit/Core/Upload/MultipartUploaderTest.php
+++ b/tests/unit/Core/Upload/MultipartUploaderTest.php
@@ -24,12 +24,13 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group upload
  */
-class MultipartUploaderTest extends \PHPUnit_Framework_TestCase
+class MultipartUploaderTest extends TestCase
 {
     public function testUploadsData()
     {

--- a/tests/unit/Core/Upload/ResumableUploaderTest.php
+++ b/tests/unit/Core/Upload/ResumableUploaderTest.php
@@ -26,12 +26,13 @@ use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group upload
  */
-class ResumableUploaderTest extends \PHPUnit_Framework_TestCase
+class ResumableUploaderTest extends TestCase
 {
     private $requestWrapper;
     private $stream;

--- a/tests/unit/Core/Upload/SignedUrlUploaderTest.php
+++ b/tests/unit/Core/Upload/SignedUrlUploaderTest.php
@@ -26,12 +26,13 @@ use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group upload
  */
-class SignedUrlUploaderTest extends \PHPUnit_Framework_TestCase
+class SignedUrlUploaderTest extends TestCase
 {
     private $requestWrapper;
     private $stream;

--- a/tests/unit/Core/Upload/StreamableUploaderTest.php
+++ b/tests/unit/Core/Upload/StreamableUploaderTest.php
@@ -26,12 +26,13 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  * @group upload
  */
-class StreamableUploaderTest extends \PHPUnit_Framework_TestCase
+class StreamableUploaderTest extends TestCase
 {
     private $requestWrapper;
     private $stream;

--- a/tests/unit/Core/UriTraitTest.php
+++ b/tests/unit/Core/UriTraitTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Core;
 
 use Google\Cloud\Core\UriTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class UriTraitTest extends \PHPUnit_Framework_TestCase
+class UriTraitTest extends TestCase
 {
     private $implementation;
 

--- a/tests/unit/Core/ValidateTraitTest.php
+++ b/tests/unit/Core/ValidateTraitTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Core;
 
 use Google\Cloud\Core\ValidateTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class ValidateTraitTest extends \PHPUnit_Framework_TestCase
+class ValidateTraitTest extends TestCase
 {
     private $stub;
 

--- a/tests/unit/Core/WhitelistTraitTest.php
+++ b/tests/unit/Core/WhitelistTraitTest.php
@@ -20,11 +20,12 @@ namespace Google\Cloud\Tests\Unit\Core;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Exception\ServiceException;
 use Google\Cloud\Core\WhitelistTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class WhitelistTraitTest extends \PHPUnit_Framework_TestCase
+class WhitelistTraitTest extends TestCase
 {
     private $trait;
 

--- a/tests/unit/Datastore/BlobTest.php
+++ b/tests/unit/Datastore/BlobTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Datastore;
 
 use Google\Cloud\Datastore\Blob;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group datastore
  */
-class BlobTest extends \PHPUnit_Framework_TestCase
+class BlobTest extends TestCase
 {
     public function testBlobString()
     {

--- a/tests/unit/Datastore/Connection/RestTest.php
+++ b/tests/unit/Datastore/Connection/RestTest.php
@@ -27,11 +27,12 @@ use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Rize\UriTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group datastore
  */
-class RestTest extends \PHPUnit_Framework_TestCase
+class RestTest extends TestCase
 {
     private $requestWrapper;
     private $successBody;

--- a/tests/unit/Datastore/DatastoreClientTest.php
+++ b/tests/unit/Datastore/DatastoreClientTest.php
@@ -29,11 +29,12 @@ use Google\Cloud\Datastore\Query\Query;
 use Google\Cloud\Datastore\Query\QueryInterface;
 use Google\Cloud\Datastore\Transaction;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group datastore
  */
-class DatastoreClientTest extends \PHPUnit_Framework_TestCase
+class DatastoreClientTest extends TestCase
 {
     private $connection;
     private $operation;

--- a/tests/unit/Datastore/DatastoreSessionHandlerTest.php
+++ b/tests/unit/Datastore/DatastoreSessionHandlerTest.php
@@ -27,11 +27,12 @@ use Google\Cloud\Datastore\Query\Query;
 use Google\Cloud\Datastore\Transaction;
 use InvalidArgumentException;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group datastore
  */
-class DatastoreSessionHandlerTest extends \PHPUnit_Framework_TestCase
+class DatastoreSessionHandlerTest extends TestCase
 {
     const KIND = 'PHPSESSID';
     const NAMESPACE_ID = 'sessions';

--- a/tests/unit/Datastore/DatastoreTraitTest.php
+++ b/tests/unit/Datastore/DatastoreTraitTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\Datastore\DatastoreClient;
 use Google\Cloud\Datastore\DatastoreTrait;
 use Google\Cloud\Datastore\Key;
 use Google\Cloud\Datastore\Transaction;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group datastore
  */
-class DatastoreTraitTest extends \PHPUnit_Framework_TestCase
+class DatastoreTraitTest extends TestCase
 {
     private $stub;
 

--- a/tests/unit/Datastore/EntityIteratorTest.php
+++ b/tests/unit/Datastore/EntityIteratorTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Datastore;
 
 use Google\Cloud\Datastore\EntityIterator;
 use Google\Cloud\Datastore\EntityPageIterator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group datastore
  */
-class EntityIteratorTest extends \PHPUnit_Framework_TestCase
+class EntityIteratorTest extends TestCase
 {
     public function testGetsMoreResultsType()
     {

--- a/tests/unit/Datastore/EntityMapperTest.php
+++ b/tests/unit/Datastore/EntityMapperTest.php
@@ -23,11 +23,12 @@ use Google\Cloud\Datastore\EntityMapper;
 use Google\Cloud\Datastore\GeoPoint;
 use Google\Cloud\Datastore\Key;
 use Google\Cloud\Core\Int64;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group datastore
  */
-class EntityMapperTest extends \PHPUnit_Framework_TestCase
+class EntityMapperTest extends TestCase
 {
     const DATE_FORMAT = 'Y-m-d\TH:i:s.uP';
 

--- a/tests/unit/Datastore/EntityPageIteratorTest.php
+++ b/tests/unit/Datastore/EntityPageIteratorTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Datastore;
 
 use Google\Cloud\Datastore\EntityPageIterator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group datastore
  */
-class EntityPageIteratorTest extends \PHPUnit_Framework_TestCase
+class EntityPageIteratorTest extends TestCase
 {
     private static $moreResultsType = 'NOT_FINISHED';
     private static $items = ['a', 'b', 'c'];

--- a/tests/unit/Datastore/EntityTest.php
+++ b/tests/unit/Datastore/EntityTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\Datastore\Entity;
 use Google\Cloud\Datastore\EntityMapper;
 use Google\Cloud\Datastore\Key;
 use GuzzleHttp\Psr7\Stream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group datastore
  */
-class EntityTest extends \PHPUnit_Framework_TestCase
+class EntityTest extends TestCase
 {
     private $key;
     private $mapper;

--- a/tests/unit/Datastore/GeoPointTest.php
+++ b/tests/unit/Datastore/GeoPointTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Datastore;
 
 use Google\Cloud\Datastore\GeoPoint;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group datastore
  */
-class GeoPointTest extends \PHPUnit_Framework_TestCase
+class GeoPointTest extends TestCase
 {
     public function testGeoPoint()
     {

--- a/tests/unit/Datastore/KeyTest.php
+++ b/tests/unit/Datastore/KeyTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Datastore;
 
 use Google\Cloud\Datastore\Key;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group datastore
  */
-class KeyTest extends \PHPUnit_Framework_TestCase
+class KeyTest extends TestCase
 {
     public function testWithInitialPath()
     {

--- a/tests/unit/Datastore/OperationTest.php
+++ b/tests/unit/Datastore/OperationTest.php
@@ -25,11 +25,12 @@ use Google\Cloud\Datastore\Key;
 use Google\Cloud\Datastore\Operation;
 use Google\Cloud\Datastore\Query\QueryInterface;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group datastore
  */
-class OperationTest extends \PHPUnit_Framework_TestCase
+class OperationTest extends TestCase
 {
     private $operation;
     private $mapper;

--- a/tests/unit/Datastore/Query/GqlQueryTest.php
+++ b/tests/unit/Datastore/Query/GqlQueryTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Datastore\Query;
 
 use Google\Cloud\Datastore\EntityMapper;
 use Google\Cloud\Datastore\Query\GqlQuery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group datastore
  */
-class GqlQueryTest extends \PHPUnit_Framework_TestCase
+class GqlQueryTest extends TestCase
 {
     private $mapper;
 

--- a/tests/unit/Datastore/Query/QueryTest.php
+++ b/tests/unit/Datastore/Query/QueryTest.php
@@ -20,11 +20,12 @@ namespace Google\Cloud\Tests\Unit\Datastore\Query;
 use Google\Cloud\Datastore\EntityMapper;
 use Google\Cloud\Datastore\Key;
 use Google\Cloud\Datastore\Query\Query;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group datastore
  */
-class QueryTest extends \PHPUnit_Framework_TestCase
+class QueryTest extends TestCase
 {
     private $query;
     private $mapper;

--- a/tests/unit/Datastore/TransactionTest.php
+++ b/tests/unit/Datastore/TransactionTest.php
@@ -23,11 +23,12 @@ use Google\Cloud\Datastore\Operation;
 use Google\Cloud\Datastore\Query\QueryInterface;
 use Google\Cloud\Datastore\Transaction;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group datastore
  */
-class TransactionTest extends \PHPUnit_Framework_TestCase
+class TransactionTest extends TestCase
 {
     private $operation;
     private $transaction;

--- a/tests/unit/ErrorReporting/BootstrapTest.php
+++ b/tests/unit/ErrorReporting/BootstrapTest.php
@@ -22,13 +22,14 @@ use Google\Cloud\ErrorReporting\Bootstrap;
 use Google\Cloud\ErrorReporting\MockValues;
 use Google\Cloud\Logging\PsrLogger;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/fakeGlobalFunctions.php';
 
 /**
  * @group error-reporting
  */
-class BootstrapTest extends \PHPUnit_Framework_TestCase
+class BootstrapTest extends TestCase
 {
 
     private $psrBatchLogger;

--- a/tests/unit/JsonFileTest.php
+++ b/tests/unit/JsonFileTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit;
 
 use League\JsonGuard\Dereferencer;
 use League\JsonGuard\Validator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group root
  */
-class JsonFileTest extends \PHPUnit_Framework_TestCase
+class JsonFileTest extends TestCase
 {
     const SCHEMA_PATH = '%s/fixtures/schema/%s';
 

--- a/tests/unit/Language/AnnotationTest.php
+++ b/tests/unit/Language/AnnotationTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Language;
 
 use Google\Cloud\Language\Annotation;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group language
  */
-class AnnotationTest extends \PHPUnit_Framework_TestCase
+class AnnotationTest extends TestCase
 {
     private $annotation;
     private $entity;

--- a/tests/unit/Language/Connection/RestTest.php
+++ b/tests/unit/Language/Connection/RestTest.php
@@ -27,11 +27,12 @@ use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Rize\UriTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group language
  */
-class RestTest extends \PHPUnit_Framework_TestCase
+class RestTest extends TestCase
 {
     private $requestWrapper;
     private $successBody;

--- a/tests/unit/Language/LanguageClientTest.php
+++ b/tests/unit/Language/LanguageClientTest.php
@@ -22,11 +22,12 @@ use Google\Cloud\Language\Connection\ConnectionInterface;
 use Google\Cloud\Language\LanguageClient;
 use Google\Cloud\Storage\StorageObject;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group language
  */
-class LanguageClientTest extends \PHPUnit_Framework_TestCase
+class LanguageClientTest extends TestCase
 {
     private $client;
     private $connection;

--- a/tests/unit/Logging/Connection/GrpcTest.php
+++ b/tests/unit/Logging/Connection/GrpcTest.php
@@ -25,11 +25,12 @@ use Google\Logging\V2\LogEntry;
 use Google\Logging\V2\LogMetric;
 use Google\Logging\V2\LogSink;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group logging
  */
-class GrpcTest extends \PHPUnit_Framework_TestCase
+class GrpcTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Logging/Connection/RestTest.php
+++ b/tests/unit/Logging/Connection/RestTest.php
@@ -27,11 +27,12 @@ use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Rize\UriTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group logging
  */
-class RestTest extends \PHPUnit_Framework_TestCase
+class RestTest extends TestCase
 {
     private $requestWrapper;
     private $successBody;

--- a/tests/unit/Logging/LoggerTest.php
+++ b/tests/unit/Logging/LoggerTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Logging\Logger;
 use Google\Cloud\Logging\Connection\ConnectionInterface;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group logging
  */
-class LoggerTest extends \PHPUnit_Framework_TestCase
+class LoggerTest extends TestCase
 {
     private $connection;
     private $formattedName = 'projects/myProjectId/logs/myLog';

--- a/tests/unit/Logging/LoggingClientTest.php
+++ b/tests/unit/Logging/LoggingClientTest.php
@@ -26,11 +26,12 @@ use Google\Cloud\Logging\Sink;
 use Google\Cloud\Logging\Connection\ConnectionInterface;
 use Google\Cloud\Tests\GrpcTestTrait;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group logging
  */
-class LoggingClientTest extends \PHPUnit_Framework_TestCase
+class LoggingClientTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Logging/MetricTest.php
+++ b/tests/unit/Logging/MetricTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Logging\Metric;
 use Google\Cloud\Logging\Connection\ConnectionInterface;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group logging
  */
-class MetricTest extends \PHPUnit_Framework_TestCase
+class MetricTest extends TestCase
 {
     public $connection;
     public $formattedName;

--- a/tests/unit/Logging/PsrLoggerBatchTest.php
+++ b/tests/unit/Logging/PsrLoggerBatchTest.php
@@ -26,11 +26,12 @@ use Google\Cloud\Logging\LoggingClient;
 use Google\Cloud\Logging\PsrLogger;
 use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group logging
  */
-class PsrLoggerBatchTest extends \PHPUnit_Framework_TestCase
+class PsrLoggerBatchTest extends TestCase
 {
     const LOG_NAME = 'my-log';
 

--- a/tests/unit/Logging/PsrLoggerTest.php
+++ b/tests/unit/Logging/PsrLoggerTest.php
@@ -22,11 +22,12 @@ use Google\Cloud\Logging\Logger;
 use Google\Cloud\Logging\PsrLogger;
 use Google\Cloud\Logging\Connection\ConnectionInterface;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group logging
  */
-class PsrLoggerTest extends \PHPUnit_Framework_TestCase
+class PsrLoggerTest extends TestCase
 {
     public $connection;
     public $formattedName;

--- a/tests/unit/Logging/SinkTest.php
+++ b/tests/unit/Logging/SinkTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Logging\Sink;
 use Google\Cloud\Logging\Connection\ConnectionInterface;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group logging
  */
-class SinkTest extends \PHPUnit_Framework_TestCase
+class SinkTest extends TestCase
 {
     public $connection;
     public $formattedName;

--- a/tests/unit/PubSub/BatchPublisherTest.php
+++ b/tests/unit/PubSub/BatchPublisherTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\Core\Batch\BatchRunner;
 use Google\Cloud\PubSub\BatchPublisher;
 use Google\Cloud\PubSub\Topic;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group pubsub
  */
-class BatchPublisherTest extends \PHPUnit_Framework_TestCase
+class BatchPublisherTest extends TestCase
 {
     const TOPIC_NAME = 'my-topic';
 

--- a/tests/unit/PubSub/Connection/GrpcTest.php
+++ b/tests/unit/PubSub/Connection/GrpcTest.php
@@ -30,11 +30,12 @@ use Google\Iam\V1\Policy;
 use Google\Pubsub\V1\PubsubMessage;
 use Google\Pubsub\V1\PushConfig;
 use Google\Pubsub\V1\Subscription;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group pubsub
  */
-class GrpcTest extends \PHPUnit_Framework_TestCase
+class GrpcTest extends TestCase
 {
     use GrpcTestTrait;
     use GrpcTrait;

--- a/tests/unit/PubSub/Connection/IamSubscriptionTest.php
+++ b/tests/unit/PubSub/Connection/IamSubscriptionTest.php
@@ -20,11 +20,12 @@ namespace Google\Cloud\Tests\Unit\PubSub\Connection;
 use Google\Cloud\PubSub\Connection\ConnectionInterface;
 use Google\Cloud\PubSub\Connection\IamSubscription;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group pubsub
  */
-class IamSubscriptionTest extends \PHPUnit_Framework_TestCase
+class IamSubscriptionTest extends TestCase
 {
     /**
      * @dataProvider methodProvider

--- a/tests/unit/PubSub/Connection/IamTopicTest.php
+++ b/tests/unit/PubSub/Connection/IamTopicTest.php
@@ -20,11 +20,12 @@ namespace Google\Cloud\Tests\Unit\PubSub\Connection;
 use Google\Cloud\PubSub\Connection\ConnectionInterface;
 use Google\Cloud\PubSub\Connection\IamTopic;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group pubsub
  */
-class IamTopicTest extends \PHPUnit_Framework_TestCase
+class IamTopicTest extends TestCase
 {
     /**
      * @dataProvider methodProvider

--- a/tests/unit/PubSub/Connection/RestTest.php
+++ b/tests/unit/PubSub/Connection/RestTest.php
@@ -27,11 +27,12 @@ use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Rize\UriTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group pubsub
  */
-class RestTest extends \PHPUnit_Framework_TestCase
+class RestTest extends TestCase
 {
     private $requestWrapper;
     private $successBody;

--- a/tests/unit/PubSub/IncomingMessageTraitTest.php
+++ b/tests/unit/PubSub/IncomingMessageTraitTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\PubSub\Connection\ConnectionInterface;
 use Google\Cloud\PubSub\IncomingMessageTrait;
 use Google\Cloud\PubSub\Message;
 use Google\Cloud\PubSub\Subscription;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group pubsub
  */
-class IncomingMessageTraitTest extends \PHPUnit_Framework_TestCase
+class IncomingMessageTraitTest extends TestCase
 {
     private $stub;
 

--- a/tests/unit/PubSub/MessageTest.php
+++ b/tests/unit/PubSub/MessageTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\PubSub;
 
 use Google\Cloud\PubSub\Message;
 use Google\Cloud\PubSub\Subscription;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group pubsub
  */
-class MessageTest extends \PHPUnit_Framework_TestCase
+class MessageTest extends TestCase
 {
     private $message;
 

--- a/tests/unit/PubSub/PubSubClientTest.php
+++ b/tests/unit/PubSub/PubSubClientTest.php
@@ -30,11 +30,12 @@ use Google\Cloud\PubSub\Subscription;
 use Google\Cloud\PubSub\Topic;
 use Google\Cloud\Tests\GrpcTestTrait;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group pubsub
  */
-class PubSubClientTest extends \PHPUnit_Framework_TestCase
+class PubSubClientTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/PubSub/ResourceNameTraitTest.php
+++ b/tests/unit/PubSub/ResourceNameTraitTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\PubSub;
 
 use Google\Cloud\PubSub\ResourceNameTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group pubsub
  */
-class ResourceNameTraitTest extends \PHPUnit_Framework_TestCase
+class ResourceNameTraitTest extends TestCase
 {
     private $trait;
 

--- a/tests/unit/PubSub/SnapshotTest.php
+++ b/tests/unit/PubSub/SnapshotTest.php
@@ -22,11 +22,12 @@ use Google\Cloud\PubSub\Snapshot;
 use Google\Cloud\PubSub\Subscription;
 use Google\Cloud\PubSub\Topic;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group pubsub
  */
-class SnapshotTest extends \PHPUnit_Framework_TestCase
+class SnapshotTest extends TestCase
 {
     const PROJECT = 'my-project';
     const NAME = 'snapshot';

--- a/tests/unit/PubSub/SubscriptionTest.php
+++ b/tests/unit/PubSub/SubscriptionTest.php
@@ -26,11 +26,12 @@ use Google\Cloud\PubSub\Message;
 use Google\Cloud\PubSub\Snapshot;
 use Google\Cloud\PubSub\Subscription;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group pubsub
  */
-class SubscriptionTest extends \PHPUnit_Framework_TestCase
+class SubscriptionTest extends TestCase
 {
     private $subscription;
     private $connection;

--- a/tests/unit/PubSub/TopicTest.php
+++ b/tests/unit/PubSub/TopicTest.php
@@ -25,11 +25,12 @@ use Google\Cloud\PubSub\Connection\ConnectionInterface;
 use Google\Cloud\PubSub\Subscription;
 use Google\Cloud\PubSub\Topic;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group pubsub
  */
-class TopicTest extends \PHPUnit_Framework_TestCase
+class TopicTest extends TestCase
 {
     private $topic;
     private $connection;

--- a/tests/unit/Spanner/BytesTest.php
+++ b/tests/unit/Spanner/BytesTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Spanner;
 
 use Google\Cloud\Spanner\Bytes;
 use Google\Cloud\Tests\GrpcTestTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class BytesTest extends \PHPUnit_Framework_TestCase
+class BytesTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Spanner/Connection/GrpcTest.php
+++ b/tests/unit/Spanner/Connection/GrpcTest.php
@@ -42,11 +42,12 @@ use Google\Spanner\V1\TransactionOptions;
 use Google\Spanner\V1\TransactionSelector;
 use Google\Spanner\V1\Type;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class GrpcTest extends \PHPUnit_Framework_TestCase
+class GrpcTest extends TestCase
 {
     use GrpcTestTrait;
     use GrpcTrait;

--- a/tests/unit/Spanner/Connection/IamDatabaseTest.php
+++ b/tests/unit/Spanner/Connection/IamDatabaseTest.php
@@ -20,12 +20,13 @@ namespace Google\Cloud\Tests\Unit\Spanner\Connection;
 use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Connection\IamDatabase;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanneradmin
  * @group spanner
  */
-class IamDatabaseTest extends \PHPUnit_Framework_TestCase
+class IamDatabaseTest extends TestCase
 {
     private $connection;
 

--- a/tests/unit/Spanner/Connection/IamInstanceTest.php
+++ b/tests/unit/Spanner/Connection/IamInstanceTest.php
@@ -20,12 +20,13 @@ namespace Google\Cloud\Tests\Unit\Spanner\Connection;
 use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Connection\IamInstance;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanneradmin
  * @group spanner
  */
-class IamInstanceTest extends \PHPUnit_Framework_TestCase
+class IamInstanceTest extends TestCase
 {
     private $connection;
 

--- a/tests/unit/Spanner/Connection/LongRunningConnectionTest.php
+++ b/tests/unit/Spanner/Connection/LongRunningConnectionTest.php
@@ -19,12 +19,13 @@ namespace Google\Cloud\Tests\Unit\Spanner\Connection;
 
 use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Connection\LongRunningConnection;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  * @group spanneradmin
  */
-class LongRunningConnectionTest extends \PHPUnit_Framework_TestCase
+class LongRunningConnectionTest extends TestCase
 {
     private $connection;
     private $lro;

--- a/tests/unit/Spanner/DatabaseTest.php
+++ b/tests/unit/Spanner/DatabaseTest.php
@@ -38,11 +38,12 @@ use Google\Cloud\Spanner\Transaction;
 use Google\Cloud\Spanner\ValueMapper;
 use Google\Cloud\Tests\GrpcTestTrait;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class DatabaseTest extends \PHPUnit_Framework_TestCase
+class DatabaseTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Spanner/DateTest.php
+++ b/tests/unit/Spanner/DateTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Spanner;
 
 use Google\Cloud\Spanner\Date;
 use Google\Cloud\Tests\GrpcTestTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class DateTest extends \PHPUnit_Framework_TestCase
+class DateTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Spanner/DurationTest.php
+++ b/tests/unit/Spanner/DurationTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Spanner;
 
 use Google\Cloud\Spanner\Duration;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class DurationTest extends \PHPUnit_Framework_TestCase
+class DurationTest extends TestCase
 {
     const SECONDS = 10;
     const NANOS = 1;

--- a/tests/unit/Spanner/InstanceConfigurationTest.php
+++ b/tests/unit/Spanner/InstanceConfigurationTest.php
@@ -23,12 +23,13 @@ use Google\Cloud\Spanner\InstanceConfiguration;
 use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Tests\GrpcTestTrait;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanneradmin
  * @group spanner
  */
-class InstanceConfigurationTest extends \PHPUnit_Framework_TestCase
+class InstanceConfigurationTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Spanner/InstanceTest.php
+++ b/tests/unit/Spanner/InstanceTest.php
@@ -31,12 +31,13 @@ use Google\Cloud\Spanner\Instance;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
 use Google\Cloud\Tests\GrpcTestTrait;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  * @group spanneradmin
  */
-class InstanceTest extends \PHPUnit_Framework_TestCase
+class InstanceTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Spanner/KeyRangeTest.php
+++ b/tests/unit/Spanner/KeyRangeTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Spanner;
 
 use Google\Cloud\Spanner\KeyRange;
 use Google\Cloud\Tests\GrpcTestTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class KeyRangeTest extends \PHPUnit_Framework_TestCase
+class KeyRangeTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Spanner/KeySetTest.php
+++ b/tests/unit/Spanner/KeySetTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Spanner;
 
 use Google\Cloud\Spanner\KeyRange;
 use Google\Cloud\Spanner\KeySet;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class KeySetTest extends \PHPUnit_Framework_TestCase
+class KeySetTest extends TestCase
 {
     public function testAddRange()
     {

--- a/tests/unit/Spanner/OperationTest.php
+++ b/tests/unit/Spanner/OperationTest.php
@@ -31,11 +31,12 @@ use Google\Cloud\Spanner\Transaction;
 use Google\Cloud\Spanner\ValueMapper;
 use Google\Cloud\Tests\GrpcTestTrait;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class OperationTest extends \PHPUnit_Framework_TestCase
+class OperationTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Spanner/ResultTest.php
+++ b/tests/unit/Spanner/ResultTest.php
@@ -25,11 +25,12 @@ use Google\Cloud\Spanner\Snapshot;
 use Google\Cloud\Spanner\ValueMapper;
 use Google\Cloud\Tests\GrpcTestTrait;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class ResultTest extends \PHPUnit_Framework_TestCase
+class ResultTest extends TestCase
 {
     use GrpcTestTrait;
     use ResultTestTrait;

--- a/tests/unit/Spanner/Session/CacheSessionPoolTest.php
+++ b/tests/unit/Spanner/Session/CacheSessionPoolTest.php
@@ -31,11 +31,12 @@ use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Prophecy\Argument;
 use Prophecy\Argument\ArgumentsWildcard;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class CacheSessionPoolTest extends \PHPUnit_Framework_TestCase
+class CacheSessionPoolTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Spanner/SnapshotTest.php
+++ b/tests/unit/Spanner/SnapshotTest.php
@@ -23,11 +23,12 @@ use Google\Cloud\Spanner\Snapshot;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Tests\GrpcTestTrait;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class SnapshotTest extends \PHPUnit_Framework_TestCase
+class SnapshotTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Spanner/SpannerClientTest.php
+++ b/tests/unit/Spanner/SpannerClientTest.php
@@ -35,11 +35,12 @@ use Google\Cloud\Spanner\SpannerClient;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Tests\GrpcTestTrait;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class SpannerClientTest extends \PHPUnit_Framework_TestCase
+class SpannerClientTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Spanner/TimestampTest.php
+++ b/tests/unit/Spanner/TimestampTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Spanner;
 
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Tests\GrpcTestTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class TimestampTest extends \PHPUnit_Framework_TestCase
+class TimestampTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Spanner/TransactionConfigurationTraitTest.php
+++ b/tests/unit/Spanner/TransactionConfigurationTraitTest.php
@@ -22,11 +22,12 @@ use Google\Cloud\Spanner\Session\SessionPoolInterface;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\TransactionConfigurationTrait;
 use Google\Cloud\Tests\GrpcTestTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class TransactionConfigurationTraitTest extends \PHPUnit_Framework_TestCase
+class TransactionConfigurationTraitTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Spanner/TransactionTest.php
+++ b/tests/unit/Spanner/TransactionTest.php
@@ -30,11 +30,12 @@ use Google\Cloud\Spanner\Transaction;
 use Google\Cloud\Spanner\ValueMapper;
 use Google\Cloud\Tests\GrpcTestTrait;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class TransactionTest extends \PHPUnit_Framework_TestCase
+class TransactionTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Spanner/TransactionTypeTest.php
+++ b/tests/unit/Spanner/TransactionTypeTest.php
@@ -32,11 +32,12 @@ use Google\Cloud\Spanner\Transaction;
 use Google\Cloud\Spanner\V1\SpannerClient;
 use Google\Cloud\Tests\GrpcTestTrait;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class TransactionTypeTest extends \PHPUnit_Framework_TestCase
+class TransactionTypeTest extends TestCase
 {
     use GrpcTestTrait;
 

--- a/tests/unit/Spanner/ValueMapperTest.php
+++ b/tests/unit/Spanner/ValueMapperTest.php
@@ -25,11 +25,12 @@ use Google\Cloud\Spanner\Result;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\ValueMapper;
 use Google\Cloud\Tests\GrpcTestTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
  */
-class ValueMapperTest extends \PHPUnit_Framework_TestCase
+class ValueMapperTest extends TestCase
 {
     use GrpcTestTrait;
     

--- a/tests/unit/Speech/Connection/RestTest.php
+++ b/tests/unit/Speech/Connection/RestTest.php
@@ -27,11 +27,12 @@ use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Rize\UriTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group speech
  */
-class RestTest extends \PHPUnit_Framework_TestCase
+class RestTest extends TestCase
 {
     private $requestWrapper;
     private $successBody;

--- a/tests/unit/Speech/OperationTest.php
+++ b/tests/unit/Speech/OperationTest.php
@@ -22,11 +22,12 @@ use Google\Cloud\Speech\Connection\ConnectionInterface;
 use Google\Cloud\Speech\Operation;
 use Google\Cloud\Speech\Result;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group speech
  */
-class OperationTest extends \PHPUnit_Framework_TestCase
+class OperationTest extends TestCase
 {
     public $connection;
     public $operationName = 'myOperation';

--- a/tests/unit/Speech/ResultTest.php
+++ b/tests/unit/Speech/ResultTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Speech;
 
 use Google\Cloud\Speech\Result;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group speech
  */
-class ResultTest extends \PHPUnit_Framework_TestCase
+class ResultTest extends TestCase
 {
     private $transcript;
     private $confidence;

--- a/tests/unit/Speech/SpeechClientTest.php
+++ b/tests/unit/Speech/SpeechClientTest.php
@@ -23,11 +23,12 @@ use Google\Cloud\Speech\Result;
 use Google\Cloud\Speech\SpeechClient;
 use Google\Cloud\Storage\StorageObject;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group speech
  */
-class SpeechClientTest extends \PHPUnit_Framework_TestCase
+class SpeechClientTest extends TestCase
 {
     CONST GCS_URI = 'gs://bucket/object';
 

--- a/tests/unit/Storage/AclTest.php
+++ b/tests/unit/Storage/AclTest.php
@@ -20,11 +20,12 @@ namespace Google\Cloud\Tests\Unit\Storage;
 use Google\Cloud\Storage\Acl;
 use Google\Cloud\Storage\Connection\ConnectionInterface;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group storage
  */
-class AclTest extends \PHPUnit_Framework_TestCase
+class AclTest extends TestCase
 {
     public $connection;
 

--- a/tests/unit/Storage/BucketTest.php
+++ b/tests/unit/Storage/BucketTest.php
@@ -29,11 +29,12 @@ use Google\Cloud\Storage\Connection\Rest;
 use Google\Cloud\Storage\Notification;
 use Google\Cloud\Storage\StorageObject;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group storage
  */
-class BucketTest extends \PHPUnit_Framework_TestCase
+class BucketTest extends TestCase
 {
     const BUCKET_NAME = 'my-bucket';
     const PROJECT_ID = 'my-project';

--- a/tests/unit/Storage/Connection/IamBucketTest.php
+++ b/tests/unit/Storage/Connection/IamBucketTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Storage\Connection;
 
 use Google\Cloud\Storage\Connection\ConnectionInterface;
 use Google\Cloud\Storage\Connection\IamBucket;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group storage
  */
-class IamBucketTest extends \PHPUnit_Framework_TestCase
+class IamBucketTest extends TestCase
 {
     /**
      * @dataProvider methodProvider

--- a/tests/unit/Storage/Connection/RestTest.php
+++ b/tests/unit/Storage/Connection/RestTest.php
@@ -30,11 +30,12 @@ use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Rize\UriTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group storage
  */
-class RestTest extends \PHPUnit_Framework_TestCase
+class RestTest extends TestCase
 {
     private $requestWrapper;
     private $successBody;

--- a/tests/unit/Storage/EncryptionTraitTest.php
+++ b/tests/unit/Storage/EncryptionTraitTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Storage;
 
 use Google\Cloud\Tests\KeyPairGenerateTrait;
 use Google\Cloud\Storage\EncryptionTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group storage
  */
-class EncryptionTraitTest extends \PHPUnit_Framework_TestCase
+class EncryptionTraitTest extends TestCase
 {
     use KeyPairGenerateTrait;
 

--- a/tests/unit/Storage/NotificationTest.php
+++ b/tests/unit/Storage/NotificationTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Storage\Connection\ConnectionInterface;
 use Google\Cloud\Storage\Notification;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group storage
  */
-class NotificationTest extends \PHPUnit_Framework_TestCase
+class NotificationTest extends TestCase
 {
     const BUCKET_NAME = 'my-bucket';
     const NOTIFICATION_ID = '1234';

--- a/tests/unit/Storage/ObjectIteratorTest.php
+++ b/tests/unit/Storage/ObjectIteratorTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Storage;
 
 use Google\Cloud\Storage\ObjectIterator;
 use Google\Cloud\Storage\ObjectPageIterator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group storage
  */
-class ObjectIteratorTest extends \PHPUnit_Framework_TestCase
+class ObjectIteratorTest extends TestCase
 {
     public function testGetsPrefixes()
     {

--- a/tests/unit/Storage/ObjectPageIteratorTest.php
+++ b/tests/unit/Storage/ObjectPageIteratorTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Storage;
 
 use Google\Cloud\Storage\ObjectPageIterator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group storage
  */
-class ObjectPageIteratorTest extends \PHPUnit_Framework_TestCase
+class ObjectPageIteratorTest extends TestCase
 {
     private static $prefixes = ['test/', 'test1/'];
     private static $items = ['a', 'b', 'c'];

--- a/tests/unit/Storage/ReadStreamTest.php
+++ b/tests/unit/Storage/ReadStreamTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\Storage\ReadStream;
 use Google\Cloud\Upload\StreamableUploader;
 use Prophecy\Argument;
 use Psr\Http\Message\StreamInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group storage
  */
-class ReadStreamTest extends \PHPUnit_Framework_TestCase
+class ReadStreamTest extends TestCase
 {
     public function testReadsFromHeadersWhenGetSizeIsNull()
     {

--- a/tests/unit/Storage/RequesterPaysTest.php
+++ b/tests/unit/Storage/RequesterPaysTest.php
@@ -23,12 +23,13 @@ use Psr\Http\Message\RequestInterface;
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Storage\Connection\Rest;
 use Google\Cloud\Core\Upload\AbstractUploader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group storage
  * @group storage-requesterpays
  */
-class RequesterPaysTest extends \PHPUnit_Framework_TestCase
+class RequesterPaysTest extends TestCase
 {
     const PROJECT = 'example_project';
     const USER_PROJECT = 'foobar';

--- a/tests/unit/Storage/StorageClientTest.php
+++ b/tests/unit/Storage/StorageClientTest.php
@@ -25,11 +25,12 @@ use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Storage\StreamWrapper;
 use GuzzleHttp\Psr7;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group storage
  */
-class StorageClientTest extends \PHPUnit_Framework_TestCase
+class StorageClientTest extends TestCase
 {
     const PROJECT = 'my-project';
     public $connection;

--- a/tests/unit/Storage/StorageObjectTest.php
+++ b/tests/unit/Storage/StorageObjectTest.php
@@ -31,11 +31,12 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group storage
  */
-class StorageObjectTest extends \PHPUnit_Framework_TestCase
+class StorageObjectTest extends TestCase
 {
     use KeyPairGenerateTrait;
 

--- a/tests/unit/Storage/StreamWrapperTest.php
+++ b/tests/unit/Storage/StreamWrapperTest.php
@@ -27,11 +27,12 @@ use GuzzleHttp\Psr7;
 use Prophecy\Argument;
 use Prophecy\Promise\CallbackPromise;
 use Prophecy\Prophecy\ObjectProphecy;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group storage
  */
-class StreamWrapperTest extends \PHPUnit_Framework_TestCase
+class StreamWrapperTest extends TestCase
 {
     private $originalDefaultContext;
 

--- a/tests/unit/Storage/WriteStreamTest.php
+++ b/tests/unit/Storage/WriteStreamTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\Storage\WriteStream;
 use Google\Cloud\Core\Upload\StreamableUploader;
 use Prophecy\Argument;
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group storage
  */
-class WriteStreamTest extends \PHPUnit_Framework_TestCase
+class WriteStreamTest extends TestCase
 {
     public function testUploadsWhenWriteOverflowsBuffer()
     {

--- a/tests/unit/Trace/Connection/RestTest.php
+++ b/tests/unit/Trace/Connection/RestTest.php
@@ -26,11 +26,12 @@ use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Rize\UriTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class RestTest extends \PHPUnit_Framework_TestCase
+class RestTest extends TestCase
 {
     private $requestWrapper;
     private $successBody;

--- a/tests/unit/Trace/Reporter/AsyncReporterTest.php
+++ b/tests/unit/Trace/Reporter/AsyncReporterTest.php
@@ -25,11 +25,12 @@ use Google\Cloud\Trace\TraceSpan;
 use Google\Cloud\Trace\Trace;
 use Google\Cloud\Trace\Tracer\TracerInterface;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class AsyncReporterTest extends \PHPUnit_Framework_TestCase
+class AsyncReporterTest extends TestCase
 {
     private $runner;
     private $tracer;

--- a/tests/unit/Trace/Reporter/EchoReporterTest.php
+++ b/tests/unit/Trace/Reporter/EchoReporterTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\Trace\Reporter\EchoReporter;
 use Google\Cloud\Trace\TraceContext;
 use Google\Cloud\Trace\TraceSpan;
 use Google\Cloud\Trace\Tracer\TracerInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class EchoReporterTest extends \PHPUnit_Framework_TestCase
+class EchoReporterTest extends TestCase
 {
     private $tracer;
 

--- a/tests/unit/Trace/Reporter/FileReporterTest.php
+++ b/tests/unit/Trace/Reporter/FileReporterTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\Trace\Reporter\FileReporter;
 use Google\Cloud\Trace\TraceContext;
 use Google\Cloud\Trace\TraceSpan;
 use Google\Cloud\Trace\Tracer\TracerInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class FileReporterTest extends \PHPUnit_Framework_TestCase
+class FileReporterTest extends TestCase
 {
     private $tracer;
     private $filename;

--- a/tests/unit/Trace/Reporter/LoggerReporterTest.php
+++ b/tests/unit/Trace/Reporter/LoggerReporterTest.php
@@ -23,11 +23,12 @@ use Google\Cloud\Trace\TraceContext;
 use Google\Cloud\Trace\TraceSpan;
 use Google\Cloud\Trace\Tracer\TracerInterface;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class LoggerReporterTest extends \PHPUnit_Framework_TestCase
+class LoggerReporterTest extends TestCase
 {
     private $tracer;
     private $logger;

--- a/tests/unit/Trace/Reporter/SyncReporterTest.php
+++ b/tests/unit/Trace/Reporter/SyncReporterTest.php
@@ -25,11 +25,12 @@ use Google\Cloud\Trace\TraceContext;
 use Google\Cloud\Trace\TraceSpan;
 use Google\Cloud\Trace\Tracer\TracerInterface;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class SyncReporterTest extends \PHPUnit_Framework_TestCase
+class SyncReporterTest extends TestCase
 {
     private $tracer;
     private $connection;

--- a/tests/unit/Trace/RequestHandlerTest.php
+++ b/tests/unit/Trace/RequestHandlerTest.php
@@ -22,11 +22,12 @@ use Google\Cloud\Trace\RequestHandler;
 use Google\Cloud\Trace\Reporter\ReporterInterface;
 use Google\Cloud\Trace\Sampler\SamplerInterface;
 use Google\Cloud\Trace\Tracer\NullTracer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class RequestHandlerTest extends \PHPUnit_Framework_TestCase
+class RequestHandlerTest extends TestCase
 {
     private $reporter;
 

--- a/tests/unit/Trace/RequestTracerTest.php
+++ b/tests/unit/Trace/RequestTracerTest.php
@@ -20,11 +20,12 @@ namespace Google\Cloud\Tests\Unit\Trace;
 use Google\Cloud\Trace\Reporter\ReporterInterface;
 use Google\Cloud\Trace\RequestTracer;
 use Google\Cloud\Trace\Tracer\NullTracer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class RequestTracerTest extends \PHPUnit_Framework_TestCase
+class RequestTracerTest extends TestCase
 {
     private $reporter;
 

--- a/tests/unit/Trace/Sampler/QpsSamplerTest.php
+++ b/tests/unit/Trace/Sampler/QpsSamplerTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\Trace\Sampler\QpsSampler;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class QpsSamplerTest extends \PHPUnit_Framework_TestCase
+class QpsSamplerTest extends TestCase
 {
     public function testCachedValue()
     {

--- a/tests/unit/Trace/Sampler/RandomSamplerTest.php
+++ b/tests/unit/Trace/Sampler/RandomSamplerTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Trace\Sampler;
 
 use Google\Cloud\Trace\Sampler\RandomSampler;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class RandomSamplerTest extends \PHPUnit_Framework_TestCase
+class RandomSamplerTest extends TestCase
 {
     /**
      * @dataProvider invalidRates

--- a/tests/unit/Trace/Sampler/SamplerFactoryTest.php
+++ b/tests/unit/Trace/Sampler/SamplerFactoryTest.php
@@ -23,11 +23,12 @@ use Google\Cloud\Trace\Sampler\AlwaysOnSampler;
 use Google\Cloud\Trace\Sampler\QpsSampler;
 use Google\Cloud\Trace\Sampler\RandomSampler;
 use Psr\Cache\CacheItemPoolInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class SamplerFactoryTest extends \PHPUnit_Framework_TestCase
+class SamplerFactoryTest extends TestCase
 {
     public function testDefaultEnabled()
     {

--- a/tests/unit/Trace/TraceClientTest.php
+++ b/tests/unit/Trace/TraceClientTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\Trace\Connection\ConnectionInterface;
 use Google\Cloud\Trace\Trace;
 use Google\Cloud\Trace\TraceClient;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class TraceClientTest extends \PHPUnit_Framework_TestCase
+class TraceClientTest extends TestCase
 {
     private $client;
     private $connection;

--- a/tests/unit/Trace/TraceContextTest.php
+++ b/tests/unit/Trace/TraceContextTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Trace;
 
 use Google\Cloud\Trace\TraceContext;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class TraceContextTest extends \PHPUnit_Framework_TestCase
+class TraceContextTest extends TestCase
 {
     /**
      * @dataProvider traceHeaders

--- a/tests/unit/Trace/TraceSpanTest.php
+++ b/tests/unit/Trace/TraceSpanTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Trace;
 
 use Google\Cloud\Trace\TraceSpan;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class TraceSpanTest extends \PHPUnit_Framework_TestCase
+class TraceSpanTest extends TestCase
 {
     const EXPECTED_TIMESTAMP_FORMAT = '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z$/';
 

--- a/tests/unit/Trace/TraceTest.php
+++ b/tests/unit/Trace/TraceTest.php
@@ -20,11 +20,12 @@ namespace Google\Cloud\Tests\Unit\Trace;
 use Google\Cloud\Trace\Connection\ConnectionInterface;
 use Google\Cloud\Trace\Trace;
 use Google\Cloud\Trace\TraceSpan;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class TraceTest extends \PHPUnit_Framework_TestCase
+class TraceTest extends TestCase
 {
     /** @var ConnectionInterface|ObjectProphecy */
     public $connection;

--- a/tests/unit/Trace/Tracer/ContextTracerTest.php
+++ b/tests/unit/Trace/Tracer/ContextTracerTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Trace\Tracer;
 
 use Google\Cloud\Trace\TraceContext;
 use Google\Cloud\Trace\Tracer\ContextTracer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group trace
  */
-class ContextTracerTest extends \PHPUnit_Framework_TestCase
+class ContextTracerTest extends TestCase
 {
     public function testMaintainsContext()
     {

--- a/tests/unit/Translate/Connection/RestTest.php
+++ b/tests/unit/Translate/Connection/RestTest.php
@@ -27,11 +27,12 @@ use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Rize\UriTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group translate
  */
-class RestTest extends \PHPUnit_Framework_TestCase
+class RestTest extends TestCase
 {
     private $requestWrapper;
     private $successBody;

--- a/tests/unit/Translate/TranslateClientTest.php
+++ b/tests/unit/Translate/TranslateClientTest.php
@@ -20,11 +20,12 @@ namespace Google\Cloud\Tests\Unit\Translate;
 use Google\Cloud\Translate\Connection\ConnectionInterface;
 use Google\Cloud\Translate\TranslateClient;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group translate
  */
-class TranslateClientTest extends \PHPUnit_Framework_TestCase
+class TranslateClientTest extends TestCase
 {
     private $client;
     private $connection;

--- a/tests/unit/Vision/Annotation/CropHintTest.php
+++ b/tests/unit/Vision/Annotation/CropHintTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Vision\Annotation;
 
 use Google\Cloud\Vision\Annotation\CropHint;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group vision
  */
-class CropHintTest extends \PHPUnit_Framework_TestCase
+class CropHintTest extends TestCase
 {
     private $info;
     private $hint;

--- a/tests/unit/Vision/Annotation/DocumentTest.php
+++ b/tests/unit/Vision/Annotation/DocumentTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Vision\Annotation;
 
 use Google\Cloud\Vision\Annotation\Document;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group vision
  */
-class DocumentTest extends \PHPUnit_Framework_TestCase
+class DocumentTest extends TestCase
 {
     public function testDocument()
     {

--- a/tests/unit/Vision/Annotation/EntityTest.php
+++ b/tests/unit/Vision/Annotation/EntityTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Vision\Annotation;
 
 use Google\Cloud\Vision\Annotation\Entity;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group vision
  */
-class EntityTest extends \PHPUnit_Framework_TestCase
+class EntityTest extends TestCase
 {
     public function testEntity()
     {

--- a/tests/unit/Vision/Annotation/Face/LandmarksTest.php
+++ b/tests/unit/Vision/Annotation/Face/LandmarksTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Vision\Annotation;
 
 use Google\Cloud\Vision\Annotation\Face\Landmarks;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group vision
  */
-class LandmarksTest extends \PHPUnit_Framework_TestCase
+class LandmarksTest extends TestCase
 {
     private $data;
     private $landmarks;

--- a/tests/unit/Vision/Annotation/FaceTest.php
+++ b/tests/unit/Vision/Annotation/FaceTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Vision\Annotation;
 
 use Google\Cloud\Vision\Annotation\Face;
 use Google\Cloud\Vision\Annotation\Face\Landmarks;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group vision
  */
-class FaceTest extends \PHPUnit_Framework_TestCase
+class FaceTest extends TestCase
 {
     private $face;
 

--- a/tests/unit/Vision/Annotation/LikelihoodTraitTest.php
+++ b/tests/unit/Vision/Annotation/LikelihoodTraitTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Vision\Annotation;
 
 use Google\Cloud\Vision\Annotation\FeatureInterface;
 use Google\Cloud\Vision\Annotation\LikelihoodTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group vision
  */
-class LikelihoodTraitTest extends \PHPUnit_Framework_TestCase
+class LikelihoodTraitTest extends TestCase
 {
     public function testLikelihoods()
     {

--- a/tests/unit/Vision/Annotation/SafeSearchTest.php
+++ b/tests/unit/Vision/Annotation/SafeSearchTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Unit\Vision\Annotation;
 
 use Google\Cloud\Vision\Annotation\SafeSearch;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group vision
  */
-class SafeSearchTest extends \PHPUnit_Framework_TestCase
+class SafeSearchTest extends TestCase
 {
     private $safeSearch;
 

--- a/tests/unit/Vision/Annotation/Web/WebEntityTest.php
+++ b/tests/unit/Vision/Annotation/Web/WebEntityTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Vision\Annotation;
 
 use Google\Cloud\Vision\Annotation\Web\WebEntity;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group vision
  */
-class WebEntityTest extends \PHPUnit_Framework_TestCase
+class WebEntityTest extends TestCase
 {
     private $info;
     private $entity;

--- a/tests/unit/Vision/Annotation/Web/WebImageTest.php
+++ b/tests/unit/Vision/Annotation/Web/WebImageTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Vision\Annotation;
 
 use Google\Cloud\Vision\Annotation\Web\WebImage;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group vision
  */
-class WebImageTest extends \PHPUnit_Framework_TestCase
+class WebImageTest extends TestCase
 {
     private $info;
     private $image;

--- a/tests/unit/Vision/Annotation/Web/WebPageTest.php
+++ b/tests/unit/Vision/Annotation/Web/WebPageTest.php
@@ -18,11 +18,12 @@
 namespace Google\Cloud\Tests\Vision\Annotation;
 
 use Google\Cloud\Vision\Annotation\Web\WebPage;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group vision
  */
-class WebPageTest extends \PHPUnit_Framework_TestCase
+class WebPageTest extends TestCase
 {
     private $info;
     private $image;

--- a/tests/unit/Vision/Annotation/WebTest.php
+++ b/tests/unit/Vision/Annotation/WebTest.php
@@ -21,11 +21,12 @@ use Google\Cloud\Vision\Annotation\Web;
 use Google\Cloud\Vision\Annotation\Web\WebEntity;
 use Google\Cloud\Vision\Annotation\Web\WebImage;
 use Google\Cloud\Vision\Annotation\Web\WebPage;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group vision
  */
-class WebTest extends \PHPUnit_Framework_TestCase
+class WebTest extends TestCase
 {
     private $info;
     private $annotation;

--- a/tests/unit/Vision/AnnotationTest.php
+++ b/tests/unit/Vision/AnnotationTest.php
@@ -25,11 +25,12 @@ use Google\Cloud\Vision\Annotation\Face;
 use Google\Cloud\Vision\Annotation\ImageProperties;
 use Google\Cloud\Vision\Annotation\SafeSearch;
 use Google\Cloud\Vision\Annotation\Web;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group vision
  */
-class AnnotationTest extends \PHPUnit_Framework_TestCase
+class AnnotationTest extends TestCase
 {
     public function testConstruct()
     {

--- a/tests/unit/Vision/Connection/RestTest.php
+++ b/tests/unit/Vision/Connection/RestTest.php
@@ -27,11 +27,12 @@ use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Rize\UriTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group vision
  */
-class RestTest extends \PHPUnit_Framework_TestCase
+class RestTest extends TestCase
 {
     private $requestWrapper;
     private $successBody;

--- a/tests/unit/Vision/ImageTest.php
+++ b/tests/unit/Vision/ImageTest.php
@@ -19,11 +19,12 @@ namespace Google\Cloud\Tests\Unit\Vision;
 
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Vision\Image;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group vision
  */
-class ImageTest extends \PHPUnit_Framework_TestCase
+class ImageTest extends TestCase
 {
     public function testWithString()
     {

--- a/tests/unit/Vision/VisionClientTest.php
+++ b/tests/unit/Vision/VisionClientTest.php
@@ -22,11 +22,12 @@ use Google\Cloud\Vision\Connection\ConnectionInterface;
 use Google\Cloud\Vision\Image;
 use Google\Cloud\Vision\VisionClient;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group vision
  */
-class VisionClientTest extends \PHPUnit_Framework_TestCase
+class VisionClientTest extends TestCase
 {
     private $client;
 


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just needed to bump PHPUnit version to [`4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21), to keep compatibility.