### PR TITLE
Debugger: Register Debuggee with labels

### DIFF
--- a/src/Debugger/Daemon.php
+++ b/src/Debugger/Daemon.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Debugger;
 
+use Google\Cloud\Core\Report\MetadataProviderUtils;
 use Google\Cloud\Core\Exception\ConflictException;
 use Google\Cloud\Debugger\BreakpointStorage\BreakpointStorageInterface;
 use Google\Cloud\Debugger\BreakpointStorage\SysvBreakpointStorage;
@@ -200,12 +201,17 @@ class Daemon
     private function defaultLabels()
     {
         $labels = [];
-        if (isset($_SERVER['GAE_SERVICE'])) {
-            $labels['module'] = $_SERVER['GAE_SERVICE'];
+        $provider = MetadataProviderUtils::autoSelect($_SERVER);
+        if ($provider->projectId()) {
+            $labels['projectid'] = $provider->projectId();
         }
-        if (isset($_SERVER['GAE_VERSION'])) {
-            $labels['version'] = $_SERVER['GAE_VERSION'];
+        if ($provider->serviceId()) {
+            $labels['module'] = $provider->serviceId();
         }
+        if ($provider->versionId()) {
+            $labels['version'] = $provider->versionId();
+        }
+        var_dump($labels);
         return $labels;
     }
 }

--- a/src/Debugger/Daemon.php
+++ b/src/Debugger/Daemon.php
@@ -69,13 +69,17 @@ class Daemon
      *            debuggee. **Defaults to** a value autodetected from the
      *            environment.
      *      @type string $description A display name for the debuggee in the
-     *            Stackdriver Debugger UI. **Defaults to** the uniquifier.
+     *            Stackdriver Debugger UI. **Defaults to** a value detected
+     *            from the environment.
      *      @type BreakpointStorageInterface $storage The breakpoint storage
      *            mechanism to use. **Defaults to** a new SysvBreakpointStorage
      *            instance.
-     *     @type MetadataProviderInterface $metadataProvider **Defaults to** An
-     *           automatically chosen provider, based on detected environment
-     *           settings.
+     *      @type array $labels A set of custom debuggee properties, populated
+     *            by the agent, to be displayed to the user. **Defaults to**
+     *            labels detected from the environment.
+     *      @type MetadataProviderInterface $metadataProvider **Defaults to** An
+     *            automatically chosen provider, based on detected environment
+     *            settings.
      * }
      */
     public function __construct($sourceRoot, array $options = [])

--- a/src/Debugger/Daemon.php
+++ b/src/Debugger/Daemon.php
@@ -83,7 +83,8 @@ class Daemon
             'sourceContext' => [],
             'extSourceContext' => [],
             'uniquifier' => null,
-            'description' => null
+            'description' => null,
+            'labels' => null
         ];
 
         $this->sourceRoot = realpath($sourceRoot);
@@ -98,11 +99,13 @@ class Daemon
 
         $uniquifier = $options['uniquifier'] ?: $this->defaultUniquifier();
         $description = $options['description'] ?: $this->defaultDescription();
+        $labels = $options['labels'] ?: $this->defaultLabels();
 
         $this->debuggee = $client->debuggee(null, [
             'uniquifier' => $uniquifier,
             'description' => $description,
-            'extSourceContexts' => $extSourceContext ? [$extSourceContext] : []
+            'extSourceContexts' => $extSourceContext ? [$extSourceContext] : [],
+            'labels' => $labels
         ]);
 
         $this->debuggee->register();
@@ -192,5 +195,17 @@ class Daemon
             return json_decode(file_get_contents($sourceContextFile), true);
         }
         return [];
+    }
+
+    private function defaultLabels()
+    {
+        $labels = [];
+        if (isset($_SERVER['GAE_SERVICE'])) {
+            $labels['module'] = $_SERVER['GAE_SERVICE'];
+        }
+        if (isset($_SERVER['GAE_VERSION'])) {
+            $labels['version'] = $_SERVER['GAE_VERSION'];
+        }
+        return $labels;
     }
 }

