### PR TITLE
When executing runQuery wait until complete before returning QueryResults

### DIFF
--- a/src/BigQuery/BigQueryClient.php
+++ b/src/BigQuery/BigQueryClient.php
@@ -277,10 +277,12 @@ class BigQueryClient
             'maxRetries'
         ], $options);
 
-        return $this->startQuery(
+        $queryResults = $this->startQuery(
             $query,
             $options
         )->queryResults($queryResultsOptions + $options);
+        $queryResults->waitUntilComplete();
+        return $queryResults;
     }
 
     /**


### PR DESCRIPTION
With this change `BigQueryClient::runQuery` will wait for the job to complete before returning `QueryResults`, whereas currently `QueryResults` could be returned prior to job completion and the waiting would occur when a user goes to iterate the results.