### PR TITLE
Add CLI for creating new component.

### DIFF
--- a/dev/google-cloud
+++ b/dev/google-cloud
@@ -18,6 +18,7 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
+use Google\Cloud\Dev\AddComponent\Command\AddComponent;
 use Google\Cloud\Dev\DocGenerator\Command\Docs;
 use Google\Cloud\Dev\Release\Command\Release;
 use Google\Cloud\Dev\Split\Command\Split;
@@ -35,4 +36,5 @@ $app = new Application;
 $app->add(new Release(__DIR__));
 $app->add(new Docs(__DIR__));
 $app->add(new Split(__DIR__));
+$app->add(new AddComponent(__DIR__));
 $app->run();

--- a/dev/src/AddComponent/Command/AddComponent.php
+++ b/dev/src/AddComponent/Command/AddComponent.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Dev\AddComponent\Command;
 
 use Google\Cloud\Dev\AddComponent\Composer;
+use Google\Cloud\Dev\AddComponent\Contributing;
 use Google\Cloud\Dev\AddComponent\License;
 use Google\Cloud\Dev\AddComponent\Manifest;
 use Google\Cloud\Dev\AddComponent\QuestionTrait;
@@ -124,6 +125,13 @@ class AddComponent extends Command
         ));
 
         (new License($this->cliBasePath, $path))->run();
+
+        $output->writeln($formatter->formatSection(
+            'Contributing',
+            'Creating CONTRIBUTING.md file by copying from template.'
+        ));
+
+        (new Contributing($this->cliBasePath, $path))->run();
 
         $output->writeln($formatter->formatSection(
             'Readme',

--- a/dev/src/AddComponent/Command/AddComponent.php
+++ b/dev/src/AddComponent/Command/AddComponent.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\AddComponent\Command;
+
+use Google\Cloud\Dev\AddComponent\Composer;
+use Google\Cloud\Dev\AddComponent\License;
+use Google\Cloud\Dev\AddComponent\Manifest;
+use Google\Cloud\Dev\AddComponent\QuestionTrait;
+use Google\Cloud\Dev\AddComponent\Readmes;
+use Google\Cloud\Dev\AddComponent\TableOfContents;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * Add a Component
+ */
+class AddComponent extends Command
+{
+    use QuestionTrait;
+
+    private $cliBasePath;
+    private $templatesPath;
+
+    private $input;
+    private $output;
+
+    public function __construct($cliBasePath)
+    {
+        $this->cliBasePath = $cliBasePath;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->setName('component')
+            ->setDescription('Add a Component');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // this is gross.
+        $this->input = $input;
+        $this->output = $output;
+
+        $formatter = $this->getHelper('formatter');
+
+        $info = [];
+        $info['name'] = $this->ask(
+            'Please enter the component name, omitting the vendor ' .
+            '(e.g. cloud-foo)'
+        );
+
+        $info['display'] = $this->ask(
+            'Please enter the component display name ' .
+            '(e.g. Google Cloud Foo)'
+        );
+
+        $q = $this->question(
+            'Please enter the URI of the service homepage on cloud.google.com'
+        )->setValidator(function ($answer) {
+            if (strpos($answer, '://') === false) {
+                $answer = 'https://'. $answer;
+            }
+
+            return $answer;
+        });
+
+        $info['cloudPage'] = $this->askQuestion($q);
+
+        $q = $this->question(
+            'Please enter the URI of the documentation homepage on cloud.google.com',
+            $info['cloudPage'] .'/docs'
+        )->setValidator(function ($answer) {
+            if (strpos($answer, '://') === false) {
+                $answer = 'https://'. $answer;
+            }
+
+            return $answer;
+        });
+
+        $info['docsPage'] = $this->askQuestion($q);
+
+        $base = $this->cliBasePath . '/../src/';
+        $q = $this->question(
+            'Please enter the directory name, relative to `src/`, where the component is found. ' .
+            'For instance, if the directory is `src/Foo`, enter `Foo`.'
+        )->setValidator(function ($answer) use ($base) {
+            $path = $base . $answer;
+
+            if (!is_dir($path)) {
+                throw new \RuntimeException(
+                    $path .' does not exist or is not a folder.'
+                );
+            }
+
+            return $path;
+        })->setMaxAttempts(null);
+
+        $path = $this->askQuestion($q);
+
+        $output->writeln($formatter->formatSection(
+            'License',
+            'Creating LICENSE file by copying from repository base.'
+        ));
+
+        (new License($this->cliBasePath, $path))->run();
+
+        $output->writeln($formatter->formatSection(
+            'Readme',
+            'Every directory which contains documented classes should contain a README file. ' .
+            'README files are populated using information you already supplied. ' .
+            'When a directory does not contain a single entry point, or a main client class, ' .
+            'README functions as a main service. In certain cases, README files are not ' .
+            'desirable. In clients with GAPICs, the `Gapic` and `resources` folders generally should not ' .
+            'include READMEs, because the Gapic client is documented in the parent class.' .
+            PHP_EOL
+        ));
+
+        $readme = new Readmes(
+            $this->getHelper('question'),
+            $input,
+            $output,
+            $this->cliBasePath,
+            $path,
+            $info
+        );
+        $readme->run();
+
+        $output->writeln($formatter->formatSection(
+            'Table of Contents',
+            'The main service for a directory is what users will see when they first ' .
+            'encounter an endpoint in the documentation hierarchy. If a main service ' .
+            'is present (as in handwritten clients), that service should be used. ' .
+            'If not, choose README.md' .
+            PHP_EOL
+        ));
+
+        (new TableOfContents(
+            $this->getHelper('formatter'),
+            $this->getHelper('question'),
+            $input,
+            $output,
+            $this->cliBasePath,
+            $path
+        ))->run($info['name']);
+
+        $output->writeln($formatter->formatSection(
+            'Table of Contents',
+            'Wrote table of contents data.' . PHP_EOL
+        ));
+
+        $output->writeln($formatter->formatSection(
+            'Composer',
+            'The following questions allow us to properly configure the new component ' .
+            'for use with PHP\'s package manager, Composer.'
+        ));
+
+        (new Composer(
+            $this->getHelper('question'),
+            $input,
+            $output,
+            $this->cliBasePath,
+            $path,
+            $info
+        ))->run();
+
+        $output->writeln($formatter->formatSection(
+            'Docs Manifest',
+            'Finally, we need to configure the manifest for the documentation site.'
+        ));
+
+        (new Manifest(
+            $this->getHelper('question'),
+            $input,
+            $output,
+            $this->cliBasePath,
+            $path,
+            $info
+        ))->run();
+
+        $output->writeln('');
+        $output->writeln('');
+        $output->writeln('Success!');
+    }
+
+    protected function questionHelper()
+    {
+        return $this->getHelper('question');
+    }
+
+    protected function input()
+    {
+        return $this->input;
+    }
+
+    protected function output()
+    {
+        return $this->output;
+    }
+}

--- a/dev/src/AddComponent/ComponentTypeTrait.php
+++ b/dev/src/AddComponent/ComponentTypeTrait.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\AddComponent;
+
+/**
+ * Trait for choosing component type.
+ */
+trait ComponentTypeTrait
+{
+    private $types = [
+        'gapic' => 'Generated Client only',
+        'veneer' => 'Handwritten veneer only',
+        'gapic-grpc' => 'Both generated and handwritten, but only generated supports gRPC',
+        'both-grpc' => 'Both generated and handwritten, and both clients support gRPC'
+    ];
+
+    private function getComponentTypesListValues()
+    {
+        return array_values($this->types);
+    }
+
+    private function getComponentTypeKey($value)
+    {
+        return array_search($value, $this->types);
+    }
+
+    private function getComponentTypeValue($key)
+    {
+        return $this->types[$key];
+    }
+}

--- a/dev/src/AddComponent/Composer.php
+++ b/dev/src/AddComponent/Composer.php
@@ -135,9 +135,10 @@ class Composer
             'Gapic-only clients should leave this blank.'
         );
 
+        $path = 'src/' . trim(explode('src', $this->path)[1], '/');
         $composer['extra']['component'] = [
             'id' => $this->info['name'],
-            'path' => $this->path,
+            'path' => $path,
             'entry' => $entry ?: null,
             'target' => $target
         ];
@@ -167,7 +168,7 @@ class Composer
 
         file_put_contents(
             $this->path .'/composer.json',
-            json_encode($composer, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES)
+            json_encode($composer, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES) . PHP_EOL
         );
     }
 

