### PR TITLE
Debugger: Default source context and default uniquifier

### DIFF
--- a/src/Debugger/Daemon.php
+++ b/src/Debugger/Daemon.php
@@ -156,9 +156,18 @@ class Daemon
 
     private function defaultUniquifier()
     {
-        $files = glob($this->sourceRoot . '/**/*.php');
+        $dir = new \RecursiveDirectoryIterator($this->sourceRoot);
+        $iterator = new \RecursiveIteratorIterator($dir);
+        $regex = new \RegexIterator(
+            $iterator,
+            '/^.+\.php$/i',
+            \RecursiveRegexIterator::GET_MATCH
+        );
+
+        $files = array_keys(iterator_to_array($regex));
         return sha1(implode(':', array_map(function ($filename) {
-            return $filename . ':' . filesize($filename);
+            $relativeFilename = str_replace($this->sourceRoot, '', $filename);
+            return $relativeFilename . ':' . filesize($filename);
         }, $files)));
     }
 

--- a/src/Debugger/Daemon.php
+++ b/src/Debugger/Daemon.php
@@ -91,7 +91,7 @@ class Daemon
 
         $description = array_key_exists('description', $options)
             ? $options['description']
-            : $uniquifier;
+            : $this->defaultDescription();
 
         $this->debuggee = $client->debuggee(null, [
             'uniquifier' => $uniquifier,
@@ -156,6 +156,14 @@ class Daemon
 
     private function defaultUniquifier()
     {
+        $files = glob($this->sourceRoot . '/**/*.php');
+        return sha1(implode(':', array_map(function ($filename) {
+            return $filename . ':' . filesize($filename);
+        }, $files)));
+    }
+
+    private function defaultDescription()
+    {
         if (isset($_SERVER['GAE_SERVICE'])) {
             return $_SERVER['GAE_SERVICE'] . ' - ' . $_SERVER['GAE_VERSION'];
         }
@@ -168,7 +176,7 @@ class Daemon
         if (file_exists($sourceContextFile)) {
             return json_decode(file_get_contents($sourceContextFile), true);
         } else {
-            return null;
+            return [];
         }
     }
 }

--- a/tests/snippets/Debugger/DaemonTest.php
+++ b/tests/snippets/Debugger/DaemonTest.php
@@ -50,7 +50,7 @@ class DaemonTest extends SnippetTestCase
             'storage' => $this->storage->reveal()
         ];
         $snippet = $this->snippetFromClass(Daemon::class);
-        $snippet->replace('new Daemon(\'/path/to/source/root\')', 'new Daemon(\'/path/to/source/root\', $options)');
+        $snippet->replace('new Daemon(\'/path/to/source/root\')', 'new Daemon(__DIR__, $options)');
         $snippet->addLocal('options', $options);
         $res = $snippet->invoke('daemon');
         $this->assertInstanceOf(Daemon::class, $res->returnVal());
@@ -62,7 +62,7 @@ class DaemonTest extends SnippetTestCase
             'client' => $this->client->reveal(),
             'storage' => $this->storage->reveal()
         ];
-        $daemon = new Daemon('/path', $options);
+        $daemon = new Daemon(__DIR__, $options);
         $snippet = $this->snippetFromMethod(Daemon::class, 'run');
         $snippet->addLocal('daemon', $daemon);
         $res = $snippet->invoke('daemon');

