### PR TITLE
Debugger: resolvedLocation bugfix

### DIFF
--- a/src/Debugger/Breakpoint.php
+++ b/src/Debugger/Breakpoint.php
@@ -434,7 +434,9 @@ class Breakpoint implements \JsonSerializable
     {
         $data = [];
         foreach ($this as $key => $value) {
-            if ($key == 'resolvedLocation') continue;
+            if ($key == 'resolvedLocation') {
+                continue;
+            }
 
             if ($value !== null && !empty($value)) {
                 $data[$key] = $value;

--- a/src/Debugger/Breakpoint.php
+++ b/src/Debugger/Breakpoint.php
@@ -432,17 +432,31 @@ class Breakpoint implements \JsonSerializable
      */
     public function jsonSerialize()
     {
-        $data = [];
-        foreach ($this as $key => $value) {
-            if ($key == 'resolvedLocation') {
-                continue;
-            }
-
-            if ($value !== null && !empty($value)) {
-                $data[$key] = $value;
-            }
+        $info = [
+            'id' => $this->id,
+            'action' => $this->action,
+            'condition' => $this->condition,
+            'expressions' => $this->expressions,
+            'logMessageFormat' => $this->logMessageFormat,
+            'logLevel' => $this->logLevel,
+            'isFinalState' => $this->isFinalState,
+            'createTime' => $this->createTime,
+            'finalTime' => $this->finalTime,
+            'userEmail' => $this->userEmail,
+            'stackFrames' => $this->stackFrames,
+            'evaluatedExpressions' => $this->evaluatedExpressions,
+            'labels' => $this->labels
+        ];
+        if ($this->location) {
+            $info['location'] = $this->location;
         }
-        return $data;
+        if ($this->status) {
+            $info['status'] = $this->status;
+        }
+        if ($this->variableTable) {
+            $info['variableTable'] = $this->variableTable;
+        }
+        return $info;
     }
 
     /**

--- a/src/Debugger/Breakpoint.php
+++ b/src/Debugger/Breakpoint.php
@@ -434,6 +434,8 @@ class Breakpoint implements \JsonSerializable
     {
         $data = [];
         foreach ($this as $key => $value) {
+            if ($key == 'resolvedLocation') continue;
+
             if ($value !== null && !empty($value)) {
                 $data[$key] = $value;
             }

--- a/src/Debugger/Debuggee.php
+++ b/src/Debugger/Debuggee.php
@@ -287,7 +287,7 @@ class Debuggee implements \JsonSerializable
             'debuggeeId' => $this->id,
             'id' => $breakpoint->id(),
             'breakpoint' => $breakpoint
-        ]) === [];
+        ]) === []; // rest connection returns empty data on success
     }
 
     /**

--- a/src/Debugger/Debuggee.php
+++ b/src/Debugger/Debuggee.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Debugger;
 
 use Google\Cloud\Debugger\Connection\ConnectionInterface;
+use Google\Cloud\Core\Exception\ServiceException;
 
 /**
  * This class represents a debuggee - a service that can handle breakpoints.
@@ -279,15 +280,16 @@ class Debuggee implements \JsonSerializable
      * @codingStandardsIgnoreEnd
      *
      * @param Breakpoint $breakpoint The modified breakpoint.
-     * @return bool
+     * @return void
+     * @throws ServiceException
      */
     public function updateBreakpoint(Breakpoint $breakpoint)
     {
-        return $this->connection->updateBreakpoint([
+        $this->connection->updateBreakpoint([
             'debuggeeId' => $this->id,
             'id' => $breakpoint->id(),
             'breakpoint' => $breakpoint
-        ]) === []; // rest connection returns empty data on success
+        ]);
     }
 
     /**
@@ -303,6 +305,8 @@ class Debuggee implements \JsonSerializable
      * @codingStandardsIgnoreEnd
      *
      * @param Breakpoint[] $breakpoints The modified breakpoints.
+     * @return void
+     * @throws ServiceException
      */
     public function updateBreakpointBatch(array $breakpoints)
     {

--- a/src/Debugger/Debuggee.php
+++ b/src/Debugger/Debuggee.php
@@ -287,7 +287,7 @@ class Debuggee implements \JsonSerializable
             'debuggeeId' => $this->id,
             'id' => $breakpoint->id(),
             'breakpoint' => $breakpoint
-        ]);
+        ]) === [];
     }
 
     /**

--- a/src/Debugger/SourceLocationResolver.php
+++ b/src/Debugger/SourceLocationResolver.php
@@ -80,7 +80,7 @@ class SourceLocationResolver
             foreach ($includePaths as $path) {
                 $file = implode(DIRECTORY_SEPARATOR, [$path, $prefix, $basename]);
                 if (file_exists($file)) {
-                    return new SourceLocation(realpath($file), $location->line());
+                    return new SourceLocation($this->realRelativePath($file, $path), $location->line());
                 }
             }
         }
@@ -92,7 +92,7 @@ class SourceLocationResolver
                 $location->path()
             );
             foreach ($iterator as $file => $info) {
-                return new SourceLocation(realpath($file), $location->line());
+                return new SourceLocation($this->realRelativePath($file, $includePath), $location->line());
             }
         }
 
@@ -116,5 +116,10 @@ class SourceLocationResolver
             array_shift($directoryParts);
         }
         return $directories;
+    }
+
+    private function realRelativePath($fullPath, $path)
+    {
+        return str_replace(realpath($path) . DIRECTORY_SEPARATOR, '', realpath($fullPath));
     }
 }

--- a/tests/system/Debugger/BasicTest.php
+++ b/tests/system/Debugger/BasicTest.php
@@ -75,8 +75,8 @@ class BasicTest extends TestCase
         $client = new GapicClient();
         $breakpoint = new GapicBreakpoint();
         $location = new SourceLocation();
-        $location->setPath('web/app.php');
-        $location->setLine(10);
+        $location->setPath('tests/system/Debugger/BasicTest.php');
+        $location->setLine(__LINE__);
         $breakpoint->setLocation($location);
         $resp = $client->setBreakpoint($debuggee->id(), $breakpoint, 'google.com/php/v0.1');
         $bp = $resp->getBreakpoint();
@@ -92,8 +92,9 @@ class BasicTest extends TestCase
 
         // fulfill a breakpoint
         $breakpoint = $breakpoints[0];
+        $this->assertTrue($breakpoint->resolveLocation());
         $breakpoint->finalize();
-        $debuggee->updateBreakpoint($breakpoint);
+        $this->assertTrue($debuggee->updateBreakpoint($breakpoint));
     }
 
     public function getClient($transport)

--- a/tests/system/Debugger/BasicTest.php
+++ b/tests/system/Debugger/BasicTest.php
@@ -94,7 +94,7 @@ class BasicTest extends TestCase
         $breakpoint = $breakpoints[0];
         $this->assertTrue($breakpoint->resolveLocation());
         $breakpoint->finalize();
-        $this->assertTrue($debuggee->updateBreakpoint($breakpoint));
+        $debuggee->updateBreakpoint($breakpoint);
     }
 
     public function getClient($transport)

--- a/tests/unit/Debugger/BreakpointTest.php
+++ b/tests/unit/Debugger/BreakpointTest.php
@@ -176,7 +176,7 @@ class BreakpointTest extends TestCase
 
     public function testResolvedLocationNotIncludedInJson()
     {
-        $path = 'src/Debugger/DebuggerClient.php';
+        $path = 'Debugger/DebuggerClient.php';
         $breakpoint = new Breakpoint([
             'location' => [
                 'path' => $path,

--- a/tests/unit/Debugger/BreakpointTest.php
+++ b/tests/unit/Debugger/BreakpointTest.php
@@ -176,7 +176,7 @@ class BreakpointTest extends TestCase
 
     public function testResolvedLocationNotIncludedInJson()
     {
-        $path = 'Debugger/DebuggerClient.php';
+        $path = implode(DIRECTORY_SEPARATOR, ['Debugger', 'DebuggerClient.php']);
         $breakpoint = new Breakpoint([
             'location' => [
                 'path' => $path,

--- a/tests/unit/Debugger/DebuggeeTest.php
+++ b/tests/unit/Debugger/DebuggeeTest.php
@@ -93,7 +93,7 @@ class DebuggeeTest extends TestCase
     {
         $this->connection->updateBreakpoint(Argument::that(function ($args) {
             return $args['id'] == 'breakpoint1';
-        }))->willReturn(true);
+        }))->willReturn([]);
         $debuggee = new Debuggee($this->connection->reveal(), ['id' => 'debuggee1', 'project' => 'project1']);
 
         $breakpoint = new Breakpoint([

--- a/tests/unit/Debugger/DebuggeeTest.php
+++ b/tests/unit/Debugger/DebuggeeTest.php
@@ -99,7 +99,7 @@ class DebuggeeTest extends TestCase
         $breakpoint = new Breakpoint([
             'id' => 'breakpoint1'
         ]);
-        $this->assertTrue($debuggee->updateBreakpoint($breakpoint));
+        $debuggee->updateBreakpoint($breakpoint);
     }
 
     // Debug agents should populate both sourceContexts and extSourceContexts.

--- a/tests/unit/Debugger/JsonTestTrait.php
+++ b/tests/unit/Debugger/JsonTestTrait.php
@@ -21,9 +21,16 @@ trait JsonTestTrait
 {
     private function assertProducesEquivalentJson($array1, $array2)
     {
-        $this->assertEquals(
-            json_decode(json_encode($array1), true),
-            json_decode(json_encode($array2), true)
-        );
+        if (!is_array($array2)) {
+            $array2 = json_decode(json_encode($array2), true);
+        }
+        foreach ($array1 as $key => $value) {
+            $this->assertArrayHasKey($key, $array2);
+            if (is_array($value)) {
+                $this->assertProducesEquivalentJson($value, $array2[$key]);
+            } else {
+                $this->assertEquals($value, $array2[$key]);
+            }
+        }
     }
 }

--- a/tests/unit/Debugger/SourceLocationResolverTest.php
+++ b/tests/unit/Debugger/SourceLocationResolverTest.php
@@ -32,7 +32,7 @@ class SourceLocationResolverTest extends TestCase
         $resolver = new SourceLocationResolver();
         $resolvedLocation = $resolver->resolve($location);
         $this->assertInstanceOf(SourceLocation::class, $resolvedLocation);
-        $expectedFile = realpath($this->sourcePath([__DIR__, '..', '..', '..', 'src', 'Debugger', 'DebuggerClient.php']));
+        $expectedFile = $this->sourcePath(['src', 'Debugger', 'DebuggerClient.php']);
         $this->assertEquals($expectedFile, $resolvedLocation->path());
         $this->assertEquals(1, $resolvedLocation->line());
     }
@@ -43,7 +43,7 @@ class SourceLocationResolverTest extends TestCase
         $resolver = new SourceLocationResolver();
         $resolvedLocation = $resolver->resolve($location);
         $this->assertInstanceOf(SourceLocation::class, $resolvedLocation);
-        $expectedFile = realpath($this->sourcePath([__DIR__, '..', '..', '..', 'src', 'Debugger', 'DebuggerClient.php']));
+        $expectedFile = $this->sourcePath(['src', 'Debugger', 'DebuggerClient.php']);
         $this->assertEquals($expectedFile, $resolvedLocation->path());
         $this->assertEquals(1, $resolvedLocation->line());
     }
@@ -54,7 +54,7 @@ class SourceLocationResolverTest extends TestCase
         $resolver = new SourceLocationResolver();
         $resolvedLocation = $resolver->resolve($location);
         $this->assertInstanceOf(SourceLocation::class, $resolvedLocation);
-        $expectedFile = realpath($this->sourcePath([__DIR__, '..', '..', '..', 'src', 'Debugger', 'DebuggerClient.php']));
+        $expectedFile = $this->sourcePath(['src', 'Debugger', 'DebuggerClient.php']);
         $this->assertEquals($expectedFile, $resolvedLocation->path());
         $this->assertEquals(1, $resolvedLocation->line());
     }


### PR DESCRIPTION
* `resolvedLocation` should not be included in the json payload
* `resolvedLocation` should be relative to the sourceRoot - the extension
requires relative paths.