### PR TITLE
Add allocate ID to upsert methods, refactor tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,14 +11,15 @@ init:
 
 environment:
   matrix:
-    - PHP_VERSION: "5.5.38-nts-Win32-VC11-x64"
-    - PHP_VERSION: "5.6.29-nts-Win32-VC11-x64"
-    - PHP_VERSION: "7.0.14-nts-Win32-VC14-x64"
-    - PHP_VERSION: "7.1.0-nts-Win32-VC14-x64"
+    - PHP_VERSION: 5.5
+    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
+    - PHP_VERSION: 7.1
 
 install:
   - cinst -y OpenSSL.Light
-  - ps: . .\appveyor_install_php.ps1
+  - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:PHP_VERSION | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+  # - ps: . .\appveyor_install_php.ps1
   - cd c:\tools\php
   - echo extension_dir=ext >> php.ini
   - echo extension=php_openssl.dll >> php.ini

--- a/appveyor_install_php.ps1
+++ b/appveyor_install_php.ps1
@@ -1,3 +1,5 @@
+Add-Type -assembly "system.io.compression.filesystem"
+
 $file = "php-$env:PHP_VERSION.zip"
 $archiveUrl = "http://windows.php.net/downloads/releases/archives/$file"
 $url = "http://windows.php.net/downloads/releases/$file"
@@ -6,8 +8,14 @@ $client = New-Object NET.WebClient
 
 try {
     $client.DownloadFile($url, "$projectPath\$file")
+    "Downloaded file from $url"
 } catch {
     $client.DownloadFile($archiveUrl, "$projectPath\$file")
+    "Downloaded file from $archiveUrl"
 }
 
-7z x $file -oc:\tools\php
+if (![System.IO.File]::Exists("$projectPath\$file")) {
+    "File $projectPath\$file does not exist! This is not a good sign for the tests passing."
+}
+
+[io.compression.zipfile]::ExtractToDirectory("$projectPath\$file", "C:\tools\php")

--- a/src/Core/Testing/DatastoreOperationRefreshTrait.php
+++ b/src/Core/Testing/DatastoreOperationRefreshTrait.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Testing;
+
+use Google\Cloud\Datastore\Connection\ConnectionInterface;
+use Google\Cloud\Datastore\EntityMapper;
+use Google\Cloud\Datastore\Operation;
+
+/**
+ * Refresh Datastore operation class
+ */
+trait DatastoreOperationRefreshTrait
+{
+    /**
+     * Refresh the operation property of a given stubbed class.
+     *
+     * @param mixed $stub
+     * @param ConnectionInterface $connection
+     * @param bool $returnInt64AsObject
+     * @return mixed
+     */
+    public function refreshOperation($stub, ConnectionInterface $connection, array $options = [])
+    {
+        $options += [
+            'projectId' => defined('static::PROJECT')
+                ? static::PROJECT
+                : null,
+            'returnInt64AsObject' => false,
+            'encode' => false
+        ];
+
+        $mapper = new EntityMapper(
+            $options['projectId'],
+            $options['encode'],
+            $options['returnInt64AsObject']
+        );
+
+        $stub->___setProperty('operation', new Operation(
+            $connection,
+            $options['projectId'],
+            $options['returnInt64AsObject'],
+            $mapper
+        ));
+
+        return $stub;
+    }
+}

--- a/src/Core/Testing/DatastoreOperationRefreshTrait.php
+++ b/src/Core/Testing/DatastoreOperationRefreshTrait.php
@@ -31,15 +31,19 @@ trait DatastoreOperationRefreshTrait
      *
      * @param mixed $stub
      * @param ConnectionInterface $connection
-     * @param bool $returnInt64AsObject
+     * @param array $options {
+     *     Configuration Options
+     *
+     *     @type string $projectId the project id.
+     *     @type bool $returnInt64AsObject if true, will encode int64s as objects.
+     *     @type bool $encode whether to base64-encode certain values.
+     * }
      * @return mixed
      */
     public function refreshOperation($stub, ConnectionInterface $connection, array $options = [])
     {
         $options += [
-            'projectId' => defined('static::PROJECT')
-                ? static::PROJECT
-                : null,
+            'projectId' => null,
             'returnInt64AsObject' => false,
             'encode' => false
         ];

--- a/src/Datastore/EntityMapper.php
+++ b/src/Datastore/EntityMapper.php
@@ -123,7 +123,7 @@ class EntityMapper
         }
 
         return array_filter([
-            'key' => $entity->key(),
+            'key' => $entity->key()->keyObject(),
             'properties' => $properties
         ]);
     }

--- a/src/Datastore/Key.php
+++ b/src/Datastore/Key.php
@@ -409,6 +409,8 @@ class Key implements JsonSerializable
      *
      * @access private
      * @return array
