### PR TITLE
Add badges to README files

### DIFF
--- a/src/BigQuery/README.md
+++ b/src/BigQuery/README.md
@@ -2,6 +2,8 @@
 
 > Idiomatic PHP client for [BigQuery](https://cloud.google.com/bigquery/).
 
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-bigquery/v/stable)](https://packagist.org/packages/google/cloud-bigquery) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-bigquery.svg)](https://packagist.org/packages/google/cloud-bigquery)
+
 * [Homepage](http://googlecloudplatform.github.io/google-cloud-php)
 * [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/cloud-bigquery/latest/bigquery/bigqueryclient)
 

--- a/src/Bigtable/README.md
+++ b/src/Bigtable/README.md
@@ -1,6 +1,6 @@
 # Google Cloud PHP Bigtable
 
-> Idiomatic PHP client for [Bigtable](https://cloud.google.com/bigtable/).
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-bigtable/v/stable)](https://packagist.org/packages/google/cloud-bigtable) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-bigtable.svg)](https://packagist.org/packages/google/cloud-bigtable)
 
 * [Homepage](http://googlecloudplatform.github.io/google-cloud-php)
 * [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/cloud-bigtable/latest/bigtable/bigtableclient)

--- a/src/Core/README.md
+++ b/src/Core/README.md
@@ -1,5 +1,7 @@
 # Google Cloud PHP Core Libraries
 
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-core/v/stable)](https://packagist.org/packages/google/cloud-core) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-core.svg)](https://packagist.org/packages/google/cloud-core)
+
 * [Homepage](http://googlecloudplatform.github.io/google-cloud-php)
 * [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/cloud-core/latest/core/readme)
 

--- a/src/Datastore/README.md
+++ b/src/Datastore/README.md
@@ -2,6 +2,8 @@
 
 > Idiomatic PHP client for [Cloud Datastore](https://cloud.google.com/datastore/).
 
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-datastore/v/stable)](https://packagist.org/packages/google/cloud-datastore) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-datastore.svg)](https://packagist.org/packages/google/cloud-datastore)
+
 * [Homepage](http://googlecloudplatform.github.io/google-cloud-php)
 * [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/cloud-datastore/latest/datastore/datastoreclient)
 

--- a/src/Dlp/README.md
+++ b/src/Dlp/README.md
@@ -1,5 +1,7 @@
 # Data Loss Prevention
 
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-dlp/v/stable)](https://packagist.org/packages/google/cloud-dlp) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-dlp.svg)](https://packagist.org/packages/google/cloud-dlp)
+
 The DLP API lets you understand and manage sensitive data.
 
 For more information, see [cloud.google.com](https://cloud.google.com/dlp/).

--- a/src/ErrorReporting/README.md
+++ b/src/ErrorReporting/README.md
@@ -1,5 +1,7 @@
 # Stackdriver Error Reporting
 
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-error-reporting/v/stable)](https://packagist.org/packages/google/cloud-error-reporting) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-error-reporting.svg)](https://packagist.org/packages/google/cloud-error-reporting)
+
 Stackdriver Error Reporting counts, analyzes and aggregates the crashes in your running cloud services.
 
 For more information, see [cloud.google.com](https://cloud.google.com/error-reporting/).

--- a/src/Firestore/README.md
+++ b/src/Firestore/README.md
@@ -2,6 +2,8 @@
 
 > Idiomatic PHP client for [Cloud Firestore](https://cloud.google.com/firestore/).
 
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-firestore/v/stable)](https://packagist.org/packages/google/cloud-firestore) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-firestore.svg)](https://packagist.org/packages/google/cloud-firestore)
+
 * [Homepage](http://googlecloudplatform.github.io/google-cloud-php)
 * [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/cloud-firestore/latest/firestore/firestoreclient)
 

--- a/src/Language/README.md
+++ b/src/Language/README.md
@@ -2,6 +2,8 @@
 
 > Idiomatic PHP client for [Cloud Natural Language](https://cloud.google.com/natural-language/).
 
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-language/v/stable)](https://packagist.org/packages/google/cloud-language) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-language.svg)](https://packagist.org/packages/google/cloud-language)
+
 * [Homepage](http://googlecloudplatform.github.io/google-cloud-php)
 * [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/cloud-language/latest/language/languageclient)
 

--- a/src/Logging/README.md
+++ b/src/Logging/README.md
@@ -2,6 +2,8 @@
 
 > Idiomatic PHP client for [Stackdriver Logging](https://cloud.google.com/logging/).
 
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-logging/v/stable)](https://packagist.org/packages/google/cloud-logging) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-logging.svg)](https://packagist.org/packages/google/cloud-logging)
+
 * [Homepage](http://googlecloudplatform.github.io/google-cloud-php)
 * [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/cloud-logging/latest/logging/loggingclient)
 

--- a/src/Monitoring/README.md
+++ b/src/Monitoring/README.md
@@ -1,5 +1,7 @@
 # Stackdriver Monitoring
 
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-monitoring/v/stable)](https://packagist.org/packages/google/cloud-monitoring) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-monitoring.svg)](https://packagist.org/packages/google/cloud-monitoring)
+
 Stackdriver Monitoring provides visibility into the performance, uptime, and overall health of cloud-powered applications.
 
 For more information, see [cloud.google.com](https://cloud.google.com/monitoring/).

--- a/src/PubSub/README.md
+++ b/src/PubSub/README.md
@@ -2,6 +2,8 @@
 
 > Idiomatic PHP client for [Cloud Pub/Sub](https://cloud.google.com/pubsub/).
 
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-pubsub/v/stable)](https://packagist.org/packages/google/cloud-pubsub) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-pubsub.svg)](https://packagist.org/packages/google/cloud-pubsub)
+
 * [Homepage](http://googlecloudplatform.github.io/google-cloud-php)
 * [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/cloud-pubsub/latest/pubsub/pubsubclient)
 

--- a/src/Spanner/README.md
+++ b/src/Spanner/README.md
@@ -2,6 +2,8 @@
 
 > Idiomatic PHP client for [Cloud Spanner](https://cloud.google.com/spanner/).
 
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-spanner/v/stable)](https://packagist.org/packages/google/cloud-spanner) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-spanner.svg)](https://packagist.org/packages/google/cloud-spanner)
+
 * [Homepage](http://googlecloudplatform.github.io/google-cloud-php)
 * [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/cloud-spanner/latest/spanner/spannerclient)
 

--- a/src/Speech/README.md
+++ b/src/Speech/README.md
@@ -2,6 +2,8 @@
 
 > Idiomatic PHP client for [Cloud Speech](https://cloud.google.com/speech/).
 
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-speech/v/stable)](https://packagist.org/packages/google/cloud-speech) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-speech.svg)](https://packagist.org/packages/google/cloud-speech)
+
 * [Homepage](http://googlecloudplatform.github.io/google-cloud-php)
 * [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/cloud-speech/latest/speech/speechclient)
 

--- a/src/Storage/README.md
+++ b/src/Storage/README.md
@@ -2,6 +2,8 @@
 
 > Idiomatic PHP client for [Cloud Storage](https://cloud.google.com/storage/).
 
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-storage/v/stable)](https://packagist.org/packages/google/cloud-storage) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-storage.svg)](https://packagist.org/packages/google/cloud-storage)
+
 * [Homepage](http://googlecloudplatform.github.io/google-cloud-php)
 * [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/cloud-storage/latest/storage/storageclient)
 

--- a/src/Trace/README.md
+++ b/src/Trace/README.md
@@ -2,6 +2,8 @@
 
 > Idiomatic PHP client for [Stackdriver Trace][stackdriver-trace].
 
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-trace/v/stable)](https://packagist.org/packages/google/cloud-trace) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-trace.svg)](https://packagist.org/packages/google/cloud-trace)
+
 * [Homepage][homepage]
 * [API documentation][api-docs]
 

--- a/src/Translate/README.md
+++ b/src/Translate/README.md
@@ -2,6 +2,8 @@
 
 > Idiomatic PHP client for [Translation](https://cloud.google.com/translate/).
 
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-translate/v/stable)](https://packagist.org/packages/google/cloud-translate) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-translate.svg)](https://packagist.org/packages/google/cloud-translate)
+
 * [Homepage](http://googlecloudplatform.github.io/google-cloud-php)
 * [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/cloud-translate/latest/translate/translateclient)
 

--- a/src/VideoIntelligence/README.md
+++ b/src/VideoIntelligence/README.md
@@ -1,6 +1,6 @@
 # Google Cloud PHP Video Intelligence
 
-> Idiomatic PHP client for [Cloud Video Intelligence](https://cloud.google.com/video-intelligence/).
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-videointelligence/v/stable)](https://packagist.org/packages/google/cloud-videointelligence) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-videointelligence.svg)](https://packagist.org/packages/google/cloud-videointelligence)
 
 * [Homepage](http://googlecloudplatform.github.io/google-cloud-php)
 * [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/cloud-videointelligence/latest/readme)

--- a/src/Vision/README.md
+++ b/src/Vision/README.md
@@ -2,6 +2,8 @@
 
 > Idiomatic PHP client for [Cloud Vision](https://cloud.google.com/vision/).
 
+[![Latest Stable Version](https://poser.pugx.org/google/cloud-vision/v/stable)](https://packagist.org/packages/google/cloud-vision) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-vision.svg)](https://packagist.org/packages/google/cloud-vision)
+
 * [Homepage](http://googlecloudplatform.github.io/google-cloud-php)
 * [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/cloud-vision/latest/vision/visionclient)
 


### PR DESCRIPTION
As suggested in #791 by @tswast. To help users understand the difference between versions of `google/cloud` and its various children.