### PR TITLE
allows to use excludeFromIndexes inside embedded Entities in datastore

### DIFF
--- a/src/Datastore/EntityMapper.php
+++ b/src/Datastore/EntityMapper.php
@@ -444,8 +444,10 @@ class EntityMapper
     private function convertArrayToEntityValue(array $value)
     {
         $properties = [];
+        $should_exclude = isset($value['excludeFromIndexes']) && $value['excludeFromIndexes'];
         foreach ($value as $key => $val) {
-            $properties[$key] = $this->valueObject($val);
+            if($key != 'excludeFromIndexes')
+                $properties[$key] = $this->valueObject($val, $should_exclude);
         }
 
         return [


### PR DESCRIPTION
helps to avoid errors like 

**The value of property stringValue is longer than 1500 bytes.**

simple use following style for embedded entities to avoid error:
```php
'entityValue' => [
    'properties' => [
        'name' => 'some_field',
        'value' => 'some_long_value',
        'excludeFromIndexes' => true,
    ]
]
```
