### PR TITLE
Introduce options to serialize closures for batch processing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
         "vierbergenlars/php-semver": "^3.0",
         "symfony/lock": "3.3.x-dev#1ba6ac9",
         "phpseclib/phpseclib": "^2",
-        "google/cloud-tools": "^0.6"
+        "google/cloud-tools": "^0.6",
+        "opis/closure": "^3.0"
     },
     "replace": {
         "google/cloud-bigquery": "1.0.3",
@@ -88,6 +89,7 @@
         "google/cloud-debugger": "0.4.0"
     },
     "suggest": {
+        "opis/closure": "May be used to serialize closures to process jobs in the batch daemon. Please require version ^3.",
         "phpseclib/phpseclib": "May be used in place of OpenSSL for creating signed Cloud Storage URLs. Please require version ^2.",
         "google/cloud-bigquerydatatransfer": "Client library for the BigQuery Data Transfer API."
     },

--- a/src/Core/Batch/BatchTrait.php
+++ b/src/Core/Batch/BatchTrait.php
@@ -196,7 +196,7 @@ trait BatchTrait
         $this->debugOutput = isset($options['debugOutput'])
             ? $options['debugOutput']
             : false;
-        $this->clientConfig = $this->setWrappedClientConfig($options);
+        $this->clientConfig = $this->getWrappedClientConfig($options);
         $batchOptions = isset($options['batchOptions'])
             ? $options['batchOptions']
             : [];
@@ -219,7 +219,7 @@ trait BatchTrait
      * @param array $options
      * @return array
      */
