### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,15 @@
+# John Pedrie
+/dev/ @jdpedrie
+/src/Datastore/ @jdpedrie
+/src/Firestore/ @jdpedrie
+/src/PubSub/ @jdpedrie
+/src/Spanner/ @jdpedrie
+/src/Vision/ @jdpedrie
+
+# David Supplee
+/src/BigQuery/ @dwsupplee
+/src/Language/ @dwsupplee
+/src/Logging/ @dwsupplee
+/src/Speech/ @dwsupplee
+/src/Storage/ @dwsupplee
+/src/Translate/ @dwsupplee


### PR DESCRIPTION
See [About CODEOWNERS](https://help.github.com/articles/about-codeowners/) for info. I've only added clients with manual veneers. GAPICs are not addressed directly in this edition of the file. I opted to place the file in the existing `docs/` folder rather than creating `.github`. If we ever adopt issue/pull templates we may want to revisit that.