### PR TITLE
Debugger: Expose setBreakpoint method

### DIFF
--- a/src/Debugger/Connection/ConnectionInterface.php
+++ b/src/Debugger/Connection/ConnectionInterface.php
@@ -53,4 +53,11 @@ interface ConnectionInterface
      * @param array $args
      */
     public function updateBreakpoint(array $args);
+
+    /**
+     * Sets a breakpoint.
+     *
+     * @param array $args
+     */
+    public function setBreakpoint(array $args);
 }

--- a/src/Debugger/Connection/Rest.php
+++ b/src/Debugger/Connection/Rest.php
@@ -86,4 +86,14 @@ class Rest implements ConnectionInterface
     {
         return $this->send('controller.resources.debuggees.resources.breakpoints', 'update', $args);
     }
+
+    /**
+     * Sets a breakpoint.
+     *
+     * @param array $args
+     */
+    public function setBreakpoint(array $args)
+    {
+        return $this->send('debugger.resources.debuggees.resources.breakpoints', 'set', $args);
+    }
 }

--- a/src/Debugger/Debuggee.php
+++ b/src/Debugger/Debuggee.php
@@ -293,6 +293,37 @@ class Debuggee implements \JsonSerializable
     }
 
     /**
+     * Set a breakpoint for this debuggee.
+     *
+     * Example:
+     * ```
+     * $breakpoint = $debuggee->setBreakpoint('DebuggerClient.php', 10);
+     * ```
+     *
+     * @codingStandardsIgnoreStart
+     * @see https://cloud.google.com/debugger/api/reference/rest/v2/debugger.debuggees.breakpoints/set Breakpoint set API documentation.
+     * @codingStandardsIgnoreEnd
+     *
+     * @param string $path Path to the source file.
+     * @param int $line Line within the source file.
+     * @param array $options [optional] Array of Breakpoint constructor arguments. See
+     *        {@see Google\Cloud\Debugger\Breakpoint::__construct()} for configuration details.
+     */
+    public function setBreakpoint($path, $line, array $options = [])
+    {
+        $breakpoint = new Breakpoint([
+            'location' => [
+                'path' => $path,
+                'line' => $line
+            ]
+        ] + $options);
+        $resp = $this->connection->setBreakpoint([
+            'debuggeeId' => $this->id
+        ] + $breakpoint->jsonSerialize());
+        return new Breakpoint($resp['breakpoint']);
+    }
+
+    /**
      * Update multiple breakpoints.
      *
      * Example:

--- a/src/Debugger/Debuggee.php
+++ b/src/Debugger/Debuggee.php
@@ -280,16 +280,19 @@ class Debuggee implements \JsonSerializable
      * @codingStandardsIgnoreEnd
      *
      * @param Breakpoint $breakpoint The modified breakpoint.
+     * @param array $options [optional] Configuration options. See
+     *        {@see Google\Cloud\Core\RequestWrapper::__construct()} for
+     *        configuration options which apply to all network requests.
      * @return void
      * @throws ServiceException
      */
-    public function updateBreakpoint(Breakpoint $breakpoint)
+    public function updateBreakpoint(Breakpoint $breakpoint, array $options = [])
     {
         $this->connection->updateBreakpoint([
             'debuggeeId' => $this->id,
             'id' => $breakpoint->id(),
             'breakpoint' => $breakpoint
-        ]);
+        ] + $options);
     }
 
     /**
@@ -307,19 +310,20 @@ class Debuggee implements \JsonSerializable
      * @param string $path Path to the source file.
      * @param int $line Line within the source file.
      * @param array $options [optional] Array of Breakpoint constructor arguments. See
-     *        {@see Google\Cloud\Debugger\Breakpoint::__construct()} for configuration details.
+     *        {@see Google\Cloud\Debugger\Breakpoint::__construct()} for
+     *        configuration details. See
+     *        {@see Google\Cloud\Core\RequestWrapper::__construct()} for
+     *        configuration options which apply to all network requests.
      */
     public function setBreakpoint($path, $line, array $options = [])
     {
-        $breakpoint = new Breakpoint([
+        $resp = $this->connection->setBreakpoint([
+            'debuggeeId' => $this->id,
             'location' => [
                 'path' => $path,
                 'line' => $line
             ]
         ] + $options);
-        $resp = $this->connection->setBreakpoint([
-            'debuggeeId' => $this->id
-        ] + $breakpoint->jsonSerialize());
         return new Breakpoint($resp['breakpoint']);
     }
 
@@ -336,13 +340,16 @@ class Debuggee implements \JsonSerializable
      * @codingStandardsIgnoreEnd
      *
      * @param Breakpoint[] $breakpoints The modified breakpoints.
+     * @param array $options [optional] Configuration options. See
+     *        {@see Google\Cloud\Core\RequestWrapper::__construct()} for
+     *        configuration options which apply to all network requests.
      * @return void
      * @throws ServiceException
      */
-    public function updateBreakpointBatch(array $breakpoints)
+    public function updateBreakpointBatch(array $breakpoints, array $options = [])
     {
         foreach ($breakpoints as $breakpoint) {
-            $this->updateBreakpoint($breakpoint);
+            $this->updateBreakpoint($breakpoint, $options);
         }
     }
 

--- a/tests/snippets/Debugger/DebuggeeTest.php
+++ b/tests/snippets/Debugger/DebuggeeTest.php
@@ -132,4 +132,15 @@ class DebuggeeTest extends SnippetTestCase
         $snippet->addLocal('breakpoint2', $breakpoint2);
         $snippet->invoke('debuggee');
     }
+
+    public function testSetBreakpoint()
+    {
+        $this->connection->setBreakpoint(Argument::any())->willReturn(['breakpoint' => ['id' => 'breakpoint1']])->shouldBeCalled();
+        $debuggee = new Debuggee($this->connection->reveal(), ['project' => 'project']);
+        $snippet = $this->snippetFromMethod(Debuggee::class, 'setBreakpoint');
+        $snippet->addLocal('debuggee', $debuggee);
+        $resp = $snippet->invoke('breakpoint');
+        $breakpoint = $resp->returnVal();
+        $this->assertInstanceOf(Breakpoint::class, $breakpoint);
+    }
 }

