### PR TITLE
Debugger: Logpoint name

### DIFF
--- a/src/Debugger/Agent.php
+++ b/src/Debugger/Agent.php
@@ -261,8 +261,7 @@ class Agent
 
     private function defaultLogger()
     {
-        $client = new LoggingClient();
-        return $client->psrBatchLogger(self::DEFAULT_LOGPOINT_LOG_NAME);
+        return LoggingClient::psrBatchLogger(self::DEFAULT_LOGPOINT_LOG_NAME);
     }
 
     private function invalidateOpcache($breakpoint)

--- a/src/Debugger/Agent.php
+++ b/src/Debugger/Agent.php
@@ -47,6 +47,8 @@ class Agent
     use BatchDaemonTrait;
     use SysvTrait;
 
+    const DEFAULT_LOGPOINT_LOG_NAME = 'appengine.googleapis.com/request_log';
+
     /**
      * @var Debuggee
      */
@@ -246,7 +248,7 @@ class Agent
     private function defaultLogger()
     {
         $client = new LoggingClient();
-        return $client->psrBatchLogger('appengine.googleapis.com/request_log"');
+        return $client->psrBatchLogger(self::DEFAULT_LOGPOINT_LOG_NAME);
     }
 
     private function invalidateOpcache($breakpoint)

--- a/src/Debugger/Agent.php
+++ b/src/Debugger/Agent.php
@@ -47,7 +47,8 @@ class Agent
     use BatchDaemonTrait;
     use SysvTrait;
 
-    const DEFAULT_LOGPOINT_LOG_NAME = 'appengine.googleapis.com%2Frequest_log';
+    const DEFAULT_LOGPOINT_LOG_NAME = 'debugger_logpoints';
+    const DEFAULT_APP_ENGINE_LOG_NAME = 'appengine.googleapis.com%2Frequest_log';
 
     /**
      * @var Debuggee
@@ -261,7 +262,10 @@ class Agent
 
     private function defaultLogger()
     {
-        return LoggingClient::psrBatchLogger(self::DEFAULT_LOGPOINT_LOG_NAME);
+        $logName = isset($server['GAE_SERVICE'])
+            ? self::DEFAULT_APP_ENGINE_LOG_NAME
+            : self::DEFAULT_LOGPOINT_LOG_NAME;
+        return LoggingClient::psrBatchLogger($logName);
     }
 
     private function invalidateOpcache($breakpoint)

--- a/src/Debugger/Agent.php
+++ b/src/Debugger/Agent.php
@@ -246,7 +246,7 @@ class Agent
     private function defaultLogger()
     {
         $client = new LoggingClient();
-        return $client->psrBatchLogger('logpoints');
+        return $client->psrBatchLogger('appengine.googleapis.com/request_log"');
     }
 
     private function invalidateOpcache($breakpoint)

--- a/src/Debugger/Agent.php
+++ b/src/Debugger/Agent.php
@@ -169,7 +169,7 @@ class Agent
                             'snapshotId'    => $breakpoint->id(),
                             'condition'     => $breakpoint->condition(),
                             'expressions'   => $breakpoint->expressions(),
-                            'callback'      => [$this->logger, 'log'],
+                            'callback'      => [$this, 'handleLogpoint'],
                             'sourceRoot'    => $this->sourceRoot
                         ]
                     );
@@ -202,6 +202,20 @@ class Agent
             $breakpoint->addStackFrames($snapshot['stackframes']);
             $this->batchRunner->submitItem($this->identifier, $breakpoint);
         }
+    }
+
+    /**
+     * Callback for reporting a logpoint.
+     *
+     * @access private
+     * @param mixed $level
+     * @param string $message
+     * @param array $context
+     * @return void
+     */
+    public function handleLogpoint($level, $message, array $context = [])
+    {
+        $this->logger->log($level, "LOGPOINT: $message", $context);
     }
 
     /**

--- a/src/Debugger/Agent.php
+++ b/src/Debugger/Agent.php
@@ -47,7 +47,7 @@ class Agent
     use BatchDaemonTrait;
     use SysvTrait;
 
-    const DEFAULT_LOGPOINT_LOG_NAME = 'appengine.googleapis.com/request_log';
+    const DEFAULT_LOGPOINT_LOG_NAME = 'appengine.googleapis.com%2Frequest_log';
 
     /**
      * @var Debuggee


### PR DESCRIPTION
The default log name for logpoints should be `appengine.googleapis.com%2Frequest_log`. Note that the `/` is uri encoded here (@dwsupplee - I'm not sure if the user should be expected to escape the log name).

Naming the log name like this allows the Debug UI to show logpoints in a special location on the same page without having to navigate to the Logging UI.

Also prefixes the logpoint message with `LOGPOINT: ` to match what other languages' agents are doing.