### PR TITLE
Use GOOGLE_CLOUD_PROJECT for project id detection on App Engine Flex.

### DIFF
--- a/src/Core/Report/GAEFlexMetadataProvider.php
+++ b/src/Core/Report/GAEFlexMetadataProvider.php
@@ -31,8 +31,8 @@ class GAEFlexMetadataProvider implements MetadataProviderInterface
      */
     public function __construct(array $server)
     {
-        $projectId = isset($server['GCLOUD_PROJECT'])
-            ? $server['GCLOUD_PROJECT']
+        $projectId = isset($server['GOOGLE_CLOUD_PROJECT'])
+            ? $server['GOOGLE_CLOUD_PROJECT']
             : 'unknown-projectid';
         $serviceId = isset($server['GAE_SERVICE'])
             ? $server['GAE_SERVICE']

--- a/src/Logging/PsrLogger.php
+++ b/src/Logging/PsrLogger.php
@@ -372,6 +372,12 @@ class PsrLogger implements LoggerInterface, \Serializable
                 (isset($options['labels'])
                  ? $options['labels']
                  : []) + $labels;
+            // Copy over the value for 'appengine.googleapis.com/trace_id' to
+            // `trace` option too.
+            if (isset($labels['appengine.googleapis.com/trace_id'])) {
+                $options['trace'] =
+                    $labels['appengine.googleapis.com/trace_id'];
+            }
         }
         // Adding MonitoredResource
         $resource = $this->metadataProvider->monitoredResource();

--- a/tests/unit/Core/Report/GAEFlexMetadataProviderTest.php
+++ b/tests/unit/Core/Report/GAEFlexMetadataProviderTest.php
@@ -28,7 +28,7 @@ class GAEFlexMetadataProviderTest extends TestCase
     private $envs = [
         'GAE_SERVICE' => 'my-service',
         'GAE_VERSION' => 'my-version',
-        'GCLOUD_PROJECT' => 'my-project',
+        'GOOGLE_CLOUD_PROJECT' => 'my-project',
         'HTTP_X_CLOUD_TRACE_CONTEXT' => 'my-traceId'
     ];
 

--- a/tests/unit/Logging/PsrLoggerBatchTest.php
+++ b/tests/unit/Logging/PsrLoggerBatchTest.php
@@ -130,6 +130,9 @@ class PsrLoggerBatchTest extends TestCase
         $this->assertEquals('stackdriver-logging-my-log', self::$logName);
         $info = self::$entry->info();
         $this->assertEquals($expectedLabels, $info['labels']);
+        if (!empty($traceId)) {
+            $this->assertEquals($traceId, $info['trace']);
+        }
     }
 
     /**


### PR DESCRIPTION
Also copy the traceid to the top level `trace` option.

Related to #827 