--- a/tests/system/Debugger/BasicTest.php
+++ b/tests/system/Debugger/BasicTest.php
@@ -72,15 +72,9 @@ class BasicTest extends TestCase
         $this->assertNotEmpty($debuggee->id());
 
         // Set a breakpoint
-        $client = new GapicClient();
-        $breakpoint = new GapicBreakpoint();
-        $location = new SourceLocation();
-        $location->setPath('tests/system/Debugger/BasicTest.php');
-        $location->setLine(__LINE__);
-        $breakpoint->setLocation($location);
-        $resp = $client->setBreakpoint($debuggee->id(), $breakpoint, 'google.com/php/v0.1');
-        $bp = $resp->getBreakpoint();
-        $this->assertNotEmpty($bp->getId());
+        $breakpoint = $debuggee->setBreakpoint('tests/system/Debugger/BasicTest.php', __LINE__);
+        $this->assertInstanceOf(Breakpoint::class, $breakpoint);
+        $this->assertNotNull($breakpoint->location());
 
         // Fetch the list of breakpoints
         $breakpoints = $debuggee->breakpoints();
@@ -91,7 +85,6 @@ class BasicTest extends TestCase
         );
 
         // fulfill a breakpoint
-        $breakpoint = $breakpoints[0];
         $this->assertTrue($breakpoint->resolveLocation());
         $breakpoint->finalize();
         $debuggee->updateBreakpoint($breakpoint);

--- a/tests/unit/Debugger/Connection/RestTest.php
+++ b/tests/unit/Debugger/Connection/RestTest.php
@@ -75,7 +75,8 @@ class RestTest extends TestCase
             ['listDebuggees'],
             ['registerDebuggee'],
             ['listBreakpoints'],
-            ['updateBreakpoint']
+            ['updateBreakpoint'],
+            ['setBreakpoint']
         ];
     }
 }

--- a/tests/unit/Debugger/DebuggeeTest.php
+++ b/tests/unit/Debugger/DebuggeeTest.php
@@ -106,8 +106,8 @@ class DebuggeeTest extends TestCase
     {
         $this->connection->setBreakpoint(Argument::that(function ($args) {
             return $args['debuggeeId'] == 'debuggee1' &&
-                $args['location']->path() == '/path/to/file.php' &&
-                $args['location']->line() == 10;
+                $args['location']['path'] == '/path/to/file.php' &&
+                $args['location']['line'] == 10;
         }))->willReturn(['breakpoint' => ['id' => 'breakpoint1']]);
         $debuggee = new Debuggee($this->connection->reveal(), ['id' => 'debuggee1', 'project' => 'project1']);
 

--- a/tests/unit/Debugger/DebuggeeTest.php
+++ b/tests/unit/Debugger/DebuggeeTest.php
@@ -102,6 +102,20 @@ class DebuggeeTest extends TestCase
         $debuggee->updateBreakpoint($breakpoint);
     }
 
+    public function testSetsBreakpoint()
+    {
+        $this->connection->setBreakpoint(Argument::that(function ($args) {
+            return $args['debuggeeId'] == 'debuggee1' &&
+                $args['location']->path() == '/path/to/file.php' &&
+                $args['location']->line() == 10;
+        }))->willReturn(['breakpoint' => ['id' => 'breakpoint1']]);
+        $debuggee = new Debuggee($this->connection->reveal(), ['id' => 'debuggee1', 'project' => 'project1']);
+
+        $breakpoint = $debuggee->setBreakpoint('/path/to/file.php', 10);
+        $this->assertInstanceOf(Breakpoint::class, $breakpoint);
+        $this->assertEquals('breakpoint1', $breakpoint->id());
+    }
+
     // Debug agents should populate both sourceContexts and extSourceContexts.
     public function testProvidesDeprecatedSourceContext()
     {


### PR DESCRIPTION
Most developers using Stackdriver Debugger will set their breakpoints from the Cloud Debugger UI Console (hence this functionality was not exposed previously). Surfacing this API will make end-to-end and system tests simpler.