### PR TITLE
Add pull request template to sub packages

### DIFF
--- a/dev/src/AddComponent/Command/AddComponent.php
+++ b/dev/src/AddComponent/Command/AddComponent.php
@@ -22,6 +22,7 @@ use Google\Cloud\Dev\AddComponent\Contributing;
 use Google\Cloud\Dev\AddComponent\Info;
 use Google\Cloud\Dev\AddComponent\License;
 use Google\Cloud\Dev\AddComponent\Manifest;
+use Google\Cloud\Dev\AddComponent\PullRequestTemplate;
 use Google\Cloud\Dev\AddComponent\QuestionTrait;
 use Google\Cloud\Dev\AddComponent\Readmes;
 use Google\Cloud\Dev\AddComponent\TableOfContents;
@@ -84,6 +85,13 @@ class AddComponent extends Command
             'Contributing',
             'Creating CONTRIBUTING.md file by copying from template.'
         ));
+
+        $output->writeln($formatter->formatSection(
+            'Pull Request Template',
+            'Creating .github/pull_request_template.md file by copying from template.'
+        ));
+
+        (new PullRequestTemplate($this->cliBasePath, $info['path']))->run();
 
         (new Contributing($this->cliBasePath, $info['path']))->run();
 

--- a/dev/src/AddComponent/PathTrait.php
+++ b/dev/src/AddComponent/PathTrait.php
@@ -33,7 +33,7 @@ trait PathTrait
 
     private function scanDirectory($path, array $excludes = [])
     {
-        $excludes = ['..', '.', '.DS_Store', 'VERSION', 'LICENSE', 'CONTRIBUTING.md'] + $excludes;
+        $excludes = ['..', '.', '.DS_Store', 'VERSION', 'LICENSE', 'CONTRIBUTING.md', '.github'] + $excludes;
         return array_diff(scandir($path), $excludes);
     }
 }

--- a/dev/src/AddComponent/PullRequestTemplate.php
+++ b/dev/src/AddComponent/PullRequestTemplate.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017 Google Inc.
+ * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dev/src/AddComponent/PullRequestTemplate.php
+++ b/dev/src/AddComponent/PullRequestTemplate.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Dev\AddComponent;
+
+/**
+ * Create pull request template file.
+ */
+class PullRequestTemplate
+{
+    /**
+     * @var string
+     */
+    private $cliBasePath;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+
+    public function __construct($cliBasePath, $path)
+    {
+        $this->cliBasePath = $cliBasePath;
+        $this->path = $path;
+    }
+
+    public function run()
+    {
+        $source = $this->cliBasePath . '/src/AddComponent/templates/template-pull_request_template.md.txt';
+        $dir = $this->path .'/.github';
+        $dest = $dir . '/pull_request_template.md';
+        @mkdir($dir);
+
+        $pathParts = explode('/', $this->path);
+        $template = file_get_contents($source);
+        $template = str_replace('{clientBase}', array_pop($pathParts), $template);
+
+        file_put_contents($dest, $template);
+    }
+}

--- a/dev/src/AddComponent/templates/template-pull_request_template.md.txt
+++ b/dev/src/AddComponent/templates/template-pull_request_template.md.txt
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/{clientBase}`, and tests in `tests/*/{clientBase}`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/dev/src/DocGenerator/DocGenerator.php
+++ b/dev/src/DocGenerator/DocGenerator.php
@@ -90,6 +90,10 @@ class DocGenerator
                     $this->isComponent
                 );
             } else {
+                if (strpos($file, '.github') !== false) {
+                    continue;
+                }
+
                 $content = file_get_contents($file);
                 $split = explode('src/', $file);
                 $parser = new MarkdownParser($split[1], $content);

--- a/src/BigQuery/.github/pull_request_template.md
+++ b/src/BigQuery/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/BigQuery`, and tests in `tests/*/BigQuery`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Bigtable/.github/pull_request_template.md
+++ b/src/Bigtable/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Bigtable`, and tests in `tests/*/Bigtable`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Container/.github/pull_request_template.md
+++ b/src/Container/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Container`, and tests in `tests/*/Container`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Core/.github/pull_request_template.md
+++ b/src/Core/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Core`, and tests in `tests/*/Core`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Dataproc/.github/pull_request_template.md
+++ b/src/Dataproc/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Dataproc`, and tests in `tests/*/Dataproc`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Datastore/.github/pull_request_template.md
+++ b/src/Datastore/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Datastore`, and tests in `tests/*/Datastore`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Debugger/.github/pull_request_template.md
+++ b/src/Debugger/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Debugger`, and tests in `tests/*/Debugger`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Dlp/.github/pull_request_template.md
+++ b/src/Dlp/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Dlp`, and tests in `tests/*/Dlp`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/ErrorReporting/.github/pull_request_template.md
+++ b/src/ErrorReporting/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/ErrorReporting`, and tests in `tests/*/ErrorReporting`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Firestore/.github/pull_request_template.md
+++ b/src/Firestore/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Firestore`, and tests in `tests/*/Firestore`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Language/.github/pull_request_template.md
+++ b/src/Language/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Language`, and tests in `tests/*/Language`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Logging/.github/pull_request_template.md
+++ b/src/Logging/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Logging`, and tests in `tests/*/Logging`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Monitoring/.github/pull_request_template.md
+++ b/src/Monitoring/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Monitoring`, and tests in `tests/*/Monitoring`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/OsLogin/.github/pull_request_template.md
+++ b/src/OsLogin/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/OsLogin`, and tests in `tests/*/OsLogin`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/PubSub/.github/pull_request_template.md
+++ b/src/PubSub/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/PubSub`, and tests in `tests/*/PubSub`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Spanner/.github/pull_request_template.md
+++ b/src/Spanner/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Spanner`, and tests in `tests/*/Spanner`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Speech/.github/pull_request_template.md
+++ b/src/Speech/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Speech`, and tests in `tests/*/Speech`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Storage/.github/pull_request_template.md
+++ b/src/Storage/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Storage`, and tests in `tests/*/Storage`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Trace/.github/pull_request_template.md
+++ b/src/Trace/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Trace`, and tests in `tests/*/Trace`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Translate/.github/pull_request_template.md
+++ b/src/Translate/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Translate`, and tests in `tests/*/Translate`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/VideoIntelligence/.github/pull_request_template.md
+++ b/src/VideoIntelligence/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/VideoIntelligence`, and tests in `tests/*/VideoIntelligence`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team

--- a/src/Vision/.github/pull_request_template.md
+++ b/src/Vision/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+**PLEASE READ THIS ENTIRE MESSAGE**
+
+Hello, and thank you for your contribution! Please note that this repository is
+a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
+unable to accept pull requests to this repository.
+
+We welcome your pull request and would be happy to consider it for inclusion in
+our library if you follow these steps:
+
+* Clone the parent client library repository:
+
+```sh
+$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
+```
+
+* Move your changes into the correct location in that library. Library code
+belongs in `src/Vision`, and tests in `tests/*/Vision`.
+
+* Push the changes in a new branch to a fork, and open a new pull request
+[here](https://github.com/GoogleCloudPlatform/google-cloud-php).
+
+Thanks again, and we look forward to seeing your proposed change!
+
+The Google Cloud PHP team


### PR DESCRIPTION
From time to time we've had pull requests opened against read-only repos. We're not able to accept those changes, and must redirect users to the parent repository. Github does not offer a way to disable pull requests on a repository.

This change adds a pull request template to each component, informing users that the pull request cannot be accepted and offering information on updating the pull and sending it to the correct repository. It also modifies the Add Component CLI to ensure that the PR template is added when a new component is created.