--- a/src/Debugger/Debuggee.php
+++ b/src/Debugger/Debuggee.php
@@ -145,7 +145,8 @@ class Debuggee implements \JsonSerializable
             'status' => null,
             'extSourceContexts' => [],
             'uniquifier' => null,
-            'description' => null
+            'description' => null,
+            'labels' => []
         ];
 
         $this->id = $info['id'];
@@ -156,6 +157,7 @@ class Debuggee implements \JsonSerializable
         $this->agentVersion = $info['agentVersion'];
         $this->isInactive = $info['isInactive'];
         $this->extSourceContexts = $info['extSourceContexts'];
+        $this->labels = $info['labels'];
     }
 
     /**
@@ -361,7 +363,7 @@ class Debuggee implements \JsonSerializable
      */
     public function jsonSerialize()
     {
-        return [
+        $info = [
             'id' => $this->id,
             'project' => $this->project,
             'uniquifier' => $this->uniquifier,
@@ -374,5 +376,9 @@ class Debuggee implements \JsonSerializable
             }, $this->extSourceContexts),
             'extSourceContexts' => $this->extSourceContexts
         ];
+        if (!empty($this->labels)) {
+            $info['labels'] = $this->labels;
+        }
+        return $info;
     }
 }

--- a/src/Debugger/Debuggee.php
+++ b/src/Debugger/Debuggee.php
@@ -130,8 +130,11 @@ class Debuggee implements \JsonSerializable
      *            user about this debuggee. Absence of this field indicates no
      *            status. The message can be either informational or an error
      *            status.
-     *      @type ExtendedSourceContext[] $extSourceContexts References to the locations and
-     *            revisions of the source code used in the deployed application.
+     *      @type ExtendedSourceContext[] $extSourceContexts References to the
+     *            locations and revisions of the source code used in the
+     *            deployed application.
+     *      @type array $labels  A set of custom debuggee properties, populated
+     *            by the agent, to be displayed to the user.
      * }
      */
     public function __construct(ConnectionInterface $connection, array $info = [])

--- a/tests/unit/Debugger/DaemonTest.php
+++ b/tests/unit/Debugger/DaemonTest.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Tests\Unit\Debugger;
 
+use Google\Cloud\Core\Report\SimpleMetadataProvider;
 use Google\Cloud\Debugger\Breakpoint;
 use Google\Cloud\Debugger\BreakpointStorage\BreakpointStorageInterface;
 use Google\Cloud\Debugger\Daemon;
@@ -156,5 +157,25 @@ class DaemonTest extends TestCase
             'storage' => $this->storage->reveal()
         ]);
         $daemon->run();
+    }
+
+    public function testDetectsLabelsFromEnvironment()
+    {
+        $provider = new SimpleMetadataProvider([], 'project1', 'service1', 'version1');
+        $expectedLabels = [
+            'module' => 'service1',
+            'projectid' => 'project1',
+            'version' => 'version1'
+        ];
+        $this->debuggee->register(Argument::any())
+            ->shouldBeCalled();
+        $this->client->debuggee(null, Argument::withEntry('labels', $expectedLabels))
+            ->willReturn($this->debuggee->reveal())
+            ->shouldBeCalled();
+
+        $daemon = new Daemon('.', [
+            'metadataProvider' => $provider,
+            'client' => $this->client->reveal()
+        ]);
     }
 }

--- a/tests/unit/Debugger/DaemonTest.php
+++ b/tests/unit/Debugger/DaemonTest.php
@@ -175,7 +175,8 @@ class DaemonTest extends TestCase
 
         $daemon = new Daemon('.', [
             'metadataProvider' => $provider,
-            'client' => $this->client->reveal()
+            'client' => $this->client->reveal(),
+            'storage' => $this->storage->reveal()
         ]);
     }
 }


### PR DESCRIPTION
Adding `projectid`, `module`, and `version` labels to the `Debuggee` when registering allows the debugger UI to link a debugger instance with both logging (via resource labels), and App Engine (by providing a link to debugger from an AppEngine service or version page).