### PR TITLE
Return latest write result

### DIFF
--- a/src/Firestore/DocumentReference.php
+++ b/src/Firestore/DocumentReference.php
@@ -418,8 +418,8 @@ class DocumentReference
      */
     private function writeResult(array $commitResponse)
     {
-        return isset($commitResponse['writeResults'][0])
-            ? $commitResponse['writeResults'][0]
+        return isset($commitResponse['writeResults']) && is_array($commitResponse['writeResults'])
+            ? array_pop($commitResponse['writeResults'])
             : [];
     }
 }

--- a/src/Firestore/DocumentReference.php
+++ b/src/Firestore/DocumentReference.php
@@ -411,7 +411,7 @@ class DocumentReference
     }
 
     /**
-     * Return the first write result from a commit response
+     * Return the latest write result from a commit response
      *
      * @param array $commitResponse
      * @return array

--- a/tests/unit/Firestore/DocumentReferenceTest.php
+++ b/tests/unit/Firestore/DocumentReferenceTest.php
@@ -249,27 +249,29 @@ class DocumentReferenceTest extends TestCase
 
     public function testWriteResult()
     {
+        $time = time();
+
         $this->connection->commit(Argument::any())
             ->shouldBeCalled()
             ->willReturn([
                 'writeResults' => [
                     [
                         'updateTime' => [
-                            'seconds' => time()
+                            'seconds' => $time
                         ]
                     ], [
                         'updateTime' => [
-                            'seconds' => time() + 100
+                            'seconds' => $time + 100
                         ]
                     ]
                 ],
-                'commitTime' => ['seconds' => time()]
+                'commitTime' => ['seconds' => $time]
             ]);
 
         $this->document->___setProperty('connection', $this->connection->reveal());
 
         $res = $this->document->set(['foo' => 'bar']);
         $this->assertInstanceOf(Timestamp::class, $res['updateTime']);
-        $this->assertEquals(time(), $res['updateTime']->get()->format('U'), '', 3);
+        $this->assertEquals($time + 100, $res['updateTime']->get()->format('U'), '', 3);
     }
 }


### PR DESCRIPTION
This change modifies the return value of mutation calls on DocumentReference. If multiple write results are found, the latest is now returned rather than the first. This is to better conform with the Firestore implementation guide, which states as follows:

> A single call to update() might return either one or two WriteResults (if there are DocumentTransforms). Since this generates an unexpected response, we should return only the latest of the WriteResults.

This change is not breaking.