### PR TITLE
Add support for excludeFromIndexes in embedded entities

### DIFF
--- a/src/Datastore/Connection/Rest.php
+++ b/src/Datastore/Connection/Rest.php
@@ -78,6 +78,7 @@ class Rest implements ConnectionInterface
      */
     public function commit(array $args)
     {
+        // print_r($args);exit;
         return $this->send('projects', 'commit', $args);
     }
 

--- a/src/Datastore/Connection/Rest.php
+++ b/src/Datastore/Connection/Rest.php
@@ -78,7 +78,6 @@ class Rest implements ConnectionInterface
      */
     public function commit(array $args)
     {
-        // print_r($args);exit;
         return $this->send('projects', 'commit', $args);
     }
 

--- a/src/Datastore/Entity.php
+++ b/src/Datastore/Entity.php
@@ -70,6 +70,8 @@ class Entity implements ArrayAccess
 {
     use DatastoreTrait;
 
+    const EXCLUDE_FROM_INDEXES = '___GOOGLECLOUDPHP___EXCLUDEFROMINDEXES___';
+
     /**
      * @var Key
      */

--- a/tests/system/Datastore/SaveAndModifyTest.php
+++ b/tests/system/Datastore/SaveAndModifyTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Tests\System\Datastore;
 
 use Google\Cloud\Core\Int64;
+use Google\Cloud\Datastore\Entity;
 
 /**
  * @group datastore
@@ -115,5 +116,21 @@ class SaveAndModifyTest extends DatastoreTestCase
 
         $this->assertInstanceOf(Int64::class, $entity[$entityDataKey]);
         $this->assertEquals($intValue, (string) $entity[$entityDataKey]);
+    }
+
+    public function testExcludeEmbeddedEntityPropertyFromIndexes()
+    {
+        $entity = self::$client->entity('Person', [
+            'foo' => [
+                'hello' => 'world',
+                Entity::EXCLUDE_FROM_INDEXES => ['hello']
+            ]
+        ]);
+        self::$client->insert($entity);
+
+        $key = $entity->key();
+        self::$localDeletionQueue->add($key);
+        $e = self::$client->lookup($key);
+        $this->assertEquals(['hello'], $e['foo'][Entity::EXCLUDE_FROM_INDEXES]);
     }
 }

--- a/tests/unit/Datastore/EntityMapperTest.php
+++ b/tests/unit/Datastore/EntityMapperTest.php
@@ -321,6 +321,36 @@ class EntityMapperTest extends TestCase
         $this->assertEquals('test', $res['prop']);
     }
 
+    public function testConvertValueEntityWithKeyExcludes()
+    {
+        $type = 'entityValue';
+        $val = [
+            'key' => [
+                'partitionId' => [
+                    'namespaceId' => 'bar'
+                ],
+                'path' => [['kind' => 'kind', 'id' => '2']]
+            ],
+            'properties' => [
+                'prop' => [
+                    'stringValue' => 'test',
+                    'excludeFromIndexes' => true
+                ]
+            ]
+        ];
+
+        $res = $this->mapper->convertValue($type, $val);
+        $this->assertInstanceOf(Entity::class, $res);
+        $this->assertInstanceOf(Key::class, $res->key());
+
+        $key = $res->key()->keyObject();
+        $this->assertEquals('bar', $key['partitionId']['namespaceId']);
+        $this->assertEquals([['kind' => 'kind', 'id' => '2']], $key['path']);
+
+        $this->assertEquals('test', $res['prop']);
+        $this->assertEquals(['prop'], $res->excludedProperties());
+    }
+
     public function testConvertValueEntityWithIncompleteKey()
     {
         $type = 'entityValue';
@@ -363,6 +393,24 @@ class EntityMapperTest extends TestCase
         $res = $this->mapper->convertValue($type, $val);
         $this->assertTrue(is_array($res));
         $this->assertEquals('test', $res['prop']);
+    }
+
+    public function testConvertValueEntityWithoutKeyExcludes()
+    {
+        $type = 'entityValue';
+        $val = [
+            'properties' => [
+                'prop' => [
+                    'stringValue' => 'test',
+                    'excludeFromIndexes' => true
+                ]
+            ]
+        ];
+
+        $res = $this->mapper->convertValue($type, $val);
+        $this->assertTrue(is_array($res));
+        $this->assertEquals('test', $res['prop']);
+        $this->assertEquals(['prop'], $res[Entity::EXCLUDE_FROM_INDEXES]);
     }
 
     public function testConvertValueDouble()
@@ -488,6 +536,20 @@ class EntityMapperTest extends TestCase
 
         $this->assertEquals('entityValue', key($entity));
         $this->assertEquals('val1', $entity['entityValue']['properties']['key1']['stringValue']);
+        $this->assertEquals('val2', $entity['entityValue']['properties']['key2']['stringValue']);
+    }
+
+    public function testValueObjectArrayEntityValueExcludes()
+    {
+        $entity = $this->mapper->valueObject([
+            'key1' => 'val1',
+            'key2' => 'val2',
+            Entity::EXCLUDE_FROM_INDEXES => ['key1']
+        ]);
+
+        $this->assertEquals('entityValue', key($entity));
+        $this->assertEquals('val1', $entity['entityValue']['properties']['key1']['stringValue']);
+        $this->assertTrue($entity['entityValue']['properties']['key1']['excludeFromIndexes']);
         $this->assertEquals('val2', $entity['entityValue']['properties']['key2']['stringValue']);
     }
 


### PR DESCRIPTION
cc @maksimru

This change adds support for excluding properties of embedded entities from datastore indexes.

```php
use Google\Cloud\Datastore\Entity;

$e = $datastore->entity('Person', [
    'entity' => [
        'prop' => 'val',
        Entity::EXCLUDE_FROM_INDEXES => ['prop']
    ]
]);

$datastore->insert($e);
```

We've added a todo item for the next major version to improve on this, but for the time being this is the best option to avoid a backwards-compatibility break.