--- a/tests/unit/Debugger/DaemonTest.php
+++ b/tests/unit/Debugger/DaemonTest.php
@@ -44,9 +44,8 @@ class DaemonTest extends TestCase
     public function testSpecifyUniquifier()
     {
         $this->debuggee->register(Argument::any())->shouldBeCalled();
-        $this->client->debuggee(null, Argument::that(function ($options) {
-            return $options['uniquifier'] == 'some uniquifier';
-        }))->willReturn($this->debuggee->reveal())->shouldBeCalled();
+        $this->client->debuggee(null, Argument::withEntry('uniquifier', 'some uniquifier'))
+            ->willReturn($this->debuggee->reveal())->shouldBeCalled();
 
         $daemon = new Daemon('.', [
             'client' => $this->client->reveal(),
@@ -59,9 +58,8 @@ class DaemonTest extends TestCase
     {
         $expectedValue = sha1('/file.php:50:/nested/folder/file2.php:50');
         $this->debuggee->register(Argument::any())->shouldBeCalled();
-        $this->client->debuggee(null, Argument::that(function ($options) use ($expectedValue) {
-            return $options['uniquifier'] == $expectedValue;
-        }))->willReturn($this->debuggee->reveal())->shouldBeCalled();
+        $this->client->debuggee(null, Argument::withEntry('uniquifier', $expectedValue))
+            ->willReturn($this->debuggee->reveal())->shouldBeCalled();
 
         $daemon = new Daemon(__DIR__ . '/example', [
             'client' => $this->client->reveal(),
@@ -72,9 +70,8 @@ class DaemonTest extends TestCase
     public function testSpecifyDescription()
     {
         $this->debuggee->register(Argument::any())->shouldBeCalled();
-        $this->client->debuggee(null, Argument::that(function ($options) {
-            return $options['description'] == 'some description';
-        }))->willReturn($this->debuggee->reveal())->shouldBeCalled();
+        $this->client->debuggee(null, Argument::withEntry('description', 'some description'))
+            ->willReturn($this->debuggee->reveal())->shouldBeCalled();
 
         $daemon = new Daemon('.', [
             'client' => $this->client->reveal(),
@@ -95,9 +92,8 @@ class DaemonTest extends TestCase
             'labels' => []
         ];
         $this->debuggee->register(Argument::any())->shouldBeCalled();
-        $this->client->debuggee(null, Argument::that(function ($options) use ($context) {
-            return $options['extSourceContexts'] == [$context];
-        }))->willReturn($this->debuggee->reveal())->shouldBeCalled();
+        $this->client->debuggee(null, Argument::withEntry('extSourceContexts', [$context]))
+            ->willReturn($this->debuggee->reveal())->shouldBeCalled();
 
         $daemon = new Daemon('.', [
             'client' => $this->client->reveal(),
@@ -109,9 +105,8 @@ class DaemonTest extends TestCase
     public function testDefaultSourceContext()
     {
         $this->debuggee->register(Argument::any())->shouldBeCalled();
-        $this->client->debuggee(null, Argument::that(function ($options) {
-            return $options['extSourceContexts'] === [];
-        }))->willReturn($this->debuggee->reveal())->shouldBeCalled();
+        $this->client->debuggee(null, Argument::withEntry('extSourceContexts', []))
+            ->willReturn($this->debuggee->reveal())->shouldBeCalled();
 
         $daemon = new Daemon('.', [
             'client' => $this->client->reveal(),

--- a/tests/unit/Debugger/DaemonTest.php
+++ b/tests/unit/Debugger/DaemonTest.php
@@ -55,6 +55,20 @@ class DaemonTest extends TestCase
         ]);
     }
 
+    public function testGeneratesDefaultUniquifier()
+    {
+        $expectedValue = sha1('/file.php:50:/nested/folder/file2.php:50');
+        $this->debuggee->register(Argument::any())->shouldBeCalled();
+        $this->client->debuggee(null, Argument::that(function ($options) use ($expectedValue) {
+            return $options['uniquifier'] == $expectedValue;
+        }))->willReturn($this->debuggee->reveal())->shouldBeCalled();
+
+        $daemon = new Daemon(__DIR__ . '/example', [
+            'client' => $this->client->reveal(),
+            'storage' => $this->storage->reveal()
+        ]);
+    }
+
     public function testSpecifyDescription()
     {
         $this->debuggee->register(Argument::any())->shouldBeCalled();

--- a/tests/unit/Debugger/DaemonTest.php
+++ b/tests/unit/Debugger/DaemonTest.php
@@ -56,10 +56,10 @@ class DaemonTest extends TestCase
 
     public function testGeneratesDefaultUniquifier()
     {
-        $expectedValue = sha1('/file.php:50:/nested/folder/file2.php:50');
         $this->debuggee->register(Argument::any())->shouldBeCalled();
-        $this->client->debuggee(null, Argument::withEntry('uniquifier', $expectedValue))
-            ->willReturn($this->debuggee->reveal())->shouldBeCalled();
+        $this->client->debuggee(null, Argument::that(function ($options) {
+            return preg_match('/[a-z0-9]{32}/', $options['uniquifier']);
+        }))->willReturn($this->debuggee->reveal())->shouldBeCalled();
 
         $daemon = new Daemon(__DIR__ . '/example', [
             'client' => $this->client->reveal(),

--- a/tests/unit/Debugger/DaemonTest.php
+++ b/tests/unit/Debugger/DaemonTest.php
@@ -92,6 +92,19 @@ class DaemonTest extends TestCase
         ]);
     }
 
+    public function testDefaultSourceContext()
+    {
+        $this->debuggee->register(Argument::any())->shouldBeCalled();
+        $this->client->debuggee(null, Argument::that(function ($options) {
+            return $options['extSourceContexts'] === [];
+        }))->willReturn($this->debuggee->reveal())->shouldBeCalled();
+
+        $daemon = new Daemon('.', [
+            'client' => $this->client->reveal(),
+            'storage' => $this->storage->reveal()
+        ]);
+    }
+
     public function testFetchesBreakpoints()
     {
         $breakpoints = [

--- a/tests/unit/Debugger/example/file.php
+++ b/tests/unit/Debugger/example/file.php
@@ -1,0 +1,3 @@
+<?php
+
+// This test php file would contain an app

--- a/tests/unit/Debugger/example/nested/folder/file2.php
+++ b/tests/unit/Debugger/example/nested/folder/file2.php
@@ -1,0 +1,3 @@
+<?php
+
+// This test php file would contain an app


### PR DESCRIPTION
The extSourceContext field should be empty when there is no
`source-contexts.json` file available.

The default uniquifier should be based off a SHA1 of available files to
debug (.php files). We add the file size as a proxy for detecting
changes.
  