### PR TITLE
Debugger: Validate breakpoint file and line

### DIFF
--- a/src/Debugger/Breakpoint.php
+++ b/src/Debugger/Breakpoint.php
@@ -540,7 +540,10 @@ class Breakpoint implements \JsonSerializable
 
     /**
      * Validate that this breakpoint can be executed. If not valid, the status
-     * field will be populated with the corresponding error message.
+     * field will be populated with the corresponding error message. This
+     * validation does not guarantee that the breakpoint will be reachable.
+     * The primary use case is to reject clearly invalid breakpoints and return
+     * a message to the developer via the Debugger console.
      *
      * Example:
      * ```
@@ -584,6 +587,17 @@ class Breakpoint implements \JsonSerializable
         return true;
     }
 
+    /**
+     * Validate that the source location is a valid. This means that:
+     *
+     * - The file exists
+     * - The file is readable
+     * - The file looks like a php file (ends in .php)
+     * - The line has code on it (non-empty and does not look like a comment)
+     *
+     * This validation is not perfect as we are not compiling the file to
+     * actually do the validation. We may miss cases.
+     */
     private function validateSourceLocation()
     {
         if (!$this->location) {

--- a/src/Debugger/Breakpoint.php
+++ b/src/Debugger/Breakpoint.php
@@ -608,7 +608,7 @@ class Breakpoint implements \JsonSerializable
         }
 
         // Ensure the file is a php file
-        if ($info->getExtension() !== "php") {
+        if (strtolower($info->getExtension()) !== "php") {
             $this->setError(
                 StatusMessage::REFERENCE_BREAKPOINT_SOURCE_LOCATION,
                 'Invalid breakpoint location - Invalid file type: $0.',

--- a/tests/unit/Debugger/BreakpointValidationTest.php
+++ b/tests/unit/Debugger/BreakpointValidationTest.php
@@ -153,4 +153,18 @@ class BreakpointValidationTest extends TestCase
             $status['refersTo']
         );
     }
+
+    public function testValidatesNonCommentMultiplication()
+    {
+        $value = 6
+            * 3;
+
+        $breakpoint = new Breakpoint([
+            'location' => [
+                'path' => __FILE__,
+                'line' => __LINE__ - 5
+            ]
+        ]);
+        $this->assertTrue($breakpoint->validate());
+    }
 }

--- a/tests/unit/Debugger/BreakpointValidationTest.php
+++ b/tests/unit/Debugger/BreakpointValidationTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017 Google Inc.
+ * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/Debugger/BreakpointValidationTest.php
+++ b/tests/unit/Debugger/BreakpointValidationTest.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Debugger;
+
+use Google\Cloud\Debugger\StatusMessage;
+use Google\Cloud\Debugger\Breakpoint;
+use Google\Cloud\Debugger\SourceLocation;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group debugger
+ */
+class BreakpointValidationTest extends TestCase
+{
+    public function setUp()
+    {
+        if (!extension_loaded('stackdriver_debugger')) {
+            $this->markTestSkipped('Breakpoint validation requires stackdriver_debugger extension');
+        }
+    }
+
+    /**
+     * @dataProvider conditionsToTest
+     */
+    public function testValidatesCondition($condition, $expectedValid)
+    {
+        $breakpoint = new Breakpoint([
+            'location' => [
+                'path' => __FILE__,
+                'line' => __LINE__
+            ],
+            'condition' => $condition
+        ]);
+        $this->assertEquals($expectedValid, $breakpoint->validate());
+        if (!$expectedValid) {
+            $status = $breakpoint->status()->jsonSerialize();
+            $this->assertTrue($status['isError']);
+            $this->assertEquals(StatusMessage::REFERENCE_BREAKPOINT_CONDITION, $status['refersTo']);
+        }
+    }
+
+    /**
+     * @dataProvider conditionsToTest
+     */
+    public function testValidatesExpression($expression, $expectedValid)
+    {
+        $breakpoint = new Breakpoint([
+            'location' => [
+                'path' => __FILE__,
+                'line' => __LINE__
+            ],
+            'expressions' => [$expression]
+        ]);
+        $this->assertEquals($expectedValid, $breakpoint->validate());
+        if (!$expectedValid) {
+            $status = $breakpoint->status()->jsonSerialize();
+            $this->assertTrue($status['isError']);
+            $this->assertEquals(StatusMessage::REFERENCE_BREAKPOINT_EXPRESSION, $status['refersTo']);
+        }
+    }
+
+    public function conditionsToTest()
+    {
+        return [
+            ['3 + 3', true],
+            ['3 + 3 == 6', true],
+            ['foo(3)', false],
+            ['abs(-3)', false],
+            ['$foo->bar', true],
+            ['$foo->bar()', false]
+        ];
+    }
+
+    public function testValidatesMissingFile()
+    {
+        $breakpoint = new Breakpoint([
+            'location' => [
+                'path' => __DIR__ . '/missing_file.php',
+                'line' => __LINE__
+            ]
+        ]);
+        $this->assertFalse($breakpoint->validate());
+        $status = $breakpoint->status()->jsonSerialize();
+        $this->assertTrue($status['isError']);
+        $this->assertEquals(
+            StatusMessage::REFERENCE_BREAKPOINT_SOURCE_LOCATION,
+            $status['refersTo']
+        );
+    }
+
+    public function testValidatesFileType()
+    {
+        $breakpoint = new Breakpoint([
+            'location' => [
+                'path' => __DIR__ . '/../../../composer.json',
+                'line' => __LINE__
+            ]
+        ]);
+        $this->assertFalse($breakpoint->validate());
+        $status = $breakpoint->status()->jsonSerialize();
+        $this->assertTrue($status['isError']);
+        $this->assertEquals(
+            StatusMessage::REFERENCE_BREAKPOINT_SOURCE_LOCATION,
+            $status['refersTo']
+        );
+    }
+
+    public function testValidatesEmptyLine()
+    {
+        $breakpoint = new Breakpoint([
+            'location' => [
+                'path' => __FILE__,
+                'line' => __LINE__ - 6
+            ]
+        ]);
+        $this->assertFalse($breakpoint->validate());
+        $status = $breakpoint->status()->jsonSerialize();
+        $this->assertTrue($status['isError']);
+        $this->assertEquals(
+            StatusMessage::REFERENCE_BREAKPOINT_SOURCE_LOCATION,
+            $status['refersTo']
+        );
+    }
+
+    public function testValidatesCommentLine()
+    {
+        $breakpoint = new Breakpoint([
+            'location' => [
+                'path' => __FILE__,
+                'line' => 2
+            ]
+        ]);
+        $this->assertFalse($breakpoint->validate());
+        $status = $breakpoint->status()->jsonSerialize();
+        $this->assertTrue($status['isError']);
+        $this->assertEquals(
+            StatusMessage::REFERENCE_BREAKPOINT_SOURCE_LOCATION,
+            $status['refersTo']
+        );
+    }
+}


### PR DESCRIPTION
Adds additional validation to a breakpoint by validating the source location.

* Ensure the file exists and is readable
* Ensure the file is a .php file
* Ensure the line is not empty or a comment line

The `Daemon` does the validation and immediately reports validation errors back to the stackdriver server.