### PR TITLE
Install gRPC on Windows CI when available

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,15 +14,16 @@ environment:
     - PHP_VERSION: 5.5
     - PHP_VERSION: 5.6
     - PHP_VERSION: 7.0
+      GRPC_SRC: "http://windows.php.net/downloads/pecl/releases/grpc/1.9.0/php_grpc-1.9.0-7.0-nts-vc14-x64.zip"
     - PHP_VERSION: 7.1
+      GRPC_SRC: "http://windows.php.net/downloads/pecl/releases/grpc/1.9.0/php_grpc-1.9.0-7.1-nts-vc14-x64.zip"
     - PHP_VERSION: 7.2
+      GRPC_SRC: "http://windows.php.net/downloads/pecl/releases/grpc/1.9.0/php_grpc-1.9.0-7.2-nts-vc15-x64.zip"
 
 install:
   - cinst -y OpenSSL.Light
   - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:PHP_VERSION | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
-  - cd c:\tools\php
-  - echo extension_dir=ext >> php.ini
-  - echo extension=php_openssl.dll >> php.ini
+  - ps: . .\dev\appveyor-grpc.ps1
   - cd c:\projects\google-cloud
   - appveyor DownloadFile https://getcomposer.org/download/1.2.1/composer.phar
   - php composer.phar self-update
@@ -30,4 +31,4 @@ install:
 
 test_script:
   - cd c:\projects\google-cloud
-  - vendor/bin/phpunit
+  - vendor/bin/phpunit -c phpunit.xml.dist

--- a/dev/appveyor-grpc.ps1
+++ b/dev/appveyor-grpc.ps1
@@ -1,0 +1,25 @@
+$currentFolder = $(get-location).Path
+cd c:\tools\php
+
+Add-Content php.ini "`nextension_dir=ext"
+Add-Content php.ini "`nextension=php_openssl.dll"
+
+if (Test-Path 'env:GRPC_SRC') {
+    "Downloading $env:GRPC_SRC as grpc.zip"
+    Invoke-WebRequest -Uri $env:GRPC_SRC -OutFile .\grpc.zip
+
+    "Unzipping grpc.zip"
+    Expand-Archive grpc.zip -DestinationPath .\ext-grpc
+
+    "Copying grpc dll to php extension folder"
+    copy ext-grpc\php_grpc.dll ext\php_grpc.dll
+
+    "Adding extension to php.ini"
+    Add-Content php.ini "`nextension=php_grpc.dll"
+} else {
+    "`n`n"
+    "gRPC source URI not specified."
+    "`n`n"
+}
+
+cd $currentFolder


### PR DESCRIPTION
This change adds support for running tests requiring gRPC in Windows environments.

Currently, the gRPC extension is build for >= PHP 7.0, therefore builds running on PHP 5.x continue to be excluded.

I chose to embed the extension download URI in the build matrix for a couple of reasons. First, it was quite difficult to predict the file name. Second, it makes updating when new versions of gRPC are released very straightforward.