### PR TITLE
Debugger: return nextWaitToken with breakpoints list

### DIFF
--- a/src/Debugger/Daemon.php
+++ b/src/Debugger/Daemon.php
@@ -118,15 +118,15 @@ class Daemon
      */
     public function run()
     {
-        $breakpoints = $this->debuggee->breakpoints();
-        $this->setBreakpoints($breakpoints);
+        $resp = $this->debuggee->breakpointsWithWaitToken();
+        $this->setBreakpoints($resp['breakpoints']);
 
-        while (array_key_exists('nextWaitToken', $breakpoints)) {
+        while (array_key_exists('nextWaitToken', $resp)) {
             try {
-                $breakpoints = $this->debuggee->breakpoints([
-                    'waitToken' => $breakpoints['nextWaitToken']
+                $resp = $this->debuggee->breakpointsWithWaitToken([
+                    'waitToken' => $resp['nextWaitToken']
                 ]);
-                $this->setBreakpoints($breakpoints);
+                $this->setBreakpoints($resp['breakpoints']);
             } catch (ConflictException $e) {
                 // Ignoring this exception
             }

--- a/src/Debugger/Debuggee.php
+++ b/src/Debugger/Debuggee.php
@@ -214,14 +214,48 @@ class Debuggee implements \JsonSerializable
      */
     public function breakpoints(array $options = [])
     {
+        $ret = $this->breakpointsWithWaitToken($options);
+        return $ret['breakpoints'];
+    }
+
+    /**
+     * Fetch the list of breakpoints this debugee should try to handle and a
+     * wait token for the next request. The return value is an associative array
+     * with keys of breakpoints and nextWaitToken.
+     *
+     * Example:
+     * ```
+     * $resp = $debuggee->breakpointsWithWaitToken();
+     * $nextWaitToken = $resp['nextWaitToken'];
+     * $breakpoints = $resp['breakpoints'];
+     * ```
+     *
+     * @codingStandardsIgnoreStart
+     * @see https://cloud.google.com/debugger/api/reference/rest/v2/controller.debuggees.breakpoints/list Breakpoints list API documentation.
+     * @codingStandardsIgnoreEnd
+     *
+     * @param array $options [optional] {
+     *      Configuration options.
+     *
+     *      @type string $waitToken A wait token that, if specified, blocks the
+     *            method call until the list of active breakpoints has changed,
+     *            or a server selected timeout has expired. The value should be
+     *            set from the last returned response.
+     * }
+     * @return array
+     */
+    public function breakpointsWithWaitToken(array $options = [])
+    {
         $ret = $this->connection->listBreakpoints(['debuggeeId' => $this->id] + $options);
 
         if (array_key_exists('breakpoints', $ret)) {
-            return array_map(function ($breakpointData) {
+            $ret['breakpoints'] = array_map(function ($breakpointData) {
                 return new Breakpoint($breakpointData);
             }, $ret['breakpoints']);
+        } else {
+            $ret['breakpoints'] = [];
         }
-        return [];
+        return $ret;
     }
 
     /**

--- a/tests/snippets/Debugger/DaemonTest.php
+++ b/tests/snippets/Debugger/DaemonTest.php
@@ -39,7 +39,7 @@ class DaemonTest extends SnippetTestCase
         $this->debuggee = $this->prophesize(Debuggee::class);
         $this->storage = $this->prophesize(BreakpointStorageInterface::class);
         $this->debuggee->register()->willReturn(true);
-        $this->debuggee->breakpoints()->willReturn([]);
+        $this->debuggee->breakpointsWithWaitToken()->willReturn(['breakpoints' => []]);
         $this->client->debuggee(null, Argument::any())->willReturn($this->debuggee->reveal());
     }
 

--- a/tests/snippets/Debugger/DebuggeeTest.php
+++ b/tests/snippets/Debugger/DebuggeeTest.php
@@ -86,6 +86,29 @@ class DebuggeeTest extends SnippetTestCase
         }
     }
 
+    public function testBreakpointsWithWaitToken()
+    {
+        $this->connection->listBreakpoints(Argument::any())->willReturn([
+            'nextWaitToken' => 'token',
+            'breakpoints' => [
+                ['id' => 'breakpoint1']
+            ]
+        ]);
+        $debuggee = new Debuggee($this->connection->reveal(), ['project' => 'project']);
+        $snippet = $this->snippetFromMethod(Debuggee::class, 'breakpointsWithWaitToken');
+        $snippet->addLocal('debuggee', $debuggee);
+
+        $res = $snippet->invoke('breakpoints');
+        $breakpoints = $res->returnVal();
+        $this->assertCount(1, $breakpoints);
+        foreach ($breakpoints as $breakpoint) {
+            $this->assertInstanceOf(Breakpoint::class, $breakpoint);
+        }
+
+        $res = $snippet->invoke('nextWaitToken');
+        $this->assertEquals('token', $res->returnVal());
+    }
+
     public function testUpdateBreakpoint()
     {
         $this->connection->updateBreakpoint(Argument::any())->willReturn(true);

--- a/tests/unit/Debugger/DaemonTest.php
+++ b/tests/unit/Debugger/DaemonTest.php
@@ -94,13 +94,13 @@ class DaemonTest extends TestCase
 
     public function testFetchesBreakpoints()
     {
-        $breakpoints = [
-            new Breakpoint(['id' => 'breakpoint1'])
+        $resp = [
+            'breakpoints' => [new Breakpoint(['id' => 'breakpoint1'])]
         ];
         $this->debuggee->register(Argument::any())
             ->shouldBeCalled();
-        $this->debuggee->breakpoints()
-            ->willReturn($breakpoints);
+        $this->debuggee->breakpointsWithWaitToken()
+            ->willReturn($resp);
         $this->debuggee->updateBreakpointBatch(Argument::any())
             ->willReturn(true);
         $this->client->debuggee(null, Argument::any())

--- a/tests/unit/Debugger/DebuggeeTest.php
+++ b/tests/unit/Debugger/DebuggeeTest.php
@@ -59,6 +59,36 @@ class DebuggeeTest extends TestCase
         $this->assertCount(0, $breakpoints);
     }
 
+    public function testFetchesBreakpointsWithWaitToken()
+    {
+        $this->connection->listBreakpoints(['debuggeeId' => 'debuggee1'])->willReturn([
+            'breakpoints' => [
+                ['id' => 'breakpoint1'],
+                ['id' => 'breakpoint2']
+            ],
+            'nextWaitToken' => 'token'
+        ]);
+        $debuggee = new Debuggee($this->connection->reveal(), ['id' => 'debuggee1', 'project' => 'project1']);
+        $resp = $debuggee->breakpointsWithWaitToken();
+        $this->assertArrayHasKey('breakpoints', $resp);
+        $this->assertCount(2, $resp['breakpoints']);
+        $this->assertArrayHasKey('nextWaitToken', $resp);
+        $this->assertEquals('token', $resp['nextWaitToken']);
+    }
+
+    public function testFetchesEmptyBreakpointsWithWaitToken()
+    {
+        $this->connection->listBreakpoints(['debuggeeId' => 'debuggee1'])->willReturn([
+            'nextWaitToken' => 'token'
+        ]);
+        $debuggee = new Debuggee($this->connection->reveal(), ['id' => 'debuggee1', 'project' => 'project1']);
+        $resp = $debuggee->breakpointsWithWaitToken();
+        $this->assertArrayHasKey('breakpoints', $resp);
+        $this->assertCount(0, $resp['breakpoints']);
+        $this->assertArrayHasKey('nextWaitToken', $resp);
+        $this->assertEquals('token', $resp['nextWaitToken']);
+    }
+
     public function testUpdatesBreakpoint()
     {
         $this->connection->updateBreakpoint(Argument::that(function ($args) {


### PR DESCRIPTION
In order to correctly poll/wait for breakpoint configuration changes, you need to return the `nextWaitToken` to pass to the next breakpoint list call. In cleaning up the code design of `Debuggee#breakpoints`, we lost the next wait token.

* Added a `Debuggee#breakpointsWithWaitToken` that returns an associative array with the `nextWaitToken` and list of `breakpoints`.
* Fixes the Daemon to use this new method in its run loop.