-    private function setWrappedClientConfig(array $options)
+    private function getWrappedClientConfig(array $options)
     {
         $config = isset($options['clientConfig'])
             ? $options['clientConfig']

--- a/src/Core/Batch/ClosureSerializerInterface.php
+++ b/src/Core/Batch/ClosureSerializerInterface.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Batch;
+
+/**
+ * A closure serializer implementation utilzing
+ * [Opis Closure](https://github.com/opis/closure).
+ *
+ * @experimental The experimental flag means that while we believe this method
+ *      or class is ready for use, it may change before release in backwards-
+ *      incompatible ways. Please use with caution, and test thoroughly when
+ *      upgrading.
+ */
+interface ClosureSerializerInterface
+{
+    /**
+     * Recursively serializes closures.
+     *
+     * @param mixed $data
+     */
+    public function wrapClosures(&$data);
+
+    /**
+     * Recursively unserializes closures.
+     *
+     * @param mixed $data
+     */
+    public function unwrapClosures(&$data);
+}

--- a/src/Core/Batch/ClosureSerializerInterface.php
+++ b/src/Core/Batch/ClosureSerializerInterface.php
@@ -18,8 +18,7 @@
 namespace Google\Cloud\Core\Batch;
 
 /**
- * A closure serializer implementation utilzing
- * [Opis Closure](https://github.com/opis/closure).
+ * An interface for serializing closures.
  *
  * @experimental The experimental flag means that while we believe this method
  *      or class is ready for use, it may change before release in backwards-

--- a/src/Core/Batch/OpisClosureSerializer.php
+++ b/src/Core/Batch/OpisClosureSerializer.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Batch;
+
+use Opis\Closure\SerializableClosure;
+
+/**
+ * A closure serializer utilizing
+ * [Opis Closure Library](https://github.com/opis/closure).
+ *
+ * @experimental The experimental flag means that while we believe this method
+ *      or class is ready for use, it may change before release in backwards-
+ *      incompatible ways. Please use with caution, and test thoroughly when
+ *      upgrading.
+ */
+class OpisClosureSerializer implements ClosureSerializerInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function wrapClosures(&$data)
+    {
+        SerializableClosure::enterContext();
+        SerializableClosure::wrapClosures($data);
+        SerializableClosure::exitContext();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function unwrapClosures(&$data)
+    {
+        SerializableClosure::enterContext();
+        SerializableClosure::unwrapClosures($data);
+        SerializableClosure::exitContext();
+    }
+}

--- a/src/Core/Batch/OpisClosureSerializer.php
+++ b/src/Core/Batch/OpisClosureSerializer.php
@@ -31,7 +31,9 @@ use Opis\Closure\SerializableClosure;
 class OpisClosureSerializer implements ClosureSerializerInterface
 {
     /**
-     * {@inheritDoc}
+     * Recursively serializes closures.
+     *
+     * @param mixed $data
      */
     public function wrapClosures(&$data)
     {
@@ -41,7 +43,9 @@ class OpisClosureSerializer implements ClosureSerializerInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Recursively unserializes closures.
+     *
+     * @param mixed $data
      */
     public function unwrapClosures(&$data)
     {

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -13,6 +13,7 @@
         "psr/http-message": "1.0.*"
     },
     "suggest": {
+        "opis/closure": "May be used to serialize closures to process jobs in the batch daemon. Please require version ^3.",
         "symfony/lock": "Required for the Spanner cached based session pool. Please require the following commit: 3.3.x-dev#1ba6ac9"
     },
     "extra": {

--- a/src/Debugger/Agent.php
+++ b/src/Debugger/Agent.php
@@ -195,7 +195,7 @@ class Agent
 
     private function defaultDebuggee()
     {
-        $client = new DebuggerClient($this->clientConfig);
+        $client = new DebuggerClient($this->getUnwrappedClientConfig());
         return $client->debuggee($this->debuggeeId);
     }
 

--- a/src/Logging/LoggingClient.php
+++ b/src/Logging/LoggingClient.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Logging;
 
 use Google\Cloud\Core\ArrayTrait;
+use Google\Cloud\Core\Batch\ClosureSerializerInterface;
 use Google\Cloud\Core\ClientTrait;
 use Google\Cloud\Core\Iterator\ItemIterator;
 use Google\Cloud\Core\Iterator\PageIterator;
@@ -121,6 +122,12 @@ class LoggingClient
      *     @type BatchRunner $batchRunner A BatchRunner object. Mainly used for
      *           the tests to inject a mock. **Defaults to** a newly created
      *           BatchRunner.
+     *     @type ClosureSerializerInterface $closureSerializer An implementation
+     *           responsible for serializing closures used in the
+     *           `$clientConfig`. This is especially important when using the
+     *           batch daemon. **Defaults to**
+     *           {@see Google\Cloud\Core\Batch\OpisClosureSerializer} if the
+     *           `opis/closure` library is installed.
      * }
      * @return PsrLogger
      * @experimental The experimental flag means that while we believe this method

--- a/src/Logging/PsrLogger.php
+++ b/src/Logging/PsrLogger.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Logging;
 
 use Google\Cloud\Core\Batch\BatchTrait;
+use Google\Cloud\Core\Batch\ClosureSerializerInterface;
 use Google\Cloud\Core\Report\MetadataProviderInterface;
 use Google\Cloud\Core\Report\MetadataProviderUtils;
 use Monolog\Formatter\NormalizerFormatter;
@@ -118,6 +119,12 @@ class PsrLogger implements LoggerInterface, \Serializable
      *     @type BatchRunner $batchRunner A BatchRunner object. Mainly used for
      *           the tests to inject a mock. **Defaults to** a newly created
      *           BatchRunner. Applies only when `batchEnabled` is set to `true`.
+     *     @type ClosureSerializerInterface $closureSerializer An implementation
+     *           responsible for serializing closures used in the
+     *           `$clientConfig`. This is especially important when using the
+     *           batch daemon. **Defaults to**
+     *           {@see Google\Cloud\Core\Batch\OpisClosureSerializer} if the
+     *           `opis/closure` library is installed.
      * }
      */
     public function __construct(
@@ -458,7 +465,7 @@ class PsrLogger implements LoggerInterface, \Serializable
     protected function getCallback()
     {
         if (!array_key_exists($this->logName, self::$loggers)) {
-            $c = new LoggingClient($this->clientConfig);
+            $c = new LoggingClient($this->getUnwrappedClientConfig());
             self::$loggers[$this->logName] = $c->logger($this->logName);
         }
         return [self::$loggers[$this->logName], $this->batchMethod];

--- a/src/PubSub/BatchPublisher.php
+++ b/src/PubSub/BatchPublisher.php
@@ -99,7 +99,7 @@ class BatchPublisher
     protected function getCallback()
     {
         if (!array_key_exists($this->topicName, self::$topics)) {
-            $client = new PubSubClient($this->clientConfig);
+            $client = new PubSubClient($this->getUnwrappedClientConfig());
             self::$topics[$this->topicName] = $client->topic($this->topicName);
         }
 

--- a/src/PubSub/Topic.php
+++ b/src/PubSub/Topic.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\PubSub;
 
 use Google\Cloud\Core\ArrayTrait;
+use Google\Cloud\Core\Batch\ClosureSerializerInterface;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Iam\Iam;
 use Google\Cloud\Core\Iterator\ItemIterator;
@@ -382,6 +383,12 @@ class Topic
      *     @type string $identifier An identifier for the batch job.
      *           **Defaults to** `pubsub-topic-{topic-name}`.
      *           Example: `pubsub-topic-mytopic`.
+     *     @type ClosureSerializerInterface $closureSerializer An implementation
+     *           responsible for serializing closures used in the
+     *           `$clientConfig`. This is especially important when using the
+     *           batch daemon. **Defaults to**
+     *           {@see Google\Cloud\Core\Batch\OpisClosureSerializer} if the
+     *           `opis/closure` library is installed.
      * }
      * @return BatchPublisher
      * @experimental The experimental flag means that while we believe this method

--- a/tests/unit/Core/Batch/OpisClosureSerializerTest.php
+++ b/tests/unit/Core/Batch/OpisClosureSerializerTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Unit\Core\Batch;
+
+use Google\Cloud\Core\Batch\OpisClosureSerializer;
+use Opis\Closure\SerializableClosure;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group core
+ * @group batch
+ */
+class OpisClosureSerializerTest extends TestCase
+{
+    private $serialzer;
+
+    public function setUp()
+    {
+        $this->serializer = new OpisClosureSerializer();
+    }
+
+    public function testWrapAndUnwrapClosures()
+    {
+        $data['closure'] = function () {
+            return true;
+        };
+
+        $this->serializer
+            ->wrapClosures($data);
+
+        $this->assertInstanceOf(SerializableClosure::class, $data['closure']);
+        $this->serializer
+            ->unwrapClosures($data);
+        $this->assertTrue($data['closure']());
+    }
+}

--- a/tests/unit/Logging/LoggingClientTest.php
+++ b/tests/unit/Logging/LoggingClientTest.php
@@ -71,11 +71,12 @@ class LoggingClientTest extends TestCase
             ['clientConfig' => ['projectId' => 'my-project']]);
         $this->assertInstanceOf(PsrLogger::class, $psrBatchLogger);
         $r = new \ReflectionObject($psrBatchLogger);
-        $p = $r->getProperty('clientConfig');
-        $p->setAccessible(true);
+        $method = $r->getMethod('getUnwrappedClientConfig');
+        $method->setAccessible(true);
+
         $this->assertEquals(
             ['projectId' => 'my-project'],
-            $p->getValue($psrBatchLogger)
+            $method->invoke($psrBatchLogger)
         );
     }
 


### PR DESCRIPTION
Closes: https://github.com/GoogleCloudPlatform/google-cloud-php/issues/588

@chingor13 What do you think? The goal of this approach was to add a lower friction way for users to supply closures to configurations used in the batch daemon. I looked at making these changes in `Google\Cloud\Core\Batch\SysvConfigStorage` but was concerned it wasn't very straight forward to supply a custom interface [when initializing the daemon](https://github.com/GoogleCloudPlatform/google-cloud-php/blob/master/src/Core/bin/google-cloud-batch#L45).