### PR TITLE
Add documents() method to Firestore Transaction

### DIFF
--- a/Firestore/src/PathTrait.php
+++ b/Firestore/src/PathTrait.php
@@ -52,6 +52,8 @@ trait PathTrait
     }
 
     /**
+     * Create a fully-qualified database name from a projectId and database id.
+     *
      * @param string $projectId The project ID.
      * @param string $database The database name.
      */
@@ -61,7 +63,10 @@ trait PathTrait
     }
 
     /**
-     * Get the database name from a path.
+     * Return the database name from a fully-qualified path name.
+     *
+     * This method returns a fully-qualified path. For the database ID, use
+     * {@see Google\Cloud\Firestore\PathTrait::databaseIdFromName()}.
      *
      * @param string $name
      * @return string
@@ -70,6 +75,43 @@ trait PathTrait
     {
         $parts = explode('/databases/', $name);
         return $parts[0] . '/databases/' . explode('/', $parts[1])[0];
+    }
+
+    /**
+     * Return the database ID from a fully-qualified path name.
+     *
+     * This method returns a bare database ID. For the fully-qualified database
+     * name, use {@see Google\Cloud\Firestore\PathTrait::databaseFromName()}.
+     *
+     * @param string $name
+     * @return string
+     */
+    private function databaseIdFromName($name)
+    {
+        $parts = explode('/databases/', $name);
+        if (count($parts) !== 2) {
+            return null;
+        }
+
+        $trailing = explode('/', $parts[1]);
+        return $trailing[0];
+    }
+
+    /**
+     * Get the project id from a path
+     *
+     * @param string $path
+     * @return string|null
+     */
+    private function projectIdFromName($name)
+    {
+        $name = trim($name, '/');
+        if (strpos($name, 'projects/') !== 0) {
+            return null;
+        }
+
+        $parts = explode('/', $name);
+        return $parts[1];
     }
 
     /**

--- a/Firestore/src/PathTrait.php
+++ b/Firestore/src/PathTrait.php
@@ -88,13 +88,13 @@ trait PathTrait
      */
     private function databaseIdFromName($name)
     {
-        $parts = explode('/databases/', $name);
-        if (count($parts) !== 2) {
+        $name = trim($name, '/');
+        $parts = explode('/', $name);
+        if ($parts[0] !== 'projects') {
             return null;
         }
 
-        $trailing = explode('/', $parts[1]);
-        return $trailing[0];
+        return $parts[3];
     }
 
     /**

--- a/Firestore/src/SnapshotTrait.php
+++ b/Firestore/src/SnapshotTrait.php
@@ -153,6 +153,19 @@ trait SnapshotTrait
         return $data;
     }
 
+    /**
+     * Fetches a list of documents by their paths, orders them to match the
+     * input order, creates a list of snapshots (whether the document exists or
+     * not), and returns.
+     *
+     * @param ConnectionInterface $connection A connection to Cloud Firestore.
+     * @param ValueMapper $mapper A Firestore value mapper.
+     * @param string $projectId The current project id.
+     * @param string $database The database id.
+     * @param string[] $paths A list of fully-qualified firestore document paths.
+     * @param array $options Configuration options.
+     * @return DocumentSnapshot[]
+     */
     private function getDocumentsByPaths(
         ConnectionInterface $connection,
         ValueMapper $mapper,
@@ -217,6 +230,17 @@ trait SnapshotTrait
         return $out;
     }
 
+    /**
+     * Creates a DocumentReference object.
+     *
+     * @param ConnectionInterface $connection A connection to Cloud Firestore.
+     * @param ValueMapper $mapper A Firestore value mapper.
+     * @param string $projectId The current project id.
+     * @param string $database The database id.
+     * @param string $name The document name, in absolute form, or relative to the database.
+     * @return DocumentReference
+     * @throws InvalidArgumentException if an invalid path is provided.
+     */
     private function getDocumentReference(
         ConnectionInterface $connection,
         ValueMapper $mapper,
@@ -246,6 +270,17 @@ trait SnapshotTrait
         );
     }
 
