### PR TITLE
Pass ServiceBuilder construct config into children

### DIFF
--- a/src/Core/ServiceBuilder.php
+++ b/src/Core/ServiceBuilder.php
@@ -54,7 +54,7 @@ class ServiceBuilder
     /**
      * @var array Configuration options to be used between clients.
      */
-    private $config;
+    private $config = [];
 
     /**
      * Pass in an array of configuration options which will be shared between
@@ -396,10 +396,17 @@ class ServiceBuilder
         return $this->createClient(TranslateClient::class, 'translate', $config);
     }
 
+    /**
+     * Create the client library, or error if not installed.
+     *
+     * @param string $class The class to create.
+     * @param string $packageName The name of the package
+     * @param array $config Configuration options.
+     */
     private function createClient($class, $packageName, array $config = [])
     {
         if (class_exists($class)) {
-            return new $class($config ? $this->resolveConfig($config) : $this->config);
+            return new $class($this->resolveConfig($config));
         }
         throw new \Exception(sprintf(
             'The google/cloud-%s package is missing and must be installed.',
@@ -419,6 +426,6 @@ class ServiceBuilder
             $config['httpHandler'] = HttpHandlerFactory::build();
         }
 
-        return $config;
+        return array_merge($this->config, $config);
     }
 }

--- a/tests/unit/fixtures/json-key-fixture.json
+++ b/tests/unit/fixtures/json-key-fixture.json
@@ -1,1 +1,7 @@
-{"type":"authorized_user","client_id":"example@example.com","client_secret":"example","refresh_token":"abc","project_id":"example_project"}
+{
+    "type": "authorized_user",
+    "client_id": "example@example.com",
+    "client_secret": "example",
+    "refresh_token": "abc",
+    "project_id": "example_project"
+}


### PR DESCRIPTION
So I've been investigating the report in #766, and found that the constructor `$config` is passed to services ONLY when no child `$config` is set.

For instance:

```php
use Google\Cloud\ServiceBuilder;

putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/keyfile1.json');

$cloud = new ServiceBuilder([
    'keyFilePath' => '/path/to/keyfile2.json'
]);

// uses `keyfile2.json`
$datastore = $cloud->datastore();

// uses `keyfile1.json`
$datastore = $cloud->datastore([
    'namespaceId' => 'myApp'
]);
```

This strikes me as incorrect, as it prevents e.g. SpeechClient from setting a languageCode and using ServiceBuilder-level credentials. My proposed solution simply merges ServiceBuilder and factory method configuration, preferring keys given later.

If accepted, this PR closes #766.

edit: for a demonstration, pull the PR and run `vendor/bin/phpunit --group=servicebuilder`. Then reset the changes to `src/Core/ServiceBuilder.php` to the current master branch. Undoing changes to ServiceBuilder will expose errors on SpeechClient.