--- a/dev/src/AddComponent/Composer.php
+++ b/dev/src/AddComponent/Composer.php
@@ -71,6 +71,15 @@ class Composer
         'google/gax'
     ];
 
+    /**
+     * @var array
+     */
+    private $defaultSuggests = [
+        'ext-grpc' => 'Enables use of gRPC, a universal high-performance RPC framework created by Google.',
+        'ext-protobuf' => 'Provides a significant increase in throughput over the pure PHP ' .
+            'protobuf implementation. See https://cloud.google.com/php/grpc for installation instructions.'
+    ];
+
     public function __construct(
         QuestionHelper $questionHelper,
         InputInterface $input,
@@ -165,6 +174,23 @@ class Composer
                 $composer['require'][$dep] = $version;
             }
         } while ($hasMoreDependencies);
+
+        foreach ($this->defaultSuggests as $dep => $val) {
+            if (array_key_exists($dep, $composer['require'])) {
+                continue;
+            }
+
+            $confirm = $this->confirm(sprintf('Should `%s` be suggested?', $dep));
+            if (!$this->askQuestion($confirm)) {
+                continue;
+            }
+
+            if (!isset($composer['suggest'])) {
+                $composer['suggest'] = [];
+            }
+
+            $composer['suggest'][$dep] = $this->defaultSuggests[$dep];
+        }
 
         file_put_contents(
             $this->path .'/composer.json',

--- a/dev/src/AddComponent/Composer.php
+++ b/dev/src/AddComponent/Composer.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\AddComponent;
+
+use GuzzleHttp\Client;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use vierbergenlars\SemVer\SemVerException;
+use vierbergenlars\SemVer\version;
+
+/**
+ * Creates and manages composer files.
+ */
+class Composer
+{
+    use PathTrait;
+    use QuestionTrait;
+
+    /**
+     * @var QuestionHelper
+     */
+    private $questionHelper;
+
+    /**
+     * @var InputInterface
+     */
+    private $input;
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var string
+     */
+    private $cliBasePath;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var array
+     */
+    private $info;
+
+    /**
+     * @var array
+     */
+    private $defaultDeps = [
+        'ext-grpc',
+        'google/proto-client',
+        'google/gax'
+    ];
+
+    public function __construct(
+        QuestionHelper $questionHelper,
+        InputInterface $input,
+        OutputInterface $output,
+        $cliBasePath,
+        $path,
+        array $info
+    ) {
+        $this->questionHelper = $questionHelper;
+        $this->input = $input;
+        $this->output = $output;
+        $this->cliBasePath = $cliBasePath;
+        $this->path = $path;
+        $this->info = $info;
+    }
+
+    public function run()
+    {
+        $this->updateMainComposer();
+        $this->createComponentComposer();
+        // update /composer.json "replaces"
+        // create /src/<pkg>/composer.json
+    }
+
+    private function updateMainComposer()
+    {
+        $path = $this->cliBasePath .'/../composer.json';
+        $composer = json_decode(file_get_contents($path), true);
+        $composer['replace']['google/'. $this->info['name']] = 'master';
+        ksort($composer['replace']);
+
+        file_put_contents($path, json_encode($composer, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
+    }
+
+    private function createComponentComposer()
+    {
+        $composer = [];
+        $composer['name'] = 'google/'. $this->info['name'];
+        $composer['description'] = $this->ask(
+            'Enter a description for this component.',
+            $this->info['display'] .' Client for PHP'
+        );
+        $composer['license'] = 'Apache-2.0';
+        $composer['minimum-stability'] = 'stable';
+
+        $parts = explode('/', $this->path);
+        $last = array_pop($parts);
+        $namespace = $this->ask(
+            'Enter the component base namespace, relative to `Google\\Cloud\\`.',
+            $last
+        );
+        $composer['autoload']['psr-4'] = [
+            'Google\\Cloud\\' . $namespace .'\\' => ''
+        ];
+
+        $path = $this->ask(
+            'Enter the path to the component root, relative to the google-cloud-php repository root.',
+            'src' . explode('src', realpath($this->path))[1]
+        );
+
+        $target = $this->ask(
+            'Enter the remote repository target, relative to the hostname. ' .
+            'For `git@github.com:foo/bar.git`, enter `foo/bar.git`.',
+            'GoogleCloudPlatform/google-cloud-'. str_replace('cloud-', '', $this->info['name']) .'.git'
+        );
+
+        $entry = $this->ask(
+            'Enter the entry service for the component, relative to the folder. ' .
+            'For instance, for path `src/Foo/FooClient.php`, enter `FooClient.php`. ' .
+            'Gapic-only clients should leave this blank.'
+        );
+
+        $composer['extra']['component'] = [
+            'id' => $this->info['name'],
+            'path' => $path,
+            'entry' => $entry ?: null,
+            'target' => $target
+        ];
+
+        foreach ($this->defaultDeps as $dep) {
+            $confirm = $this->confirm(sprintf('Should `%s` be required?', $dep));
+            if (!$this->askQuestion($confirm)) {
+                continue;
+            }
+
+            $version = $this->askForVersion($dep);
+
+            $composer['require'][$dep] = $version;
+        }
+
+        $hasMoreDependencies = true;
+        do {
+            $dep = $this->ask('Enter the next dependency name, or leave blank if done.');
+            if (!$dep) {
+                $hasMoreDependencies = false;
+            } else {
+                $version = $this->askForVersion($dep);
+
+                $composer['require'][$dep] = $version;
+            }
+        } while ($hasMoreDependencies);
+
+        file_put_contents(
+            $this->path .'/composer.json',
+            json_encode($composer, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    private function askForVersion($dep)
+    {
+        if (strpos($dep, 'ext-') !== false) {
+            $defaultVersion = '*';
+        } else {
+            $defaultVersion = $this->getLatestVersion($dep);
+        }
+
+        return $this->ask('Enter the version to require', $defaultVersion);
+    }
+
+    private function getLatestVersion($dep)
+    {
+        $client = new Client;
+        $uri = 'https://packagist.org/packages/'. $dep .'.json';
+        $pkg = $client->request('GET', $uri);
+
+        $versions = json_decode($pkg->getBody(), true)['package']['versions'];
+        $def = null;
+        foreach (array_keys($versions) as $v) {
+            if (strpos($v, 'dev-') !== false) {
+                continue;
+            }
+
+            try {
+                $version = new version($v);
+            } catch (SemVerException $e) {
+                continue;
+            }
+
+            $def = sprintf(
+                '^%d.%d.0',
+                $version->getMajor(),
+                $version->getMinor()
+            );
+
+            break;
+        }
+
+        return $def;
+    }
+
+    protected function questionHelper()
+    {
+        return $this->questionHelper;
+    }
+
+    protected function input()
+    {
+        return $this->input;
+    }
+
+    protected function output()
+    {
+        return $this->output;
+    }
+}

--- a/dev/src/AddComponent/Composer.php
+++ b/dev/src/AddComponent/Composer.php
@@ -76,14 +76,13 @@ class Composer
         InputInterface $input,
         OutputInterface $output,
         $cliBasePath,
-        $path,
         array $info
     ) {
         $this->questionHelper = $questionHelper;
         $this->input = $input;
         $this->output = $output;
         $this->cliBasePath = $cliBasePath;
-        $this->path = $path;
+        $this->path = $info['path'];
         $this->info = $info;
     }
 
@@ -91,8 +90,6 @@ class Composer
     {
         $this->updateMainComposer();
         $this->createComponentComposer();
-        // update /composer.json "replaces"
-        // create /src/<pkg>/composer.json
     }
 
     private function updateMainComposer()
@@ -126,15 +123,10 @@ class Composer
             'Google\\Cloud\\' . $namespace .'\\' => ''
         ];
 
-        $path = $this->ask(
-            'Enter the path to the component root, relative to the google-cloud-php repository root.',
-            'src' . explode('src', realpath($this->path))[1]
-        );
-
         $target = $this->ask(
             'Enter the remote repository target, relative to the hostname. ' .
             'For `git@github.com:foo/bar.git`, enter `foo/bar.git`.',
-            'GoogleCloudPlatform/google-cloud-'. str_replace('cloud-', '', $this->info['name']) .'.git'
+            'GoogleCloudPlatform/google-cloud-php-'. str_replace('cloud-', '', $this->info['name']) .'.git'
         );
 
         $entry = $this->ask(
@@ -145,7 +137,7 @@ class Composer
 
         $composer['extra']['component'] = [
             'id' => $this->info['name'],
-            'path' => $path,
+            'path' => $this->path,
             'entry' => $entry ?: null,
             'target' => $target
         ];

--- a/dev/src/AddComponent/Contributing.php
+++ b/dev/src/AddComponent/Contributing.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\AddComponent;
+
+/**
+ * Create contributing file.
+ */
+class Contributing
+{
+    const CONTRIBUTING_TPL = 'template-CONTRIBUTING.md.txt';
+
+    /**
+     * @var string
+     */
+    private $cliBasePath;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+
+    public function __construct($cliBasePath, $path)
+    {
+        $this->cliBasePath = $cliBasePath;
+        $this->path = $path;
+    }
+
+    public function run()
+    {
+        $source = $this->cliBasePath . '/src/AddComponent/templates/' . self::CONTRIBUTING_TPL;
+        $dest = $this->path .'/CONTRIBUTING.md';
+
+        copy($source, $dest);
+    }
+}

--- a/dev/src/AddComponent/Info.php
+++ b/dev/src/AddComponent/Info.php
@@ -28,6 +28,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class Info
 {
+    use ComponentTypeTrait;
     use QuestionTrait;
 
     /**
@@ -107,6 +108,21 @@ class Info
 
         $info['path'] = $this->askQuestion($q);
 
+        $defaultType = $this->getComponentTypeValue('gapic');
+        $q = $this->choice(
+            'What type of component is this?',
+            $this->getComponentTypesListValues(),
+            $defaultType
+        )->setValidator($this->validators([
+            $this->defaultChoice($defaultType),
+            $this->preventEmpty(),
+            $this->removeDefaultNotice($defaultType),
+            function ($answer) {
+                return $this->getComponentTypeKey($answer);
+            }
+        ]));
+        $info['type'] = $this->askQuestion($q);
+
         $this->output->writeln('Confirm entered data');
         foreach ($info as $key => $val) {
             $this->output->writeln(sprintf('<info>%s</info>: %s', $key, $val));
@@ -132,7 +148,7 @@ class Info
             $description,
             $default
         )->setValidator($this->validators([
-            [$this, 'preventEmpty'],
+            $this->preventEmpty(),
             function ($answer) use ($default) {
                 if ($answer === $default) {
                     return $answer;
@@ -186,7 +202,7 @@ class Info
         $q = $this->question(
             'Please enter the component short name. Examples include bigquery, datastore, spanner.'
         )->setValidator($this->validators([
-            [$this, 'preventEmpty']
+            $this->preventEmpty()
         ]));
 
         return $this->askQuestion($q);
@@ -219,7 +235,7 @@ class Info
             'Please enter the component name, omitting the vendor',
             'cloud-'. $info['shortName']
         )->setValidator($this->validators([
-            [$this, 'preventEmpty'],
+            $this->preventEmpty(),
             $validator
         ]));
 

--- a/dev/src/AddComponent/Info.php
+++ b/dev/src/AddComponent/Info.php
@@ -133,7 +133,13 @@ class Info
             $default
         )->setValidator($this->validators([
             [$this, 'preventEmpty'],
-            [$this, 'uriValidate']
+            function ($answer) use ($default) {
+                if ($answer === $default) {
+                    return $answer;
+                }
+
+                return $this->uriValidate($answer);
+            }
         ]));
 
         return $this->askQuestion($q);

--- a/dev/src/AddComponent/Info.php
+++ b/dev/src/AddComponent/Info.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\AddComponent;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Collect basic component information
+ */
+class Info
+{
+    use QuestionTrait;
+
+    /**
+     * @var QuestionHelper
+     */
+    private $questionHelper;
+
+    /**
+     * @var InputInterface
+     */
+    private $input;
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var string
+     */
+    private $cliBasePath;
+
+    public function __construct(
+        QuestionHelper $questionHelper,
+        InputInterface $input,
+        OutputInterface $output,
+        $cliBasePath
+    ) {
+        $this->questionHelper = $questionHelper;
+        $this->input = $input;
+        $this->output = $output;
+        $this->cliBasePath = $cliBasePath;
+    }
+
+    public function run()
+    {
+        $info = [];
+
+        $info['shortName'] = $this->askShortName();
+
+        $info['name'] = $this->askComponentName($info);
+
+        $info['display'] = $this->askDisplayName($info);
+
+        $info['cloudPage'] = $this->askCloudPage(
+            'Please enter the URI of the service homepage',
+            sprintf('https://cloud.google.com/%s', $info['shortName']),
+            $info
+        );
+
+        $default = $info['cloudPage'] . '/docs';
+        $default = explode('://', $default);
+        $default[1] = str_replace('//', '/', $default[1]);
+
+        $info['docsPage'] = $this->askCloudPage(
+            'Please enter the URI of the documentation homepage',
+             $default[0] . '://' . $default[1],
+            $info
+        );
+
+        $default = str_replace(' ', '', ucwords(str_replace('-', ' ', $info['shortName'])));
+        $base = $this->cliBasePath . '/../src/';
+        $q = $this->question(
+            'Please enter the directory name, relative to `src/`, where the component is found. Be sure to verify correct casing.',
+            $default
+        )->setValidator(function ($answer) use ($base) {
+            $path = realpath($base . $answer);
+
+            if (!is_dir($path)) {
+                throw new \RuntimeException(
+                    $path .' does not exist or is not a folder.'
+                );
+            }
+
+            return $path;
+        });
+
+        $info['path'] = $this->askQuestion($q);
+
+        $this->output->writeln('Confirm entered data');
+        foreach ($info as $key => $val) {
+            $this->output->writeln(sprintf('<info>%s</info>: %s', $key, $val));
+        }
+
+        if (!$this->askQuestion($this->confirm('Does everything look correct? Choosing no will restart the wizard.'))) {
+            return $this->run();
+        }
+
+        return $info;
+    }
+
+    private function askCloudPage($description, $default, array $info)
+    {
+        $default = $this->validUri($default)
+            ? $default
+            : null;
+
+        if (!$default) {
+            $description = $description . ' (could not determine a valid default)';
+        }
+        $q = $this->question(
+            $description,
+            $default
+        )->setValidator($this->validators([
+            [$this, 'preventEmpty'],
+            [$this, 'uriValidate']
+        ]));
+
+        return $this->askQuestion($q);
+    }
+
+    private function uriValidate($answer)
+    {
+        if (strpos($answer, '://') === false) {
+            $answer = 'https://'. $answer;
+        }
+
+        if (strpos($answer, 'http://') !== false) {
+            $confirm = $this->confirm('You entered http as the protocol. Should we change this to https?');
+
+            if ($this->askQuestion($confirm)) {
+                $answer = str_replace('http://', 'https://', $answer);
+            }
+        }
+
+        $confirm = $this->confirm('The URI you entered returned a non-200 status code. Would you like to re-enter a different URI?');
+        if (!$this->validUri($answer) && $this->askQuestion($confirm)) {
+            throw new \RuntimeException('Re-enter a new URI');
+        }
+
+        return $answer;
+    }
+
+    private function validUri($uri)
+    {
+        $client = new Client;
+        try {
+            $res = $client->get($uri);
+        } catch (RequestException $e) {
+            return false;
+        } catch (\Exception $e) {
+            return true;
+        }
+
+        return true;
+    }
+
+    private function askShortName()
+    {
+        $q = $this->question(
+            'Please enter the component short name. Examples include bigquery, datastore, spanner.'
+        )->setValidator($this->validators([
+            [$this, 'preventEmpty']
+        ]));
+
+        return $this->askQuestion($q);
+    }
+
+    private function askComponentName(array $info)
+    {
+        $validator = function ($answer) {
+            $answer = trim($answer);
+
+            if (strpos($answer, 'google/') === 0) {
+                $answer = str_replace('google/', '', $answer);
+            }
+
+            if (strpos($answer, 'cloud-') !== 0) {
+                $confirm = $this->confirm(
+                    'You entered a non-standard name. Standard name convention is `cloud-<name>`. Accept non-standard name?',
+                    false
+                );
+
+                if (!$this->askQuestion($confirm)) {
+                    throw new \RuntimeException('Re-enter a valid name');
+                }
+            }
+
+            return $answer;
+        };
+
+        $q = $this->question(
+            'Please enter the component name, omitting the vendor',
+            'cloud-'. $info['shortName']
+        )->setValidator($this->validators([
+            [$this, 'preventEmpty'],
+            $validator
+        ]));
+
+        return $this->askQuestion($q);
+    }
+
+    private function askDisplayName(array $info)
+    {
+        $name = 'Google '. ucwords(str_replace('-', ' ', $info['name']));
+
+
+        return $this->ask(
+            'Please enter the component display name',
+            $name
+        );
+    }
+
+    protected function questionHelper()
+    {
+        return $this->questionHelper;
+    }
+
+    protected function input()
+    {
+        return $this->input;
+    }
+
+    protected function output()
+    {
+        return $this->output;
+    }
+}

--- a/dev/src/AddComponent/License.php
+++ b/dev/src/AddComponent/License.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\AddComponent;
+
+/**
+ * Create license file.
+ */
+class License
+{
+    /**
+     * @var string
+     */
+    private $cliBasePath;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+
+    public function __construct($cliBasePath, $path)
+    {
+        $this->cliBasePath = $cliBasePath;
+        $this->path = $path;
+    }
+
+    public function run()
+    {
+        $source = $this->cliBasePath .'/../LICENSE';
+        $dest = $this->path .'/LICENSE';
+
+        copy($source, $dest);
+    }
+}

--- a/dev/src/AddComponent/Manifest.php
+++ b/dev/src/AddComponent/Manifest.php
@@ -73,14 +73,13 @@ class Manifest
         InputInterface $input,
         OutputInterface $output,
         $cliBasePath,
-        $path,
         array $info
     ) {
         $this->questionHelper = $questionHelper;
         $this->input = $input;
         $this->output = $output;
         $this->cliBasePath = $cliBasePath;
-        $this->path = $path;
+        $this->path = $info['path'];
         $this->info = $info;
     }
 

--- a/dev/src/AddComponent/Manifest.php
+++ b/dev/src/AddComponent/Manifest.php
@@ -146,7 +146,7 @@ class Manifest
 
         $manifest['modules'] = $modules;
 
-        file_put_contents($path, json_encode($manifest, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
+        file_put_contents($path, json_encode($manifest, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES) . PHP_EOL);
     }
 
     protected function questionHelper()

--- a/dev/src/AddComponent/Manifest.php
+++ b/dev/src/AddComponent/Manifest.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\AddComponent;
+
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Configure the docs manifest
+ */
+class Manifest
+{
+    use PathTrait;
+    use QuestionTrait;
+
+    /**
+     * @var QuestionHelper
+     */
+    private $questionHelper;
+
+    /**
+     * @var InputInterface
+     */
+    private $input;
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var string
+     */
+    private $cliBasePath;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var array
+     */
+    private $info;
+
+    /**
+     * @var array
+     */
+    private $defaultDeps = [
+        'ext-grpc',
+        'google/proto-client',
+        'google/gax'
+    ];
+
+    public function __construct(
+        QuestionHelper $questionHelper,
+        InputInterface $input,
+        OutputInterface $output,
+        $cliBasePath,
+        $path,
+        array $info
+    ) {
+        $this->questionHelper = $questionHelper;
+        $this->input = $input;
+        $this->output = $output;
+        $this->cliBasePath = $cliBasePath;
+        $this->path = $path;
+        $this->info = $info;
+    }
+
+    public function run()
+    {
+        $path = $this->cliBasePath .'/../docs/manifest.json';
+        $manifest = json_decode(file_get_contents($path), true);
+
+        $modules = $manifest['modules'];
+        $matches = array_filter($modules, function ($module) {
+            return $module['id'] === $this->info['name'];
+        });
+
+        if ($matches) {
+            $continue = $this->ask(sprintf(
+                'The component %s alreay exists in the manifest. Continuing will overwrite. Enter "continue" to continue.',
+                $this->info['name']
+            ));
+
+            if (strtolower($continue) !== 'continue') {
+                $this->output->writeln('skipping further work in docs manifest.');
+                return;
+            } else {
+                unset($modules[array_keys($matches)[0]]);
+            }
+        }
+        $q = $this->question(
+            'Enter the default service. For handwritten clients, this will be the client entry point. ' .
+            'For instance, if the service is `Foo/FooClient.php`, enter `FooClient.php`. ' .
+            'For Gapic-only clients, the default service is generally the README file.',
+            'README.md'
+        )->setValidator(function ($answer) {
+            if (!file_exists($this->path .'/'. $answer)) {
+                throw new \RuntimeException('file does not exist');
+            }
+
+            $pathParts = explode('/', $this->path);
+            $last = array_pop($pathParts);
+
+            $answerParts = explode('.', $answer);
+            array_pop($answerParts);
+            return strtolower($last .'/'. implode('.', $answerParts));
+        });
+
+        $defaultService = $this->askQuestion($q);
+
+        $manifestEntry = [
+            'id' => $this->info['name'],
+            'name' => 'google/'. $this->info['name'],
+            'defaultService' => $defaultService,
+            'versions' => ['master']
+        ];
+
+        $modules[] = $manifestEntry;
+
+        $main = $modules[0];
+        unset($modules[0]);
+
+        usort($modules, function ($item1, $item2) {
+            return strcmp($item1['id'], $item2['id']);
+        });
+
+        array_unshift($modules, $main);
+
+        $manifest['modules'] = $modules;
+
+        file_put_contents($path, json_encode($manifest, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
+    }
+
+    protected function questionHelper()
+    {
+        return $this->questionHelper;
+    }
+
+    protected function input()
+    {
+        return $this->input;
+    }
+
+    protected function output()
+    {
+        return $this->output;
+    }
+}

--- a/dev/src/AddComponent/PathTrait.php
+++ b/dev/src/AddComponent/PathTrait.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\AddComponent;
+
+/**
+ * Methods for dealing with paths and directories.
+ */
+trait PathTrait
+{
+    private $GAPIC_PATH_REGEX = '/[vV]\d{0,}/';
+
+    private function pathIsGapic($path)
+    {
+        $parts = explode('/', $path);
+        $last = array_pop($parts);
+        return preg_match($this->GAPIC_PATH_REGEX, $last) === 1;
+    }
+
+    private function scanDirectory($path, array $excludes = [])
+    {
+        $excludes = ['..', '.', '.DS_Store', 'VERSION', 'LICENSE'] + $excludes;
+        return array_diff(scandir($path), $excludes);
+    }
+}

--- a/dev/src/AddComponent/PathTrait.php
+++ b/dev/src/AddComponent/PathTrait.php
@@ -33,7 +33,7 @@ trait PathTrait
 
     private function scanDirectory($path, array $excludes = [])
     {
-        $excludes = ['..', '.', '.DS_Store', 'VERSION', 'LICENSE'] + $excludes;
+        $excludes = ['..', '.', '.DS_Store', 'VERSION', 'LICENSE', 'CONTRIBUTING.md'] + $excludes;
         return array_diff(scandir($path), $excludes);
     }
 }

--- a/dev/src/AddComponent/QuestionTrait.php
+++ b/dev/src/AddComponent/QuestionTrait.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\AddComponent;
+
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * Helpers for asking questions
+ */
+trait QuestionTrait
+{
+    protected abstract function questionHelper();
+    protected abstract function input();
+    protected abstract function output();
+
+    private function ask($question, $default = null)
+    {
+        $question = $this->question($question, $default);
+        return $this->askQuestion($question);
+    }
+
+    private function askQuestion(Question $question)
+    {
+        return $this->questionHelper()->ask(
+            $this->input(),
+            $this->output(),
+            $question
+        );
+    }
+
+    private function question($question, $default = null)
+    {
+        if ($default) {
+            $question = $question . ' (leave blank for '. $default .')';
+        }
+
+        return new Question(
+            $question . PHP_EOL,
+            $default
+        );
+    }
+
+    private function choice($question, array $options)
+    {
+        return new ChoiceQuestion($question, $options);
+    }
+
+    private function confirm($question)
+    {
+        return new ConfirmationQuestion($question .' (y/n)' . PHP_EOL);
+    }
+}

--- a/dev/src/AddComponent/QuestionTrait.php
+++ b/dev/src/AddComponent/QuestionTrait.php
@@ -62,8 +62,33 @@ trait QuestionTrait
         return new ChoiceQuestion($question, $options);
     }
 
-    private function confirm($question)
+    private function confirm($question, $defaultToYes = true)
     {
-        return new ConfirmationQuestion($question .' (y/n)' . PHP_EOL);
+        $choices = implode('/', [
+            ($defaultToYes) ? 'y [default]' : 'y',
+            (!$defaultToYes) ? 'n [default]' : 'n',
+        ]);
+
+        return new ConfirmationQuestion($question . ' (' . $choices .')' . PHP_EOL, $defaultToYes);
+    }
+
+    private function validators(array $callables)
+    {
+        return function ($answer) use ($callables) {
+            foreach ($callables as $callable) {
+                $answer = call_user_func($callable, $answer);
+            }
+
+            return $answer;
+        };
+    }
+
+    private function preventEmpty($answer)
+    {
+        if (empty($answer)) {
+            throw new \RuntimeException('Answer cannot be blank.');
+        }
+
+        return $answer;
     }
 }

--- a/dev/src/AddComponent/QuestionTrait.php
+++ b/dev/src/AddComponent/QuestionTrait.php
@@ -85,7 +85,7 @@ trait QuestionTrait
 
     private function preventEmpty($answer)
     {
-        if (empty($answer)) {
+        if (empty($answer) && $answer !== 0 && $answer !== '0') {
             throw new \RuntimeException('Answer cannot be blank.');
         }
 

--- a/dev/src/AddComponent/Readmes.php
+++ b/dev/src/AddComponent/Readmes.php
@@ -89,11 +89,13 @@ class Readmes
         $files = $this->scanDirectory($path);
         if (!in_array('README.md', $files)) {
             $questionText = sprintf('%s '. PHP_EOL .'Create README.md?', $path);
+            $suggest = true;
             if (strpos($path, 'Gapic') !== false || strpos($path, 'resources') !== false) {
+                $suggest = false;
                 $questionText = $questionText . self::SUGGESTION_TEXT;
             }
 
-            $q = $this->confirm($questionText);
+            $q = $this->confirm($questionText, $suggest);
             $create = $this->askQuestion($q);
 
             if ($create) {

--- a/dev/src/AddComponent/Readmes.php
+++ b/dev/src/AddComponent/Readmes.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\AddComponent;
+
+use Google\Cloud\Dev\AddComponent\Command\AddComponent;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Write README files for the component.
+ */
+class Readmes
+{
+    const README_TPL = 'template-README.md.txt';
+    const SUGGESTION_TEXT = ' (skip suggested based on path name)';
+
+    use PathTrait;
+    use QuestionTrait;
+
+    /**
+     * @var QuestionHelper
+     */
+    private $questionHelper;
+
+    /**
+     * @var InputInterface
+     */
+    private $input;
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var string
+     */
+    private $cliBasePath;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var array
+     */
+    private $info;
+
+    /**
+     * @var string
+     */
+    private $templatesPath;
+
+    public function __construct(
+        QuestionHelper $questionHelper,
+        InputInterface $input,
+        OutputInterface $output,
+        $cliBasePath,
+        $path,
+        array $info
+    ) {
+        $this->questionHelper = $questionHelper;
+        $this->input = $input;
+        $this->output = $output;
+        $this->cliBasePath = $cliBasePath;
+        $this->path = $path;
+        $this->info = $info;
+
+        $this->templatesPath = $this->cliBasePath .'/src/AddComponent/templates';
+    }
+
+    public function run()
+    {
+        $this->createReadmes($this->path);
+    }
+
+    private function createReadmes($path)
+    {
+        $files = $this->scanDirectory($path);
+        if (!in_array('README.md', $files)) {
+            $questionText = sprintf('%s '. PHP_EOL .'Create README.md?', realpath($path));
+            if (strpos($path, 'Gapic') !== false || strpos($path, 'resources') !== false) {
+                $questionText = $questionText . self::SUGGESTION_TEXT;
+            }
+
+            $q = $this->confirm($questionText);
+            $create = $this->askQuestion($q);
+
+            if ($create) {
+                $file = $path .'/README.md';
+                $content = file_get_contents($this->templatesPath .'/'. self::README_TPL);
+                $content = str_replace('{display}', $this->info['display'], $content);
+                $content = str_replace('{homepage}', $this->info['cloudPage'], $content);
+                $content = str_replace('{name}', $this->info['name'], $content);
+                $content = str_replace('{client}', 'readme', $content);
+
+                file_put_contents($file, $content);
+            }
+        }
+
+        foreach ($files as $file) {
+            $file = $path .'/'. $file;
+            if (is_dir($file)) {
+                $this->createReadmes($file);
+            }
+        }
+    }
+
+    protected function questionHelper()
+    {
+        return $this->questionHelper;
+    }
+
+    protected function input()
+    {
+        return $this->input;
+    }
+
+    protected function output()
+    {
+        return $this->output;
+    }
+}

--- a/dev/src/AddComponent/Readmes.php
+++ b/dev/src/AddComponent/Readmes.php
@@ -28,6 +28,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Readmes
 {
     const README_TPL = 'template-README.md.txt';
+    const GRPC_NOTICE_TPL = 'template-README.md-%s.txt';
     const SUGGESTION_TEXT = ' (skip suggested based on path name)';
 
     use PathTrait;
@@ -101,6 +102,10 @@ class Readmes
             if ($create) {
                 $file = $path .'/README.md';
                 $content = file_get_contents($this->templatesPath .'/'. self::README_TPL);
+
+                $content = str_replace('{notice}', file_get_contents(
+                    $this->templatesPath .'/'. sprintf(self::GRPC_NOTICE_TPL, $this->info['type'])
+                ), $content);
                 $content = str_replace('{display}', $this->info['display'], $content);
                 $content = str_replace('{homepage}', $this->info['cloudPage'], $content);
                 $content = str_replace('{name}', $this->info['name'], $content);

--- a/dev/src/AddComponent/Readmes.php
+++ b/dev/src/AddComponent/Readmes.php
@@ -54,11 +54,6 @@ class Readmes
     private $cliBasePath;
 
     /**
-     * @var string
-     */
-    private $path;
-
-    /**
      * @var array
      */
     private $info;
@@ -73,14 +68,12 @@ class Readmes
         InputInterface $input,
         OutputInterface $output,
         $cliBasePath,
-        $path,
         array $info
     ) {
         $this->questionHelper = $questionHelper;
         $this->input = $input;
         $this->output = $output;
         $this->cliBasePath = $cliBasePath;
-        $this->path = $path;
         $this->info = $info;
 
         $this->templatesPath = $this->cliBasePath .'/src/AddComponent/templates';
@@ -88,14 +81,14 @@ class Readmes
 
     public function run()
     {
-        $this->createReadmes($this->path);
+        $this->createReadmes($this->info['path']);
     }
 
     private function createReadmes($path)
     {
         $files = $this->scanDirectory($path);
         if (!in_array('README.md', $files)) {
-            $questionText = sprintf('%s '. PHP_EOL .'Create README.md?', realpath($path));
+            $questionText = sprintf('%s '. PHP_EOL .'Create README.md?', $path);
             if (strpos($path, 'Gapic') !== false || strpos($path, 'resources') !== false) {
                 $questionText = $questionText . self::SUGGESTION_TEXT;
             }

--- a/dev/src/AddComponent/TableOfContents.php
+++ b/dev/src/AddComponent/TableOfContents.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\AddComponent;
+
+use Symfony\Component\Console\Helper\FormatterHelper;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Generate a Table of Contents
+ */
+class TableOfContents
+{
+    const SUGGESTION_TEXT = ' (suggested based on path name)';
+    const TOC_PATH = 'docs/contents';
+
+    use PathTrait;
+    use QuestionTrait;
+
+    /**
+     * @var OutputFormatterInterface
+     */
+    private $formatter;
+
+    /**
+     * @var QuestionHelper
+     */
+    private $questionHelper;
+
+    /**
+     * @var InputInterface
+     */
+    private $input;
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var string
+     */
+    private $cliBasePath;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    public function __construct(
+        FormatterHelper $formatter,
+        QuestionHelper $questionHelper,
+        InputInterface $input,
+        OutputInterface $output,
+        $cliBasePath,
+        $path
+    ) {
+        $this->formatter = $formatter;
+        $this->questionHelper = $questionHelper;
+        $this->input = $input;
+        $this->output = $output;
+        $this->cliBasePath = $cliBasePath;
+        $this->path = $path;
+    }
+
+    public function run($name)
+    {
+        $toc = $this->buildToc($this->path, false, true);
+        $this->writeToc($name, $toc);
+
+        $this->addToIncludes($name);
+    }
+
+    private function buildToc($path, $main = false, $isTopLevel = false)
+    {
+        $this->output->writeln($this->formatter->formatSection(
+            'Table of Contents',
+            sprintf('Working in directory `%s`', realpath($path)) . PHP_EOL
+        ));
+
+        $files = $this->scanDirectory($path);
+
+        if (!$main) {
+            $skipText = 'skip directory';
+
+            if (strpos($path, 'Gapic') !== false || strpos($path, 'resources') !== false) {
+                $skipText = $skipText . self::SUGGESTION_TEXT;
+            }
+
+            $choices = array_values($files);
+            $choices[] = $skipText;
+
+            if ($this->pathIsGapic($path)) {
+                foreach ($choices as &$choice) {
+                    if ($choice === 'README.md') {
+                        $choice = 'README.md' . self::SUGGESTION_TEXT;
+                    }
+                }
+            }
+
+            $q = $this->choice('Please select the main service.', $choices)
+                ->setValidator(function ($answer) use ($choices) {
+                    if (!array_key_exists((int)$answer, $choices)) {
+                        throw new \RuntimeException('Invalid selection.');
+                    }
+
+                    $answer = $choices[$answer];
+                    if ($answer === 'README.md' . self::SUGGESTION_TEXT) {
+                        $answer = 'README.md';
+                    }
+
+                    return $answer;
+                });
+
+            $main = $this->askQuestion($q);
+            if ($main === $skipText) {
+                return;
+            }
+
+            $i = array_search($main, $files);
+            unset($files[$i]);
+        }
+
+        $services = [];
+        $main = $this->buildSingleTocEntry(new \SplFileInfo($main), $path, true);
+
+        if ($isTopLevel) {
+            $services[] = [
+                'title' => 'Overview',
+                'type' => $main['type']
+            ];
+
+            unset($main['type']);
+        }
+
+        $i = array_search('README.md', $files);
+        unset($files[$i]);
+
+        $i = array_search($main, $files);
+        unset($files[$i]);
+
+        foreach ($files as $file) {
+            $service = $this->buildSingleTocEntry(new \SplFileInfo($file), $path);
+            if (!empty($service)) {
+                $services[] = $service;
+            }
+        }
+
+        if ($isTopLevel) {
+            $parent = explode('/', $services[0]['type']);
+        } else {
+            $parent = explode('/', $main['type']);
+        }
+
+        array_pop($parent);
+        $parent = implode('/', $parent);
+
+        if ($isTopLevel) {
+            $main['services'] = $services;
+        } else {
+            $main['nav'] = $services;
+        }
+
+        $pattern = $parent .'/\w{1,}';
+        if ($isTopLevel) {
+            $main['pattern'] = $pattern;
+        } else {
+            $main['patterns'] = [$pattern];
+        }
+
+        return $main;
+    }
+
+    private function buildSingleTocEntry(\SplFileInfo $file, $path, $isMain = false)
+    {
+        if (is_dir($path .'/'. $file)) {
+            return $this->buildToc($path .'/'. $file);
+        }
+
+        $file = new \SplFileInfo($file);
+        if (!in_array($file->getExtension(), ['php', 'md'])) {
+            return;
+        }
+
+        $file = trim($file, '/');
+
+        if (!$isMain) {
+            $q = $this->confirm(sprintf('Should %s be included in the table of contents?', $file));
+            $include = $this->askQuestion($q);
+            if (!$include) {
+                return;
+            }
+        }
+
+        $withoutExt = explode('.', $file)[0];
+        $base = trim(explode('src', realpath($path))[1], '/');
+
+        if (strpos($file, 'README.md') !== false) {
+            $parts = explode('/', $path);
+            $last = array_pop($parts);
+
+            if ($this->pathIsGapic($path)) {
+                $last = strtolower($last);
+            }
+            $suggestedTitle = $last;
+        } else {
+            $suggestedTitle = basename($withoutExt);
+        }
+
+        $title = $this->ask('Enter the service title', $suggestedTitle);
+
+        return [
+            'title' => $title,
+            'type' => strtolower($base .'/'. $withoutExt)
+        ];
+    }
+
+    private function writeToc($name, array $toc)
+    {
+        $path = $this->cliBasePath .'/../'. self::TOC_PATH .'/'. $name .'.json';
+        file_put_contents($path, json_encode($toc, JSON_PRETTY_PRINT) . PHP_EOL);
+    }
+
+    private function addToIncludes($name)
+    {
+        $path = $this->cliBasePath .'/../'. self::TOC_PATH .'/google-cloud.json';
+        $toc = json_decode(file_get_contents($path), true);
+        $toc['includes'][] = $name;
+        sort($toc['includes']);
+        $toc['includes'] = array_unique($toc['includes']);
+
+        $this->writeToc('google-cloud', $toc);
+    }
+
+    protected function questionHelper()
+    {
+        return $this->questionHelper;
+    }
+
+    protected function input()
+    {
+        return $this->input;
+    }
+
+    protected function output()
+    {
+        return $this->output;
+    }
+}

--- a/dev/src/AddComponent/TableOfContents.php
+++ b/dev/src/AddComponent/TableOfContents.php
@@ -164,7 +164,7 @@ class TableOfContents
             $q = $this->choice('Please select the main service.', $choices)
                 ->setValidator($this->validators([
                     $setDefault,
-                    [$this, 'preventEmpty'],
+                    $this->preventEmpty(),
                     $validator,
                 ]));
 

--- a/dev/src/AddComponent/templates/template-CONTRIBUTING.md.txt
+++ b/dev/src/AddComponent/templates/template-CONTRIBUTING.md.txt
@@ -1,0 +1,10 @@
+# How to Contribute
+
+We'd love to accept your patches and contributions to this project. We accept
+and review pull requests against the main
+[Google Cloud PHP](https://github.com/GoogleCloudPlatform/google-cloud-php)
+repository, which contains all of our client libraries. You will also need to
+sign a Contributor License Agreement. For more details about how to contribute,
+see the
+[CONTRIBUTING.md](https://github.com/GoogleCloudPlatform/google-cloud-php/blob/master/CONTRIBUTING.md)
+file in the main Google Cloud PHP repository.

--- a/dev/src/AddComponent/templates/template-README.md-both-grpc.txt
+++ b/dev/src/AddComponent/templates/template-README.md-both-grpc.txt
@@ -1,0 +1,4 @@
+
+If gRPC is not installed, this client uses REST over HTTP/1.1. For improved performance, or to make use of the generated clients, we recommend installing the gRPC PHP extension. For installation instructions, [see here](https://cloud.google.com/php/grpc).
+
+NOTE: In addition to the gRPC extension, we recommend installing the protobuf extension for improved performance. For installation instructions, [see here](https://cloud.google.com/php/grpc#install_the_protobuf_runtime_library).

--- a/dev/src/AddComponent/templates/template-README.md-gapic-grpc.txt
+++ b/dev/src/AddComponent/templates/template-README.md-gapic-grpc.txt
@@ -1,0 +1,4 @@
+
+Use of the included generated clients requires installation of the gRPC PHP extension. For instructions, [see here](https://cloud.google.com/php/grpc).
+
+NOTE: In addition to the gRPC extension, we recommend installing the protobuf extension for improved performance. For installation instructions, [see here](https://cloud.google.com/php/grpc#install_the_protobuf_runtime_library).

--- a/dev/src/AddComponent/templates/template-README.md-gapic.txt
+++ b/dev/src/AddComponent/templates/template-README.md-gapic.txt
@@ -1,0 +1,4 @@
+
+If it is not already installed, you will also require the gRPC extension. For installation instructions, [see here](https://cloud.google.com/php/grpc).
+
+NOTE: In addition to the gRPC extension, we recommend installing the protobuf extension for improved performance. For installation instructions, [see here](https://cloud.google.com/php/grpc#install_the_protobuf_runtime_library).

--- a/dev/src/AddComponent/templates/template-README.md.txt
+++ b/dev/src/AddComponent/templates/template-README.md.txt
@@ -1,0 +1,18 @@
+# {display} for PHP
+
+> Idiomatic PHP client for [{display}]({homepage}).
+
+* [Homepage](http://googlecloudplatform.github.io/google-cloud-php)
+* [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/{name}/latest/{client})
+
+**NOTE:** This repository a Read-Only subtree split of
+[Google Cloud PHP](https://github.com/googlecloudplatform/google-cloud-php). Any
+support requests, bug reports, or development contributions should be directed to
+that project. Additional tests and build information can also be found at the
+parent project.
+
+## Installation
+
+```
+$ composer require google/{name}
+```

--- a/dev/src/AddComponent/templates/template-README.md.txt
+++ b/dev/src/AddComponent/templates/template-README.md.txt
@@ -12,7 +12,7 @@
 support requests, bug reports, or development contributions should be directed to
 that project. Additional tests and build information can also be found at the
 parent project.
-
+{notice}
 ## Installation
 
 ```

--- a/dev/src/AddComponent/templates/template-README.md.txt
+++ b/dev/src/AddComponent/templates/template-README.md.txt
@@ -2,6 +2,8 @@
 
 > Idiomatic PHP client for [{display}]({homepage}).
 
+[![Latest Stable Version](https://poser.pugx.org/google/{name}/v/stable)](https://packagist.org/packages/google/{name}) [![Packagist](https://img.shields.io/packagist/dm/google/{name}.svg)](https://packagist.org/packages/google/{name})
+
 * [Homepage](http://googlecloudplatform.github.io/google-cloud-php)
 * [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/{name}/latest/{client})
 


### PR DESCRIPTION
To simplify the process of adding a new component and to make it easier for those not as familiar with the workings of Google Cloud PHP, we're adding an interactive CLI to configure new components.

This CLI is built with the intention of being used for gapic-only clients, but will work with handwritten veneers as well. I've tried to include explanations and suggestions wherever possible to make it as straightforward as possible.

Running it is simple:
```
$ dev/google-cloud component
```

I've created a branch with Bigtable completely uninitialized -- that is, the gapics are present, but no component setup has been done, in order to allow you to try it out. You can find it here: https://github.com/jdpedrie/google-cloud-php/tree/bigtable-uninitialized