+     *
+     * @todo (major) rename to `toArray()`.
      */
     public function keyObject()
     {

--- a/src/Datastore/Operation.php
+++ b/src/Datastore/Operation.php
@@ -266,8 +266,7 @@ class Operation
         // The API will throw a 400 if the key is named, but it's an easy
         // check we can handle before going to the API to save a request.
         // @todo replace with json schema
-        $serviceKeys = [];
-        $this->validateBatch($keys, Key::class, function ($key) use (&$serviceKeys) {
+        $this->validateBatch($keys, Key::class, function ($key) {
             if ($key->state() !== Key::STATE_INCOMPLETE) {
                 throw new InvalidArgumentException(sprintf(
                     'Given $key is in an invalid state. Can only allocate IDs for incomplete keys. ' .
@@ -284,9 +283,12 @@ class Operation
                     (string) $key
                 ));
             }
-
-            $serviceKeys[] = $key->keyObject();
         });
+
+        $serviceKeys = [];
+        foreach ($keys as $key) {
+            $serviceKeys[] = $key->keyObject();
+        }
 
         $res = $this->connection->allocateIds([
             'projectId' => $this->projectId,

--- a/src/Datastore/Operation.php
+++ b/src/Datastore/Operation.php
@@ -228,6 +228,24 @@ class Operation
     }
 
     /**
+     * Begin a Datastore Transaction.
+     *
+     * @param array $transactionOptions
+     *        [Transaction Options](https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects/beginTransaction#TransactionOptions)
+     * @param array $options Configuration options.
+     * @return string
+     */
+    public function beginTransaction($transactionOptions, array $options = [])
+    {
+        $res = $this->connection->beginTransaction([
+            'projectId' => $this->projectId,
+            'transactionOptions' => $transactionOptions
+        ] + $options);
+
+        return $res['transaction'];
+    }
+
+    /**
      * Allocate available IDs to a set of keys
      *
      * Keys MUST be in an incomplete state (i.e. including a kind but not an ID
@@ -248,7 +266,8 @@ class Operation
         // The API will throw a 400 if the key is named, but it's an easy
         // check we can handle before going to the API to save a request.
         // @todo replace with json schema
-        $this->validateBatch($keys, Key::class, function ($key) {
+        $serviceKeys = [];
+        $this->validateBatch($keys, Key::class, function ($key) use (&$serviceKeys) {
             if ($key->state() !== Key::STATE_INCOMPLETE) {
                 throw new InvalidArgumentException(sprintf(
                     'Given $key is in an invalid state. Can only allocate IDs for incomplete keys. ' .
@@ -256,11 +275,22 @@ class Operation
                     (string) $key
                 ));
             }
+
+            if (!isset($key->pathEnd()['kind'])) {
+                throw new InvalidArgumentException(sprintf(
+                    'Cannot allocate IDs because a path element was missing a kind. ' .
+                    'This usually means a key was created but no path elements were defined. ' .
+                    'Given path was %s',
+                    (string) $key
+                ));
+            }
+
+            $serviceKeys[] = $key->keyObject();
         });
 
         $res = $this->connection->allocateIds([
             'projectId' => $this->projectId,
-            'keys' => $keys
+            'keys' => $serviceKeys
         ] + $options);
 
         if (isset($res['keys'])) {
@@ -311,7 +341,8 @@ class Operation
             'sort' => false
         ];
 
-        $this->validateBatch($keys, Key::class, function ($key) {
+        $serviceKeys = [];
+        $this->validateBatch($keys, Key::class, function ($key) use (&$serviceKeys) {
             if ($key->state() !== Key::STATE_NAMED) {
                 throw new InvalidArgumentException(sprintf(
                     'Given $key is in an invalid state. Can only lookup records when given a complete key. ' .
@@ -319,11 +350,13 @@ class Operation
                     (string) $key
                 ));
             }
+
+            $serviceKeys[] = $key->keyObject();
         });
 
         $res = $this->connection->lookup($options + $this->readOptions($options) + [
             'projectId' => $this->projectId,
-            'keys' => $keys
+            'keys' => $serviceKeys
         ]);
 
         $result = [];
@@ -555,9 +588,9 @@ class Operation
             if (!$entity->populatedByService() && !$allowOverwrite) {
                 throw new InvalidArgumentException(sprintf(
                     'Given entity cannot be saved because it may overwrite an '.
-                    'existing record. When manually creating entities for '.
-                    'update operations, please set the options '.
-                    '`$allowOverwrite` flag to `true`. Invalid entity key was %s',
+                    'existing record. When updating manually created entities, '.
+                    'please set the options `$allowOverwrite` flag to `true`. '.
+                    'Invalid entity key was %s',
                     (string) $entity->key()
                 ));
             }

--- a/src/Datastore/Transaction.php
+++ b/src/Datastore/Transaction.php
@@ -63,10 +63,14 @@ class Transaction
     private $mutations = [];
 
     /**
-     * Insert an entity
+     * Insert an entity.
      *
-     * No service requests are run when this method is called.
-     * Use {@see Google\Cloud\Datastore\Transaction::commit()} to commit changes.
+     * Changes are not immediately committed to Cloud Datastore when calling
+     * this method. Use {@see Google\Cloud\Datastore\Transaction::commit()} to
+     * commit changes and end the transaction.
+     *
+     * If entities with incomplete keys are provided, this method will immediately
+     * trigger a service call to allocate IDs to the entities.
      *
      * Example:
      * ```
@@ -86,10 +90,14 @@ class Transaction
     }
 
     /**
-     * Insert multiple entities
+     * Insert multiple entities.
      *
-     * No service requests are run when this method is called.
-     * Use {@see Google\Cloud\Datastore\Transaction::commit()} to commit changes.
+     * Changes are not immediately committed to Cloud Datastore when calling
+     * this method. Use {@see Google\Cloud\Datastore\Transaction::commit()} to
+     * commit changes and end the transaction.
+     *
+     * If entities with incomplete keys are provided, this method will immediately
+     * trigger a service call to allocate IDs to the entities.
      *
      * Example:
      * ```
@@ -116,10 +124,11 @@ class Transaction
     }
 
     /**
-     * Update an entity
+     * Update an entity.
      *
-     * No service requests are run when this method is called.
-     * Use {@see Google\Cloud\Datastore\Transaction::commit()} to commit changes.
+     * Changes are not immediately committed to Cloud Datastore when calling
+     * this method. Use {@see Google\Cloud\Datastore\Transaction::commit()} to
+     * commit changes and end the transaction.
      *
      * Example:
      * ```
@@ -154,10 +163,11 @@ class Transaction
     }
 
     /**
-     * Update multiple entities
+     * Update multiple entities.
      *
-     * No service requests are run when this method is called.
-     * Use {@see Google\Cloud\Datastore\Transaction::commit()} to commit changes.
+     * Changes are not immediately committed to Cloud Datastore when calling
+     * this method. Use {@see Google\Cloud\Datastore\Transaction::commit()} to
+     * commit changes and end the transaction.
      *
      * Example:
      * ```
@@ -198,13 +208,17 @@ class Transaction
     }
 
     /**
-     * Upsert an entity
+     * Upsert an entity.
      *
-     * No service requests are run when this method is called.
-     * Use {@see Google\Cloud\Datastore\Transaction::commit()} to commit changes.
+     * Changes are not immediately committed to Cloud Datastore when calling
+     * this method. Use {@see Google\Cloud\Datastore\Transaction::commit()} to
+     * commit changes and end the transaction.
      *
      * Upsert will create a record if one does not already exist, or overwrite
      * existing record if one already exists.
+     *
+     * If entities with incomplete keys are provided, this method will immediately
+     * trigger a service call to allocate IDs to the entities.
      *
      * Example:
      * ```
@@ -224,13 +238,17 @@ class Transaction
     }
 
     /**
-     * Upsert multiple entities
+     * Upsert multiple entities.
      *
-     * No service requests are run when this method is called.
-     * Use {@see Google\Cloud\Datastore\Transaction::commit()} to commit changes.
+     * Changes are not immediately committed to Cloud Datastore when calling
+     * this method. Use {@see Google\Cloud\Datastore\Transaction::commit()} to
+     * commit changes and end the transaction.
      *
      * Upsert will create a record if one does not already exist, or overwrite
      * existing record if one already exists.
+     *
+     * If entities with incomplete keys are provided, this method will immediately
+     * trigger a service call to allocate IDs to the entities.
      *
      * Example:
      * ```
@@ -253,6 +271,7 @@ class Transaction
      */
     public function upsertBatch(array $entities)
     {
+        $entities = $this->operation->allocateIdsToEntities($entities);
         foreach ($entities as $entity) {
             $this->mutations[] = $this->operation->mutation('upsert', $entity, Entity::class);
         }
@@ -261,10 +280,11 @@ class Transaction
     }
 
     /**
-     * Delete a record
+     * Delete a record.
      *
-     * No service requests are run when this method is called.
-     * Use {@see Google\Cloud\Datastore\Transaction::commit()} to commit changes.
+     * Changes are not immediately committed to Cloud Datastore when calling
+     * this method. Use {@see Google\Cloud\Datastore\Transaction::commit()} to
+     * commit changes and end the transaction.
      *
      * Example:
      * ```
@@ -283,10 +303,11 @@ class Transaction
     }
 
     /**
-     * Delete multiple records
+     * Delete multiple records.
      *
-     * No service requests are run when this method is called.
-     * Use {@see Google\Cloud\Datastore\Transaction::commit()} to commit changes.
+     * Changes are not immediately committed to Cloud Datastore when calling
+     * this method. Use {@see Google\Cloud\Datastore\Transaction::commit()} to
+     * commit changes and end the transaction.
      *
      * Example:
      * ```
@@ -312,7 +333,7 @@ class Transaction
     }
 
     /**
-     * Commit all mutations
+     * Commit all mutations.
      *
      * Calling this method will end the operation (and close the transaction,
      * if one is specified).

--- a/tests/snippets/Datastore/DatastoreClientTest.php
+++ b/tests/snippets/Datastore/DatastoreClientTest.php
@@ -43,6 +43,8 @@ class DatastoreClientTest extends SnippetTestCase
 {
     use DatastoreOperationRefreshTrait;
 
+    const PROJECT = 'example-project';
+
     private $connection;
     private $operation;
     private $client;
@@ -259,7 +261,9 @@ class DatastoreClientTest extends SnippetTestCase
         $snippet->addLocal('datastore', $this->client);
 
         $this->allocateIdsConnectionMock();
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke('keyWithAllocatedId');
 
@@ -274,7 +278,9 @@ class DatastoreClientTest extends SnippetTestCase
         $snippet->addLocal('datastore', $this->client);
 
         $this->allocateIdsConnectionMock();
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke('keysWithAllocatedIds');
 
@@ -295,7 +301,9 @@ class DatastoreClientTest extends SnippetTestCase
                 'transaction' => 'foo'
             ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke('transaction');
         $this->assertInstanceOf(Transaction::class, $res->returnVal());
@@ -310,7 +318,9 @@ class DatastoreClientTest extends SnippetTestCase
             ->willReturn([
                 'transaction' => 'foo'
             ]);
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
         $res = $snippet->invoke('transaction');
         $this->assertInstanceOf(ReadOnlyTransaction::class, $res->returnVal());
     }
@@ -330,7 +340,9 @@ class DatastoreClientTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke('entity');
 
@@ -349,7 +361,9 @@ class DatastoreClientTest extends SnippetTestCase
 
         $this->allocateIdsConnectionMock();
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke('entities');
 
@@ -374,7 +388,9 @@ class DatastoreClientTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
     }
@@ -392,7 +408,9 @@ class DatastoreClientTest extends SnippetTestCase
             return array_keys($args['mutations'][0])[0] === 'update';
         }))->shouldBeCalled();
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
     }
@@ -412,7 +430,9 @@ class DatastoreClientTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
     }
@@ -426,7 +446,9 @@ class DatastoreClientTest extends SnippetTestCase
             return array_keys($args['mutations'][0])[0] === 'upsert';
         }))->shouldBeCalled();
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
     }
@@ -446,7 +468,9 @@ class DatastoreClientTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
     }
@@ -460,7 +484,9 @@ class DatastoreClientTest extends SnippetTestCase
             return array_keys($args['mutations'][0])[0] === 'delete';
         }))->shouldBeCalled();
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
     }
@@ -491,7 +517,9 @@ class DatastoreClientTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
         $this->assertEquals('Bob', $res->output());
@@ -537,7 +565,9 @@ class DatastoreClientTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
         $this->assertEquals("Bob", explode("\n", $res->output())[0]);
@@ -618,7 +648,9 @@ class DatastoreClientTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke('result');
         $this->assertEquals('Bob', $res->output());

--- a/tests/snippets/Datastore/ReadOnlyTransactionTest.php
+++ b/tests/snippets/Datastore/ReadOnlyTransactionTest.php
@@ -81,7 +81,9 @@ class ReadOnlyTransactionTest extends SnippetTestCase
                 'transaction' => 'foo'
             ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $snippet = $this->snippetFromClass(ReadOnlyTransaction::class);
         $snippet->setLine(2, '');
@@ -106,7 +108,9 @@ class ReadOnlyTransactionTest extends SnippetTestCase
 
         $snippet = $this->snippetFromClass(ReadOnlyTransaction::class, 1);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $transaction = $this->client->readOnlyTransaction();
 
@@ -146,7 +150,9 @@ class ReadOnlyTransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
         $this->assertEquals('Bob', $res->output());
@@ -196,7 +202,9 @@ class ReadOnlyTransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
         $this->assertEquals("Bob", explode("\n", $res->output())[0]);
@@ -236,7 +244,9 @@ class ReadOnlyTransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke('result');
         $this->assertEquals('Bob', $res->output());
@@ -250,7 +260,9 @@ class ReadOnlyTransactionTest extends SnippetTestCase
         $this->connection->rollback(Argument::any())
             ->shouldBeCalled();
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $snippet->invoke();
     }

--- a/tests/snippets/Datastore/TransactionTest.php
+++ b/tests/snippets/Datastore/TransactionTest.php
@@ -81,7 +81,9 @@ class TransactionTest extends SnippetTestCase
                 'transaction' => 'foo'
             ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $snippet = $this->snippetFromClass(Transaction::class);
         $snippet->setLine(2, '');
@@ -108,7 +110,9 @@ class TransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
     }
@@ -132,7 +136,9 @@ class TransactionTest extends SnippetTestCase
 
         $this->allocateIdsConnectionMock();
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
     }
@@ -157,7 +163,9 @@ class TransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
     }
@@ -201,7 +209,9 @@ class TransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
     }
@@ -242,7 +252,9 @@ class TransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
     }
@@ -290,7 +302,9 @@ class TransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
         $this->assertEquals('Bob', $res->output());
@@ -337,7 +351,9 @@ class TransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke();
         $this->assertEquals("Bob", explode("\n", $res->output())[0]);
@@ -374,7 +390,9 @@ class TransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $snippet->invoke('result');
         $this->assertEquals('Bob', $res->output());
@@ -388,7 +406,9 @@ class TransactionTest extends SnippetTestCase
         $this->connection->commit(Argument::any())
             ->shouldBeCalled();
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $snippet->invoke();
     }
@@ -401,7 +421,9 @@ class TransactionTest extends SnippetTestCase
         $this->connection->rollback(Argument::any())
             ->shouldBeCalled();
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $snippet->invoke();
     }

--- a/tests/snippets/Datastore/TransactionTest.php
+++ b/tests/snippets/Datastore/TransactionTest.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Tests\Snippets\Datastore;
 
+use Google\Cloud\Core\Testing\DatastoreOperationRefreshTrait;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Datastore\Connection\ConnectionInterface;
@@ -33,26 +34,36 @@ use Prophecy\Argument;
  */
 class TransactionTest extends SnippetTestCase
 {
+    use DatastoreOperationRefreshTrait;
+
     const PROJECT = 'my-awesome-project';
+    const TRANSACTION = 'transaction-id';
 
     private $connection;
     private $operation;
     private $transaction;
-    private $transactionId = 'foo';
-    private $datastore;
+    private $client;
     private $key;
 
     public function setUp()
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
-        $this->operation = \Google\Cloud\Core\Testing\TestHelpers::stub(Operation::class, [
+
+        $operation = new Operation(
             $this->connection->reveal(),
             self::PROJECT,
             '',
             new EntityMapper(self::PROJECT, false, false)
-        ]);
-        $this->transaction = new Transaction($this->operation, self::PROJECT, $this->transactionId);
-        $this->datastore = new DatastoreClient;
+        );
+
+        $this->transaction = TestHelpers::stub(Transaction::class, [
+            $operation,
+            self::PROJECT,
+            self::TRANSACTION
+        ], ['operation']);
+
+        $this->client = TestHelpers::stub(DatastoreClient::class, [], ['operation']);
+
         $this->key = new Key('my-awesome-project', [
             [
                 'path' => [
@@ -64,18 +75,17 @@ class TransactionTest extends SnippetTestCase
 
     public function testClass()
     {
-        $connectionStub = $this->prophesize(ConnectionInterface::class);
-        $connectionStub->beginTransaction(Argument::any())
+        $this->connection->beginTransaction(Argument::any())
             ->shouldBeCalled()
             ->willReturn([
                 'transaction' => 'foo'
             ]);
 
-        $client = TestHelpers::stub(DatastoreClient::class);
-        $client->___setProperty('connection', $connectionStub->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal());
+
         $snippet = $this->snippetFromClass(Transaction::class);
         $snippet->setLine(2, '');
-        $snippet->addLocal('datastore', $client);
+        $snippet->addLocal('datastore', $this->client);
 
         $res = $snippet->invoke('transaction');
         $this->assertInstanceOf(Transaction::class, $res->returnVal());
@@ -84,11 +94,11 @@ class TransactionTest extends SnippetTestCase
     public function testInsert()
     {
         $snippet = $this->snippetFromMethod(Transaction::class, 'insert');
-        $snippet->addLocal('datastore', $this->datastore);
+        $snippet->addLocal('datastore', $this->client);
         $snippet->addLocal('transaction', $this->transaction);
 
         $this->connection->commit(Argument::that(function ($args) {
-            if ($args['transaction'] !== $this->transactionId) return false;
+            if ($args['transaction'] !== self::TRANSACTION) return false;
             return array_keys($args['mutations'][0])[0] === 'insert';
         }))
             ->shouldBeCalled()
@@ -98,7 +108,7 @@ class TransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->operation->___setProperty('connection', $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal());
 
         $res = $snippet->invoke();
     }
@@ -106,11 +116,11 @@ class TransactionTest extends SnippetTestCase
     public function testInsertBatch()
     {
         $snippet = $this->snippetFromMethod(Transaction::class, 'insertBatch');
-        $snippet->addLocal('datastore', $this->datastore);
+        $snippet->addLocal('datastore', $this->client);
         $snippet->addLocal('transaction', $this->transaction);
 
         $this->connection->commit(Argument::that(function ($args) {
-            if ($args['transaction'] !== $this->transactionId) return false;
+            if ($args['transaction'] !== self::TRANSACTION) return false;
             return array_keys($args['mutations'][0])[0] === 'insert';
         }))
             ->shouldBeCalled()
@@ -122,7 +132,7 @@ class TransactionTest extends SnippetTestCase
 
         $this->allocateIdsConnectionMock();
 
-        $this->operation->___setProperty('connection', $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal());
 
         $res = $snippet->invoke();
     }
@@ -130,14 +140,14 @@ class TransactionTest extends SnippetTestCase
     public function testUpdate()
     {
         $snippet = $this->snippetFromMethod(Transaction::class, 'update');
-        $snippet->addLocal('datastore', $this->datastore);
+        $snippet->addLocal('datastore', $this->client);
         $snippet->addLocal('transaction', $this->transaction);
-        $snippet->addLocal('entity', $this->datastore->entity($this->key, [], [
+        $snippet->addLocal('entity', $this->client->entity($this->key, [], [
             'populatedByService' => true
         ]));
 
         $this->connection->commit(Argument::that(function ($args) {
-            if ($args['transaction'] !== $this->transactionId) return false;
+            if ($args['transaction'] !== self::TRANSACTION) return false;
             return array_keys($args['mutations'][0])[0] === 'update';
         }))
             ->shouldBeCalled()
@@ -147,7 +157,7 @@ class TransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->operation->___setProperty('connection', $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal());
 
         $res = $snippet->invoke();
     }
@@ -155,15 +165,15 @@ class TransactionTest extends SnippetTestCase
     public function testUpdateBatch()
     {
         $snippet = $this->snippetFromMethod(Transaction::class, 'updateBatch');
-        $snippet->addLocal('datastore', $this->datastore);
+        $snippet->addLocal('datastore', $this->client);
         $snippet->addLocal('transaction', $this->transaction);
         $snippet->addLocal('entities', [
-            $this->datastore->entity($this->datastore->key('Person', 'Bob'), [], ['populatedByService' => true]),
-            $this->datastore->entity($this->datastore->key('Person', 'John'), [], ['populatedByService' => true])
+            $this->client->entity($this->client->key('Person', 'Bob'), [], ['populatedByService' => true]),
+            $this->client->entity($this->client->key('Person', 'John'), [], ['populatedByService' => true])
         ]);
 
         $this->connection->commit(Argument::that(function ($args) {
-            if ($args['transaction'] !== $this->transactionId) return false;
+            if ($args['transaction'] !== self::TRANSACTION) return false;
             return array_keys($args['mutations'][0])[0] === 'update';
         }))
             ->shouldBeCalled();
@@ -174,14 +184,14 @@ class TransactionTest extends SnippetTestCase
     public function testUpsert()
     {
         $snippet = $this->snippetFromMethod(Transaction::class, 'upsert');
-        $snippet->addLocal('datastore', $this->datastore);
+        $snippet->addLocal('datastore', $this->client);
         $snippet->addLocal('transaction', $this->transaction);
-        $snippet->addLocal('entity', $this->datastore->entity($this->key, [], [
+        $snippet->addLocal('entity', $this->client->entity($this->key, [], [
             'populatedByService' => true
         ]));
 
         $this->connection->commit(Argument::that(function ($args) {
-            if ($args['transaction'] !== $this->transactionId) return false;
+            if ($args['transaction'] !== self::TRANSACTION) return false;
             return array_keys($args['mutations'][0])[0] === 'upsert';
         }))
             ->shouldBeCalled()
@@ -191,7 +201,7 @@ class TransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->operation->___setProperty('connection', $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal());
 
         $res = $snippet->invoke();
     }
@@ -199,15 +209,15 @@ class TransactionTest extends SnippetTestCase
     public function testUpsertBatch()
     {
         $snippet = $this->snippetFromMethod(Transaction::class, 'upsertBatch');
-        $snippet->addLocal('datastore', $this->datastore);
+        $snippet->addLocal('datastore', $this->client);
         $snippet->addLocal('transaction', $this->transaction);
         $snippet->addLocal('entities', [
-            $this->datastore->entity($this->datastore->key('Person', 'Bob'), [], ['populatedByService' => true]),
-            $this->datastore->entity($this->datastore->key('Person', 'John'), [], ['populatedByService' => true])
+            $this->client->entity($this->client->key('Person', 'Bob'), [], ['populatedByService' => true]),
+            $this->client->entity($this->client->key('Person', 'John'), [], ['populatedByService' => true])
         ]);
 
         $this->connection->commit(Argument::that(function ($args) {
-            if ($args['transaction'] !== $this->transactionId) return false;
+            if ($args['transaction'] !== self::TRANSACTION) return false;
             return array_keys($args['mutations'][0])[0] === 'upsert';
         }))
             ->shouldBeCalled();
@@ -218,11 +228,11 @@ class TransactionTest extends SnippetTestCase
     public function testDelete()
     {
         $snippet = $this->snippetFromMethod(Transaction::class, 'delete');
-        $snippet->addLocal('datastore', $this->datastore);
+        $snippet->addLocal('datastore', $this->client);
         $snippet->addLocal('transaction', $this->transaction);
 
         $this->connection->commit(Argument::that(function ($args) {
-            if ($args['transaction'] !== $this->transactionId) return false;
+            if ($args['transaction'] !== self::TRANSACTION) return false;
             return array_keys($args['mutations'][0])[0] === 'delete';
         }))
             ->shouldBeCalled()
@@ -232,7 +242,7 @@ class TransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->operation->___setProperty('connection', $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal());
 
         $res = $snippet->invoke();
     }
@@ -240,11 +250,11 @@ class TransactionTest extends SnippetTestCase
     public function testDeleteBatch()
     {
         $snippet = $this->snippetFromMethod(Transaction::class, 'deleteBatch');
-        $snippet->addLocal('datastore', $this->datastore);
+        $snippet->addLocal('datastore', $this->client);
         $snippet->addLocal('transaction', $this->transaction);
 
         $this->connection->commit(Argument::that(function ($args) {
-            if ($args['transaction'] !== $this->transactionId) return false;
+            if ($args['transaction'] !== self::TRANSACTION) return false;
             if (array_keys($args['mutations'][0])[0] !== 'delete') return false;
             return true;
         }))
@@ -256,12 +266,10 @@ class TransactionTest extends SnippetTestCase
     public function testLookup()
     {
         $snippet = $this->snippetFromMethod(Transaction::class, 'lookup');
-        $snippet->addLocal('datastore', $this->datastore);
+        $snippet->addLocal('datastore', $this->client);
         $snippet->addLocal('transaction', $this->transaction);
 
-        $this->connection->lookup(Argument::that(function ($args) {
-            return $args['transaction'] === $this->transactionId;
-        }))
+        $this->connection->lookup(Argument::withEntry('transaction', self::TRANSACTION))
             ->shouldBeCalled()
             ->willReturn([
                 'found' => [
@@ -282,7 +290,7 @@ class TransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->operation->___setProperty('connection', $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal());
 
         $res = $snippet->invoke();
         $this->assertEquals('Bob', $res->output());
@@ -291,12 +299,10 @@ class TransactionTest extends SnippetTestCase
     public function testLookupBatch()
     {
         $snippet = $this->snippetFromMethod(Transaction::class, 'lookupBatch');
-        $snippet->addLocal('datastore', $this->datastore);
+        $snippet->addLocal('datastore', $this->client);
         $snippet->addLocal('transaction', $this->transaction);
 
-        $this->connection->lookup(Argument::that(function ($args) {
-            return $args['transaction'] === $this->transactionId;
-        }))
+        $this->connection->lookup(Argument::withEntry('transaction', self::TRANSACTION))
             ->shouldBeCalled()
             ->willReturn([
                 'found' => [
@@ -331,7 +337,7 @@ class TransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->operation->___setProperty('connection', $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal());
 
         $res = $snippet->invoke();
         $this->assertEquals("Bob", explode("\n", $res->output())[0]);
@@ -341,13 +347,11 @@ class TransactionTest extends SnippetTestCase
     public function testRunQuery()
     {
         $snippet = $this->snippetFromMethod(Transaction::class, 'runQuery');
-        $snippet->addLocal('datastore', $this->datastore);
+        $snippet->addLocal('datastore', $this->client);
         $snippet->addLocal('transaction', $this->transaction);
         $snippet->addLocal('query', $this->prophesize(QueryInterface::class)->reveal());
 
-        $this->connection->runQuery(Argument::that(function ($args) {
-            return $args['transaction'] === $this->transactionId;
-        }))
+        $this->connection->runQuery(Argument::withEntry('transaction', self::TRANSACTION))
             ->shouldBeCalled()
             ->willReturn([
                 'batch' => [
@@ -370,7 +374,7 @@ class TransactionTest extends SnippetTestCase
                 ]
             ]);
 
-        $this->operation->___setProperty('connection', $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal());
 
         $res = $snippet->invoke('result');
         $this->assertEquals('Bob', $res->output());
@@ -384,7 +388,7 @@ class TransactionTest extends SnippetTestCase
         $this->connection->commit(Argument::any())
             ->shouldBeCalled();
 
-        $this->operation->___setProperty('connection', $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal());
 
         $snippet->invoke();
     }
@@ -397,7 +401,7 @@ class TransactionTest extends SnippetTestCase
         $this->connection->rollback(Argument::any())
             ->shouldBeCalled();
 
-        $this->operation->___setProperty('connection', $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal());
 
         $snippet->invoke();
     }

--- a/tests/unit/Datastore/DatastoreClientTest.php
+++ b/tests/unit/Datastore/DatastoreClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017 Google Inc.
+ * Copyright 2016 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,13 +31,14 @@ use Google\Cloud\Datastore\Query\Query;
 use Google\Cloud\Datastore\Query\QueryInterface;
 use Google\Cloud\Datastore\ReadOnlyTransaction;
 use Google\Cloud\Datastore\Transaction;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
 /**
  * @group datastore
  * @group datastore-client
  */
-class DatastoreClientTest extends \PHPUnit_Framework_TestCase
+class DatastoreClientTest extends TestCase
 {
     use DatastoreOperationRefreshTrait;
 
@@ -164,7 +165,9 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $batch
             ? $this->client->$method([$key])[0]
@@ -201,7 +204,10 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
             'transaction' => self::TRANSACTION
         ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal(), ['projectId' => self::PROJECT]);
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
+
         $res = $this->client->$method();
         $this->assertInstanceOf($type, $res);
     }
@@ -227,7 +233,9 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
             ->shouldBeCalled()
             ->willReturn([]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $this->client->$method(['transactionOptions' => $options]);
         $this->assertInstanceOf($type, $res);
@@ -254,7 +262,9 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
             Argument::withEntry('mutations', [[$method => $mutation]])
         ))->shouldBeCalled()->willReturn($this->commitResponse());
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $entity = $this->client->entity($key, ['name' => 'John']);
         $res = $this->client->$method($entity, ['allowOverwrite' => true]);
@@ -273,7 +283,9 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
             Argument::withEntry('mutations', [[$method => $mutation]])
         ))->shouldBeCalled()->willReturn($this->commitResponse());
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $method = $method . 'Batch';
 
@@ -309,7 +321,9 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $entity = $this->client->entity($key, ['name' => 'John']);
         $this->client->$method($entity);
@@ -336,7 +350,9 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $method = $method . 'Batch';
         $entity = $this->client->entity($key, ['name' => 'John']);
@@ -365,7 +381,9 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
             ])
         ))->shouldBeCalled()->willReturn($this->commitResponse());
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $this->client->delete($key);
 
@@ -386,7 +404,9 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
             ])
         ))->shouldBeCalled()->willReturn($this->commitResponse());
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $this->client->deleteBatch([$key]);
 
@@ -407,7 +427,9 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $key = $this->client->key('Person', 'John');
         $res = $this->client->lookup($key);
@@ -429,7 +451,9 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $key = $this->client->key('Person', 'John');
         $res = $this->client->lookup($key);
@@ -458,7 +482,9 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $key = $this->client->key('Person', 'John');
         $res = $this->client->lookupBatch([$key]);
@@ -500,7 +526,9 @@ class DatastoreClientTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
-        $this->refreshOperation($this->client, $this->connection->reveal());
+        $this->refreshOperation($this->client, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $query = $this->prophesize(QueryInterface::class);
         $query->queryKey()->willReturn('gqlQuery');

--- a/tests/unit/Datastore/EntityMapperTest.php
+++ b/tests/unit/Datastore/EntityMapperTest.php
@@ -249,7 +249,7 @@ class EntityMapperTest extends TestCase
         ]);
 
         $res = $this->mapper->objectToRequest($entity);
-        $this->assertEquals($key, $res['key']);
+        $this->assertEquals($key->keyObject(), $res['key']);
         $this->assertEquals('val', $res['properties']['key']['stringValue']);
     }
 

--- a/tests/unit/Datastore/OperationTest.php
+++ b/tests/unit/Datastore/OperationTest.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Tests\Unit\Datastore;
 
+use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Datastore\Connection\ConnectionInterface;
 use Google\Cloud\Datastore\Entity;
 use Google\Cloud\Datastore\EntityIterator;
@@ -24,23 +25,30 @@ use Google\Cloud\Datastore\EntityMapper;
 use Google\Cloud\Datastore\Key;
 use Google\Cloud\Datastore\Operation;
 use Google\Cloud\Datastore\Query\QueryInterface;
-use Prophecy\Argument;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 
 /**
  * @group datastore
+ * @group datastore-operation
  */
 class OperationTest extends TestCase
 {
+    const PROJECT = 'example-project';
+    const NAMESPACEID = 'namespace-id';
+
     private $operation;
-    private $mapper;
     private $connection;
 
     public function setUp()
     {
         $this->connection = $this->prophesize(ConnectionInterface::class);
-        $this->mapper = new EntityMapper('foo', true, false);
-        $this->operation = new OperationStub($this->connection->reveal(), 'foo', '', $this->mapper);
+        $this->operation = TestHelpers::stub(Operation::class, [
+            $this->connection->reveal(),
+            self::PROJECT,
+            null,
+            new EntityMapper('foo', true, false)
+        ], ['connection', 'namespaceId']);
     }
 
     public function testKey()
@@ -54,17 +62,17 @@ class OperationTest extends TestCase
 
     public function testKeyWithNamespaceId()
     {
-        $op = new Operation($this->connection->reveal(), 'foo', 'namespace', $this->mapper);
-        $key = $op->key('Person', 'Bob');
+        $this->operation->___setProperty('namespaceId', self::NAMESPACEID);
+        $key = $this->operation->key('Person', 'Bob');
         $obj = $key->keyObject();
 
-        $this->assertEquals('namespace', $obj['partitionId']['namespaceId']);
+        $this->assertEquals(self::NAMESPACEID, $obj['partitionId']['namespaceId']);
     }
 
     public function testKeyWithNamespaceIdOverride()
     {
-        $op = new Operation($this->connection->reveal(), 'foo', 'namespace', $this->mapper);
-        $key = $op->key('Person', 'Bob', [
+        $this->operation->___setProperty('namespaceId', self::NAMESPACEID);
+        $key = $this->operation->key('Person', 'Bob', [
             'namespaceId' => 'otherNamespace'
         ]);
         $obj = $key->keyObject();
@@ -126,8 +134,8 @@ class OperationTest extends TestCase
 
     public function testEntity()
     {
-        $key = $this->prophesize(Key::class);
-        $e = $this->operation->entity($key->reveal());
+        $key = $this->operation->key('Person');
+        $e = $this->operation->entity($key);
 
         $this->assertInstanceOf(Entity::class, $e);
     }
@@ -137,6 +145,7 @@ class OperationTest extends TestCase
         $e = $this->operation->entity('Foo');
         $this->assertInstanceOf(Entity::class, $e);
         $this->assertEquals($e->key()->state(), Key::STATE_INCOMPLETE);
+        $this->assertEquals('Foo', $e->key()->pathEnd()['kind']);
     }
 
     /**
@@ -168,28 +177,25 @@ class OperationTest extends TestCase
 
     public function testAllocateIds()
     {
-        $keys = [
-            $this->operation->key('foo')
-        ];
+        $key = $this->operation->key('foo');
 
-        $this->connection->allocateIds(Argument::type('array'))
+        $id = 12345;
+        $keyWithId = clone $key;
+        $keyWithId->setLastElementIdentifier($id);
+        $this->connection->allocateIds(Argument::withEntry('keys', [$key->keyObject()]))
             ->shouldBeCalled()
             ->willReturn([
                 'keys' => [
-                    [
-                        'path' => [
-                            ['kind' => 'foo', 'id' => '1']
-                        ]
-                    ]
+                    $keyWithId->keyObject()
                 ]
             ]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
-        $res = $this->operation->allocateIds($keys);
+        $res = $this->operation->allocateIds([$key]);
 
         $this->assertEquals($res[0]->state(), Key::STATE_NAMED);
-        $this->assertEquals($res[0]->path()[0]['id'], '1');
+        $this->assertEquals($res[0]->path()[0]['id'], $id);
     }
 
     /**
@@ -197,26 +203,22 @@ class OperationTest extends TestCase
      */
     public function testAllocateIdsNamedKey()
     {
-        $keys = [
-            $this->operation->key('foo', 'Bar')
-        ];
+        $key = $this->operation->key('foo', 'Bar');
 
-        $this->operation->allocateIds($keys);
+        $this->operation->allocateIds([$key]);
     }
 
     public function testLookup()
     {
-        $keys = [
-            $this->operation->key('foo', 'Bar')
-        ];
+        $key = $this->operation->key('foo', 'Bar');
 
         $this->connection->lookup(Argument::type('array'))
             ->shouldBeCalled()
             ->willReturn([]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
-        $res = $this->operation->lookup($keys);
+        $res = $this->operation->lookup([$key]);
 
         $this->assertInternalType('array', $res);
     }
@@ -228,7 +230,7 @@ class OperationTest extends TestCase
             'found' => $body
         ]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $key = $this->operation->key('Kind', 'ID');
         $res = $this->operation->lookup([$key]);
@@ -250,7 +252,7 @@ class OperationTest extends TestCase
             'missing' => $body
         ]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $key = $this->operation->key('Kind', 'ID');
 
@@ -270,7 +272,7 @@ class OperationTest extends TestCase
             'deferred' => [ $body[0]['entity']['key'] ]
         ]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $key = $this->operation->key('Kind', 'ID');
 
@@ -285,7 +287,7 @@ class OperationTest extends TestCase
     {
         $this->connection->lookup(Argument::withKey('readOptions'))->shouldBeCalled()->willReturn([]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $k = new Key('test-project', [
             'path' => [['kind' => 'kind', 'id' => '123']]
@@ -298,7 +300,7 @@ class OperationTest extends TestCase
     {
         $this->connection->lookup(Argument::withKey('readOptions'))->shouldBeCalled()->willReturn([]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $k = new Key('test-project', [
             'path' => [['kind' => 'kind', 'id' => '123']]
@@ -313,7 +315,7 @@ class OperationTest extends TestCase
             return !isset($args['readOptions']);
         }))->shouldBeCalled()->willReturn([]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $k = new Key('test-project', [
             'path' => [['kind' => 'kind', 'id' => '123']]
@@ -337,7 +339,7 @@ class OperationTest extends TestCase
             'found' => $data['entities']
         ]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $res = $this->operation->lookup($keys, [
             'sort' => true
@@ -366,7 +368,7 @@ class OperationTest extends TestCase
             'missing' => $data['missing']
         ]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $res = $this->operation->lookup($keys);
 
@@ -397,7 +399,7 @@ class OperationTest extends TestCase
             'found' => $data['entities']
         ]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $res = $this->operation->lookup($keys, [
             'sort' => true
@@ -433,7 +435,7 @@ class OperationTest extends TestCase
         $this->connection->runQuery(Argument::type('array'))
             ->willReturn($queryResult['notPaged']);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $q = $this->prophesize(QueryInterface::class);
         $q->queryKey()->shouldBeCalled()->willReturn('query');
@@ -461,7 +463,7 @@ class OperationTest extends TestCase
                 return $queryResult['paged'][0];
             });
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $q = $this->prophesize(QueryInterface::class);
         $q->queryKey()->shouldBeCalled()->willReturn('query');
@@ -484,7 +486,7 @@ class OperationTest extends TestCase
         $this->connection->runQuery(Argument::type('array'))
             ->willReturn($queryResult['noResults']);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $q = $this->prophesize(QueryInterface::class);
         $q->queryKey()->shouldBeCalled()->willReturn('query');
@@ -503,7 +505,7 @@ class OperationTest extends TestCase
     {
         $this->connection->runQuery(Argument::withKey('readOptions'))->willReturn([]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $q = $this->prophesize(QueryInterface::class);
         $q->queryKey()->willReturn('query');
@@ -517,7 +519,7 @@ class OperationTest extends TestCase
     {
         $this->connection->runQuery(Argument::withKey('readOptions'))->willReturn([]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $q = $this->prophesize(QueryInterface::class);
         $q->queryKey()->willReturn('query');
@@ -533,7 +535,7 @@ class OperationTest extends TestCase
             return !isset($args['readOptions']);
         }))->willReturn([]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $q = $this->prophesize(QueryInterface::class);
         $q->queryKey()->willReturn('query');
@@ -555,7 +557,7 @@ class OperationTest extends TestCase
             ->shouldBeCalled()
             ->willReturn(['foo']);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $this->assertEquals(['foo'], $this->operation->commit([]));
     }
@@ -572,7 +574,7 @@ class OperationTest extends TestCase
             ->shouldBeCalled()
             ->willReturn(['foo']);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $this->operation->commit([], [
             'transaction' => '1234'
@@ -583,14 +585,12 @@ class OperationTest extends TestCase
     {
         $this->connection->commit(Argument::that(function($arg) {
             return count($arg['mutations']) === 1;
-        }))
-            ->shouldBeCalled()
-            ->willReturn(['foo']);
+        }))->shouldBeCalled()->willReturn(['foo']);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
-        $key = $this->prophesize(Key::class);
-        $e = new Entity($key->reveal());
+        $key = $this->operation->key('Person');
+        $e = new Entity($key);
 
         $mutation = $this->operation->mutation('insert', $e, Entity::class, null);
 
@@ -599,36 +599,37 @@ class OperationTest extends TestCase
 
     public function testRollback()
     {
-        $this->connection->rollback(Argument::exact(['projectId' => 'foo', 'transaction' => 'bar']))
-            ->shouldBeCalled()
-            ->willReturn(null);
+        $this->connection->rollback(Argument::allOf(
+            Argument::withEntry('projectId', self::PROJECT),
+            Argument::withEntry('transaction', 'bar')
+        ))->shouldBeCalled()->willReturn(null);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $this->operation->rollback('bar');
     }
 
     public function testAllocateIdsToEntities()
     {
-        $this->connection->allocateIds(Argument::that(function ($arg) {
-            return count($arg['keys']) === 1;
-        }))
+        $completeKey = $this->operation->key('Foo', 'Bar');
+        $partialKey = $this->operation->key('Foo');
+
+        $id = 12345;
+        $keyWithId = clone $partialKey;
+        $keyWithId->setLastElementIdentifier($id);
+        $this->connection->allocateIds(Argument::withEntry('keys', [$partialKey->keyObject()]))
             ->shouldBeCalled()
             ->willReturn([
                 'keys' => [
-                    [
-                        'path' => [
-                            ['kind' => 'foo', 'id' => '1']
-                        ]
-                    ]
+                    $keyWithId->keyObject()
                 ]
             ]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $entities = [
-            $this->operation->entity($this->operation->key('Foo', 'Bar')),
-            $this->operation->entity($this->operation->key('Foo'))
+            $this->operation->entity($completeKey),
+            $this->operation->entity($partialKey)
         ];
 
         $res = $this->operation->allocateIdsToEntities($entities);
@@ -642,18 +643,20 @@ class OperationTest extends TestCase
 
     public function testMutate()
     {
+        $id = 12345;
+
         $this->connection->commit(Argument::that(function ($arg) {
             if (count($arg['mutations']) !== 1) return false;
 
             if (!isset($arg['mutations'][0]['insert'])) return false;
 
             return true;
-        }))->willReturn('foo');
+        }))->shouldBeCalled();
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
-        $key = $this->prophesize(Key::class);
-        $e = new Entity($key->reveal());
+        $key = $this->operation->key('Person', $id);
+        $e = new Entity($key);
 
         $mutation = $this->operation->mutation('insert', $e, Entity::class, null);
         $this->operation->commit([$mutation]);
@@ -665,7 +668,7 @@ class OperationTest extends TestCase
             return $arg['mutations'][0]['baseVersion'] === 1;
         }))->willReturn('foo');
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $key = $this->prophesize(Key::class);
         $e = new Entity($key->reveal(), [], [
@@ -685,7 +688,7 @@ class OperationTest extends TestCase
             return true;
         }))->willReturn('foo');
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
         $key = new Key('foo', [
             'path' => [['kind' => 'foo', 'id' => 1]]
@@ -740,12 +743,11 @@ class OperationTest extends TestCase
                 'found' => $res
             ]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
-        $k = $this->prophesize(Key::class);
-        $k->state()->willReturn(Key::STATE_NAMED);
+        $key = $this->operation->key('Person', 12345);
 
-        $entity = $this->operation->lookup([$k->reveal()]);
+        $entity = $this->operation->lookup([$key]);
         $this->assertInstanceOf(Entity::class, $entity['found'][0]);
 
         $this->assertEquals($entity['found'][0]->baseVersion(), $res[0]['version']);
@@ -762,12 +764,11 @@ class OperationTest extends TestCase
                 'found' => $res
             ]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
-        $k = $this->prophesize(Key::class);
-        $k->state()->willReturn(Key::STATE_NAMED);
+        $key = $this->operation->key('Person', 12345);
 
-        $entity = $this->operation->lookup([$k->reveal()]);
+        $entity = $this->operation->lookup([$key]);
         $this->assertInstanceOf(Entity::class, $entity['found'][0]);
 
         $this->assertEquals($entity['found'][0]->baseVersion(), $res[0]['version']);
@@ -783,12 +784,11 @@ class OperationTest extends TestCase
                 'found' => $res
             ]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
-        $k = $this->prophesize(Key::class);
-        $k->state()->willReturn(Key::STATE_NAMED);
+        $key = $this->operation->key('Person', 12345);
 
-        $entity = $this->operation->lookup([$k->reveal()], [
+        $entity = $this->operation->lookup([$key], [
             'className' => [
                 'Kind' => MyEntity::class
             ]
@@ -809,12 +809,11 @@ class OperationTest extends TestCase
                 'found' => $res
             ]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
-        $k = $this->prophesize(Key::class);
-        $k->state()->willReturn(Key::STATE_NAMED);
+        $key = $this->operation->key('Person', 12345);
 
-        $entity = $this->operation->lookup([$k->reveal()], [
+        $entity = $this->operation->lookup([$key], [
             'className' => [
                 'Kind2' => MyEntity::class
             ]
@@ -828,11 +827,10 @@ class OperationTest extends TestCase
         }))
             ->willReturn([]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
-        $k = $this->prophesize(Key::class);
-        $k->state()->willReturn(Key::STATE_NAMED);
-        $this->operation->lookup([$k->reveal()], [
+        $key = $this->operation->key('Person', 12345);
+        $this->operation->lookup([$key], [
             'transaction' => '1234'
         ]);
     }
@@ -844,11 +842,10 @@ class OperationTest extends TestCase
         }))
             ->willReturn([]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
-        $k = $this->prophesize(Key::class);
-        $k->state()->willReturn(Key::STATE_NAMED);
-        $this->operation->lookup([$k->reveal()]);
+        $key = $this->operation->key('Person', 12345);
+        $this->operation->lookup([$key]);
     }
 
     public function testReadConsistencyInReadOptions()
@@ -860,11 +857,10 @@ class OperationTest extends TestCase
         }))
             ->willReturn([]);
 
-        $this->operation->setConnection($this->connection->reveal());
+        $this->operation->___setProperty('connection', $this->connection->reveal());
 
-        $k = $this->prophesize(Key::class);
-        $k->state()->willReturn(Key::STATE_NAMED);
-        $this->operation->lookup([$k->reveal()], [
+        $key = $this->operation->key('Person', 12345);
+        $this->operation->lookup([$key], [
             'readConsistency' => 'test'
         ]);
     }
@@ -875,19 +871,6 @@ class OperationTest extends TestCase
     public function testInvalidBatchType()
     {
         $this->operation->lookup(['foo']);
-    }
-}
-
-class OperationStub extends Operation
-{
-    // public function runQuery(QueryInterface $q, array $args = [])
-    // {
-    //     echo 'test';
-    //     exit;
-    // }
-    public function setConnection($connection)
-    {
-        $this->connection = $connection;
     }
 }
 

--- a/tests/unit/Datastore/TransactionTest.php
+++ b/tests/unit/Datastore/TransactionTest.php
@@ -89,7 +89,9 @@ class TransactionTest extends TestCase
         ]);
 
         $transaction = $transaction();
-        $this->refreshOperation($transaction, $this->connection->reveal());
+        $this->refreshOperation($transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $transaction->lookup($this->key);
         $this->assertInstanceOf(Entity::class, $res);
@@ -112,7 +114,9 @@ class TransactionTest extends TestCase
         ]);
 
         $transaction = $transaction();
-        $this->refreshOperation($transaction, $this->connection->reveal());
+        $this->refreshOperation($transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $transaction->lookup($this->key);
         $this->assertNull($res);
@@ -142,7 +146,9 @@ class TransactionTest extends TestCase
         ]);
 
         $transaction = $transaction();
-        $this->refreshOperation($transaction, $this->connection->reveal());
+        $this->refreshOperation($transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $res = $transaction->lookupBatch([$this->key]);
         $this->assertInstanceOf(Entity::class, $res['found'][0]);
@@ -169,7 +175,9 @@ class TransactionTest extends TestCase
         ]);
 
         $transaction = $transaction();
-        $this->refreshOperation($transaction, $this->connection->reveal());
+        $this->refreshOperation($transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $query = $this->prophesize(QueryInterface::class);
         $query->queryKey()->willReturn('gqlQuery');
@@ -188,7 +196,9 @@ class TransactionTest extends TestCase
             ->shouldBeCalled();
 
         $transaction = $transaction();
-        $this->refreshOperation($transaction, $this->connection->reveal());
+        $this->refreshOperation($transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $transaction->rollback();
     }
@@ -204,7 +214,9 @@ class TransactionTest extends TestCase
             Argument::withEntry('mutations', [[$method => $mutation]])
         ))->shouldBeCalled()->willReturn($this->commitResponse());
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $this->transaction->$method($this->entity, ['allowOverwrite' => true]);
         $res = $this->transaction->commit();
@@ -223,7 +235,9 @@ class TransactionTest extends TestCase
             Argument::withEntry('mutations', [[$method => $mutation]])
         ))->shouldBeCalled()->willReturn($this->commitResponse());
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $method = $method . 'Batch';
 
@@ -259,7 +273,9 @@ class TransactionTest extends TestCase
             ]
         ]);
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $entity = new Entity($key, ['name' => 'John']);
         $this->transaction->$method($entity);
@@ -289,7 +305,9 @@ class TransactionTest extends TestCase
             ]
         ]);
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $method = $method . 'Batch';
         $entity = new Entity($key, ['name' => 'John']);
@@ -319,7 +337,9 @@ class TransactionTest extends TestCase
             ])
         ))->shouldBeCalled()->willReturn($this->commitResponse());
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $this->transaction->delete($this->key);
         $res = $this->transaction->commit();
@@ -340,7 +360,9 @@ class TransactionTest extends TestCase
             ])
         ))->shouldBeCalled()->willReturn($this->commitResponse());
 
-        $this->refreshOperation($this->transaction, $this->connection->reveal());
+        $this->refreshOperation($this->transaction, $this->connection->reveal(), [
+            'projectId' => self::PROJECT
+        ]);
 
         $this->transaction->deleteBatch([$this->key]);
         $res = $this->transaction->commit();


### PR DESCRIPTION
Closes #903.

I did some housecleaning as well. When I added the feature, I found that the tests were lacking in some ways, and that certain minor features of the client were in need of improvement.