### PR TITLE
Update required cloud-core version

### DIFF
--- a/src/BigQuery/composer.json
+++ b/src/BigQuery/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.0",
+        "google/cloud-core": "^1.14",
         "ramsey/uuid": "~3"
     },
     "suggest": {

--- a/src/Datastore/composer.json
+++ b/src/Datastore/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.0"
+        "google/cloud-core": "^1.14"
     },
     "extra": {
         "component": {

--- a/src/Firestore/composer.json
+++ b/src/Firestore/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "ext-grpc": "*",
-        "google/cloud-core": "^1.0",
+        "google/cloud-core": "^1.14",
         "google/gax": "^0.27",
         "google/proto-client": "^0.27",
         "ramsey/uuid": "~3"

--- a/src/Language/composer.json
+++ b/src/Language/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.0",
+        "google/cloud-core": "^1.14",
         "google/proto-client": "^0.27",
         "google/gax": "^0.27"
     },

--- a/src/Logging/composer.json
+++ b/src/Logging/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.0",
+        "google/cloud-core": "^1.14",
         "google/proto-client": "^0.27",
         "google/gax": "^0.27"
     },

--- a/src/PubSub/composer.json
+++ b/src/PubSub/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.0",
+        "google/cloud-core": "^1.14",
         "google/proto-client": "^0.27",
         "google/gax": "^0.27"
     },

--- a/src/Spanner/composer.json
+++ b/src/Spanner/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "ext-grpc": "*",
-        "google/cloud-core": "^1.5",
+        "google/cloud-core": "^1.14",
         "google/gax": "^0.27",
         "google/proto-client": "^0.27"
     },

--- a/src/Speech/composer.json
+++ b/src/Speech/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.0",
+        "google/cloud-core": "^1.14",
         "google/proto-client": "^0.27",
         "google/gax": "^0.27"
     },

--- a/src/Storage/composer.json
+++ b/src/Storage/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.0"
+        "google/cloud-core": "^1.14"
     },
     "suggest": {
         "phpseclib/phpseclib": "May be used in place of OpenSSL for creating signed Cloud Storage URLs. Please require version ^2.",

--- a/src/Trace/composer.json
+++ b/src/Trace/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.4",
+        "google/cloud-core": "^1.14",
         "ramsey/uuid": "~3"
     },
     "suggest": {

--- a/src/Translate/composer.json
+++ b/src/Translate/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.0"
+        "google/cloud-core": "^1.14"
     },
     "extra": {
         "component": {

--- a/src/Vision/composer.json
+++ b/src/Vision/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/cloud-core": "^1.0",
+        "google/cloud-core": "^1.14",
         "google/proto-client": "^0.27",
         "google/gax": "^0.27"
     },


### PR DESCRIPTION
Closes #782. Replaces #786.

Question for the group: Would it be useful to script automated requirement bumps into the release process? i.e. when a new release of cloud-core is created, should we automatically update the requirement in all packages depending on cloud-core?