+    /**
+     * Creates a CollectionReference object.
+     *
+     * @param ConnectionInterface $connection A connection to Cloud Firestore.
+     * @param ValueMapper $mapper A Firestore value mapper.
+     * @param string $projectId The current project id.
+     * @param string $database The database id.
+     * @param string $name The collection name, in absolute form, or relative to the database.
+     * @return CollectionReference
+     * @throws InvalidArgumentException if an invalid path is provided.
+     */
     private function getCollectionReference(
         ConnectionInterface $connection,
         ValueMapper $mapper,

--- a/Firestore/src/SnapshotTrait.php
+++ b/Firestore/src/SnapshotTrait.php
@@ -17,11 +17,12 @@
 
 namespace Google\Cloud\Firestore;
 
-use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\ArrayTrait;
-use Google\Cloud\Core\ValueMapperTrait;
 use Google\Cloud\Core\Exception\NotFoundException;
+use Google\Cloud\Core\Timestamp;
+use Google\Cloud\Core\ValueMapperTrait;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
+use Google\Cloud\Firestore\DocumentReference;
 
 /**
  * Methods common to representing Document Snapshots.
@@ -150,5 +151,119 @@ trait SnapshotTrait
             : null;
 
         return $data;
+    }
+
+    private function getDocumentsByPaths(
+        ConnectionInterface $connection,
+        ValueMapper $mapper,
+        $projectId,
+        $database,
+        array $paths,
+        array $options
+    ) {
+        array_walk($paths, function (&$path) use ($projectId, $database) {
+            if ($path instanceof DocumentReference) {
+                $path = $path->name();
+            }
+
+            if (!is_string($path)) {
+                throw new \InvalidArgumentException(
+                    'All members of $paths must be strings or instances of DocumentReference.'
+                );
+            }
+
+            $path = $this->isRelative($path)
+                ? $this->fullName($projectId, $database, $path)
+                : $path;
+        });
+
+        $documents = $this->connection->batchGetDocuments([
+            'database' => $this->databaseName($projectId, $database),
+            'documents' => $paths,
+        ] + $options);
+
+        $res = [];
+        foreach ($documents as $document) {
+            $exists = isset($document['found']);
+            $data = $exists
+                ? $document['found'] + ['readTime' => $document['readTime']]
+                : ['readTime' => $document['readTime']];
+
+            $name = $exists
+                ? $document['found']['name']
+                : $document['missing'];
+
+            $ref = $this->getDocumentReference(
+                $connection,
+                $mapper,
+                $projectId,
+                $database,
+                $name
+            );
+
+            $res[$name] = $this->createSnapshotWithData(
+                $mapper,
+                $ref,
+                $data,
+                $exists
+            );
+        }
+
+        $out = [];
+        foreach ($paths as $path) {
+            $out[] = $res[$path];
+        }
+
+        return $out;
+    }
+
+    private function getDocumentReference(
+        ConnectionInterface $connection,
+        ValueMapper $mapper,
+        $projectId,
+        $database,
+        $name
+    ) {
+        if ($this->isRelative($name)) {
+            $name = $this->fullName($projectId, $database, $name);
+        }
+
+        if (!$this->isDocument($name)) {
+            throw new \InvalidArgumentException('Given path is not a valid document path.');
+        }
+
+        return new DocumentReference(
+            $connection,
+            $mapper,
+            $this->getCollectionReference(
+                $connection,
+                $mapper,
+                $projectId,
+                $database,
+                $this->parentPath($name)
+            ),
+            $name
+        );
+    }
+
+    private function getCollectionReference(
+        ConnectionInterface $connection,
+        ValueMapper $mapper,
+        $projectId,
+        $database,
+        $name
+    ) {
+        if ($this->isRelative($name)) {
+            $name = $this->fullName($projectId, $database, $name);
+        }
+
+        if (!$this->isCollection($name)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Given path `%s` is not a valid collection path.',
+                $name
+            ));
+        }
+
+        return new CollectionReference($connection, $mapper, $name);
     }
 }

--- a/Firestore/src/Transaction.php
+++ b/Firestore/src/Transaction.php
@@ -113,6 +113,60 @@ class Transaction
     }
 
     /**
+     * Get a list of documents by their path.
+     *
+     * The number of results generated will be equal to the number of documents
+     * requested, except in case of error.
+     *
+     * Note that this method will **always** return instances of
+     * {@see Google\Cloud\Firestore\DocumentSnapshot}, even if the documents
+     * requested do not exist. It is highly recommended that you check for
+     * existence before accessing document data.
+     *
+     * Example:
+     * ```
+     * $documents = $transaction->documents([
+     *     'users/john',
+     *     'users/dave'
+     * ]);
+     * ```
+     *
+     * ```
+     * // To check whether a given document exists, use `DocumentSnapshot::exists()`.
+     * $documents = $transaction->documents([
+     *     'users/deleted-user'
+     * ]);
+     *
+     * foreach ($documents as $document) {
+     *     if (!$document->exists()) {
+     *         echo $document->id() . ' Does Not Exist';
+     *     }
+     * }
+     * ```
+     *
+     * @codingStandardsIgnoreStart
+     * @see https://cloud.google.com/firestore/docs/reference/rpc/google.firestore.v1beta1#google.firestore.v1beta1.Firestore.BatchGetDocuments BatchGetDocuments
+     * @codingStandardsIgnoreEnd
+     *
+     * @param string[]|DocumentReference[] $paths Any combination of string paths or DocumentReference instances.
+     * @param array $options Configuration options.
+     * @return DocumentSnapshot[]
+     */
+    public function documents(array $paths, array $options = [])
+    {
+        return $this->getDocumentsByPaths(
+            $this->connection,
+            $this->valueMapper,
+            $this->projectIdFromName($this->database),
+            $this->databaseIdFromName($this->database),
+            $paths,
+            [
+                'transaction' => $this->transaction
+            ] + $options
+        );
+    }
+
+    /**
      * Run a Query inside the Transaction.
      *
      * Example:

--- a/Firestore/tests/Snippet/TransactionTest.php
+++ b/Firestore/tests/Snippet/TransactionTest.php
@@ -40,6 +40,8 @@ class TransactionTest extends SnippetTestCase
 {
     use GrpcTestTrait;
 
+    const PROJECT = 'example_project';
+    const DATABASE_ID = '(default)';
     const TRANSACTION = 'foobar';
     const DATABASE = 'projects/example_project/databases/(default)';
     const DOCUMENT = 'projects/example_project/databases/(default)/documents/a/b';
@@ -205,6 +207,59 @@ class TransactionTest extends SnippetTestCase
         $snippet->addLocal('transaction', $this->transaction);
         $snippet->addLocal('document', $this->document->reveal());
         $snippet->invoke();
+    }
+
+    public function testDocuments()
+    {
+        $tpl = 'projects/%s/databases/%s/documents/users/%s';
+
+        $this->connection->batchGetDocuments(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                [
+                    'found' => [
+                        'name' => sprintf($tpl, self::PROJECT, self::DATABASE_ID, 'john'),
+                        'fields' => []
+                    ],
+                    'readTime' => ['seconds' => time()]
+                ], [
+                    'found' => [
+                        'name' => sprintf($tpl, self::PROJECT, self::DATABASE_ID, 'dave'),
+                        'fields' => []
+                    ],
+                    'readTime' => ['seconds' => time()]
+                ]
+            ]);
+
+        $this->transaction->___setProperty('connection', $this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(Transaction::class, 'documents');
+        $snippet->addLocal('transaction', $this->transaction);
+        $res = $snippet->invoke('documents')->returnVal();
+
+        $this->assertInstanceOf(DocumentSnapshot::class, $res[0]);
+        $this->assertEquals('john', $res[0]->id());
+    }
+
+    public function testDocumentsDoesntExist()
+    {
+        $tpl = 'projects/%s/databases/%s/documents/users/%s';
+        $this->connection->batchGetDocuments(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                [
+                    'missing' => sprintf($tpl, self::PROJECT, self::DATABASE_ID, 'deleted-user'),
+                    'readTime' => ['seconds' => time()]
+                ]
+            ]);
+
+        $this->transaction->___setProperty('connection', $this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(Transaction::class, 'documents', 1);
+        $snippet->addLocal('transaction', $this->transaction);
+        $res = $snippet->invoke();
+
+        $this->assertEquals('deleted-user Does Not Exist', $res->output());
     }
 }
 

--- a/Firestore/tests/Snippet/TransactionTest.php
+++ b/Firestore/tests/Snippet/TransactionTest.php
@@ -45,6 +45,7 @@ class TransactionTest extends SnippetTestCase
     const TRANSACTION = 'foobar';
     const DATABASE = 'projects/example_project/databases/(default)';
     const DOCUMENT = 'projects/example_project/databases/(default)/documents/a/b';
+    const DOCUMENT_TEMPLATE = 'projects/%s/databases/%s/documents/users/%s';
 
     private $connection;
     private $transaction;
@@ -211,20 +212,18 @@ class TransactionTest extends SnippetTestCase
 
     public function testDocuments()
     {
-        $tpl = 'projects/%s/databases/%s/documents/users/%s';
-
         $this->connection->batchGetDocuments(Argument::any())
             ->shouldBeCalled()
             ->willReturn([
                 [
                     'found' => [
-                        'name' => sprintf($tpl, self::PROJECT, self::DATABASE_ID, 'john'),
+                        'name' => sprintf(self::DOCUMENT_TEMPLATE, self::PROJECT, self::DATABASE_ID, 'john'),
                         'fields' => []
                     ],
                     'readTime' => ['seconds' => time()]
                 ], [
                     'found' => [
-                        'name' => sprintf($tpl, self::PROJECT, self::DATABASE_ID, 'dave'),
+                        'name' => sprintf(self::DOCUMENT_TEMPLATE, self::PROJECT, self::DATABASE_ID, 'dave'),
                         'fields' => []
                     ],
                     'readTime' => ['seconds' => time()]
@@ -243,12 +242,11 @@ class TransactionTest extends SnippetTestCase
 
     public function testDocumentsDoesntExist()
     {
-        $tpl = 'projects/%s/databases/%s/documents/users/%s';
         $this->connection->batchGetDocuments(Argument::any())
             ->shouldBeCalled()
             ->willReturn([
                 [
-                    'missing' => sprintf($tpl, self::PROJECT, self::DATABASE_ID, 'deleted-user'),
+                    'missing' => sprintf(self::DOCUMENT_TEMPLATE, self::PROJECT, self::DATABASE_ID, 'deleted-user'),
                     'readTime' => ['seconds' => time()]
                 ]
             ]);

--- a/Firestore/tests/System/GetAllDocumentsTest.php
+++ b/Firestore/tests/System/GetAllDocumentsTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Tests\System\Firestore;
+namespace Google\Cloud\Firestore\Tests\System;
 
 use Google\Cloud\Firestore\DocumentReference;
 use Google\Cloud\Firestore\DocumentSnapshot;

--- a/Firestore/tests/System/GetAllDocumentsTest.php
+++ b/Firestore/tests/System/GetAllDocumentsTest.php
@@ -91,10 +91,10 @@ class GetAllDocumentsTest extends FirestoreTestCase
         }
     }
 
-    private function interleave($names = false)
+    private function interleave()
     {
-        $exist = $names ? array_keys(self::$refsExist) : array_values(self::$refsExist);
-        $nonExist = $names ? array_keys(self::$refsNonExist) : array_values(self::$refsNonExist);
+        $exist = array_values(self::$refsExist);
+        $nonExist = array_values(self::$refsNonExist);
         $docs = [];
         foreach ($exist as $i => $doc) {
             $docs[] = $doc;

--- a/Firestore/tests/Unit/FirestoreClientTest.php
+++ b/Firestore/tests/Unit/FirestoreClientTest.php
@@ -181,10 +181,6 @@ class FirestoreClientTest extends TestCase
      */
     public function testDocuments(array $input, array $names)
     {
-        $name = function ($name) {
-            return sprintf('projects/%s/databases/%s/documents/%s', self::PROJECT, self::DATABASE, $name);
-        };
-
         $res = [
             [
                 'found' => [

--- a/Firestore/tests/Unit/TransactionTest.php
+++ b/Firestore/tests/Unit/TransactionTest.php
@@ -201,6 +201,126 @@ class TransactionTest extends TestCase
         ]);
     }
 
+    /**
+     * @dataProvider documents
+     */
+    public function testDocuments(array $input, array $names)
+    {
+        $name = function ($name) {
+            return sprintf('projects/%s/databases/%s/documents/%s', self::PROJECT, self::DATABASE, $name);
+        };
+
+        $res = [
+            [
+                'found' => [
+                    'name' => $names[0],
+                    'fields' => [
+                        'hello' => [
+                            'stringValue' => 'world'
+                        ]
+                    ]
+                ],
+                'readTime' => ['seconds' => 1, 'nanos' => 0]
+            ], [
+                'missing' => $names[1],
+                'readTime' => ['seconds' => 1, 'nanos' => 0]
+            ], [
+                'missing' => $names[2],
+                'readTime' => ['seconds' => 1, 'nanos' => 0]
+            ]
+        ];
+
+        $this->connection->batchGetDocuments(Argument::allOf(
+            Argument::withEntry('documents', $names),
+            Argument::withEntry('transaction', self::TRANSACTION)
+        ))->shouldBeCalled()->willReturn($res);
+
+        $this->transaction->___setProperty('connection', $this->connection->reveal());
+
+        $res = $this->transaction->documents($input);
+
+        $this->assertEquals('world', $res[0]['hello']);
+    }
+
+    public function documents()
+    {
+        $b = $this->prophesize(DocumentReference::class);
+        $b->name()->willReturn('a/b');
+
+        $c = $this->prophesize(DocumentReference::class);
+        $c->name()->willReturn('a/c');
+
+        $d = $this->prophesize(DocumentReference::class);
+        $d->name()->willReturn('a/d');
+        return [
+            [
+                [
+                    'a/b',
+                    'a/c',
+                    'a/d'
+                ], [
+                    'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/b',
+                    'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/c',
+                    'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/d'
+                ]
+                ], [
+                    [
+                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/b',
+                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/c',
+                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/d'
+                    ], [
+                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/b',
+                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/c',
+                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/d'
+                    ]
+                ], [
+                    [
+                        $b->reveal(),
+                        $c->reveal(),
+                        $d->reveal()
+                    ], [
+                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/b',
+                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/c',
+                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/d'
+                    ]
+                ]
+        ];
+    }
+
+    public function testDocumentsOrdered()
+    {
+        $tpl = 'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/%s';
+        $names = [
+            sprintf($tpl, 'a'),
+            sprintf($tpl, 'b'),
+            sprintf($tpl, 'c'),
+        ];
+
+        $res = [
+            [
+                'missing' => $names[2],
+                'readTime' => ['seconds' => 1, 'nanos' => 0]
+            ], [
+                'missing' => $names[1],
+                'readTime' => ['seconds' => 1, 'nanos' => 0]
+            ], [
+                'missing' => $names[0],
+                'readTime' => ['seconds' => 1, 'nanos' => 0]
+            ]
+        ];
+
+        $this->connection->batchGetDocuments(Argument::withEntry('documents', $names))
+            ->shouldBeCalled()
+            ->willReturn($res);
+
+        $this->transaction->___setProperty('connection', $this->connection->reveal());
+
+        $res = $this->transaction->documents($names);
+        $this->assertEquals($names[0], $res[0]->name());
+        $this->assertEquals($names[1], $res[1]->name());
+        $this->assertEquals($names[2], $res[2]->name());
+    }
+
     private function expectAndInvoke(array $writes)
     {
         $this->connection->commit([

--- a/Firestore/tests/Unit/TransactionTest.php
+++ b/Firestore/tests/Unit/TransactionTest.php
@@ -206,10 +206,6 @@ class TransactionTest extends TestCase
      */
     public function testDocuments(array $input, array $names)
     {
-        $name = function ($name) {
-            return sprintf('projects/%s/databases/%s/documents/%s', self::PROJECT, self::DATABASE, $name);
-        };
-
         $res = [
             [
                 'found' => [
@@ -245,6 +241,8 @@ class TransactionTest extends TestCase
 
     public function documents()
     {
+        $pathBase = 'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents';
+
         $b = $this->prophesize(DocumentReference::class);
         $b->name()->willReturn('a/b');
 
@@ -260,19 +258,19 @@ class TransactionTest extends TestCase
                     'a/c',
                     'a/d'
                 ], [
-                    'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/b',
-                    'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/c',
-                    'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/d'
+                    $pathBase . '/a/b',
+                    $pathBase . '/a/c',
+                    $pathBase . '/a/d'
                 ]
                 ], [
                     [
-                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/b',
-                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/c',
-                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/d'
+                        $pathBase . '/a/b',
+                        $pathBase . '/a/c',
+                        $pathBase . '/a/d'
                     ], [
-                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/b',
-                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/c',
-                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/d'
+                        $pathBase . '/a/b',
+                        $pathBase . '/a/c',
+                        $pathBase . '/a/d'
                     ]
                 ], [
                     [
@@ -280,9 +278,9 @@ class TransactionTest extends TestCase
                         $c->reveal(),
                         $d->reveal()
                     ], [
-                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/b',
-                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/c',
-                        'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/d'
+                        $pathBase . '/a/b',
+                        $pathBase . '/a/c',
+                        $pathBase . '/a/d'
                     ]
                 ]
         ];

--- a/Firestore/tests/Unit/TransactionTest.php
+++ b/Firestore/tests/Unit/TransactionTest.php
@@ -240,6 +240,7 @@ class TransactionTest extends TestCase
         $res = $this->transaction->documents($input);
 
         $this->assertEquals('world', $res[0]['hello']);
+        $this->assertCount(3, $res);
     }
 
     public function documents()

--- a/tests/system/Firestore/GetAllDocumentsTest.php
+++ b/tests/system/Firestore/GetAllDocumentsTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\System\Firestore;
+
+use Google\Cloud\Firestore\DocumentReference;
+use Google\Cloud\Firestore\DocumentSnapshot;
+
+/**
+ * @group firestore
+ * @group firestore-getalldocuments
+ */
+class GetAllDocumentsTest extends FirestoreTestCase
+{
+    private static $refsExist = [];
+    private static $refsNonExist = [];
+
+    public static function setupBeforeClass()
+    {
+        parent::setupBeforeClass();
+
+        $c = self::$client->collection('getAllDocumentsTest');
+        for ($i = 0; $i < 5; $i++) {
+            $doc = $c->add([
+                'name' => 'foo'
+            ]);
+            self::$refsExist[$doc->name()] = $doc;
+            self::$deletionQueue->add($doc);
+        }
+
+        for ($i = 0; $i < 5; $i++) {
+            $doc = $c->newDocument();
+            self::$refsNonExist[$doc->name()] = $doc;
+        }
+    }
+
+    public function testDocumentsNonTransactional()
+    {
+        $f = self::$client;
+
+        $paths = $this->interleave();
+        $res = $f->documents($paths);
+
+        $this->assertContainsOnlyInstancesOf(DocumentSnapshot::class, $res);
+        foreach ($res as $i => $document) {
+            $name = $document->name();
+
+            // check order
+            $this->assertEquals($paths[$i]->name(), $name);
+
+            $exist = array_key_exists($name, self::$refsExist);
+
+            $this->assertEquals($exist, $document->exists());
+        }
+    }
+
+    public function testDocumentsTransactional()
+    {
+        $f = self::$client;
+
+        $paths = $this->interleave();
+        $res = [];
+        $f->runTransaction(function ($t) use ($paths, &$res) {
+            $res = $t->documents($paths);
+        });
+
+        $this->assertContainsOnlyInstancesOf(DocumentSnapshot::class, $res);
+        foreach ($res as $i => $document) {
+            $name = $document->name();
+
+            // check order
+            $this->assertEquals($paths[$i]->name(), $name);
+
+            $exist = array_key_exists($name, self::$refsExist);
+
+            $this->assertEquals($exist, $document->exists());
+        }
+    }
+
+    private function interleave($names = false)
+    {
+        $exist = $names ? array_keys(self::$refsExist) : array_values(self::$refsExist);
+        $nonExist = $names ? array_keys(self::$refsNonExist) : array_values(self::$refsNonExist);
+        $docs = [];
+        foreach ($exist as $i => $doc) {
+            $docs[] = $doc;
+            $docs[] = $nonExist[$i];
+        }
+
+        return $docs;
+    }
+}


### PR DESCRIPTION
To support retrieval of a specific set of document snapshots within transactions, this PR adds a method similar to FirestoreClient::documents(), accepting an array of paths or DocumentReference objects and returning a list of DocumentSnapshot instances.

cc @schmidt-sebastian 