### PR TITLE
[Breaking Change] Change return value of FirestoreClient::runTransaction()

### DIFF
--- a/tests/snippets/Firestore/FirestoreClientTest.php
+++ b/tests/snippets/Firestore/FirestoreClientTest.php
@@ -208,7 +208,8 @@ class FirestoreClientTest extends SnippetTestCase
         $snippet = $this->snippetFromMethod(FirestoreClient::class, 'runTransaction');
         $snippet->addLocal('firestore', $this->client);
 
-        $snippet->invoke();
+        $res = $snippet->invoke('toNewBalance');
+        $this->assertEquals(1500.00, $res->returnVal());
     }
 
     public function testGeoPoint()

--- a/tests/unit/Firestore/FirestoreClientTest.php
+++ b/tests/unit/Firestore/FirestoreClientTest.php
@@ -349,9 +349,10 @@ class FirestoreClientTest extends TestCase
             $doc = $this->prophesize(DocumentReference::class);
             $doc->name('foo');
             $t->create($doc->reveal(), ['foo'=>'bar']);
+
+            return 'foo';
         });
-        $this->assertInstanceOf(Timestamp::class, $res['commitTime']);
-        $this->assertEquals($timestamp['seconds'], $res['commitTime']->get()->format('U'));
+        $this->assertEquals('foo', $res);
     }
 
     /**


### PR DESCRIPTION
Transaction callable now returns user value, not writeResult.

Implementation guide states:

> Transactions return the value provided by the user’s callback. It is not possible to obtain the WriteResult directly.

This change modifies the PHP client to better conform to requirements.