### PR TITLE
Prepare v0.57.1

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -11,6 +11,8 @@
             "name": "google/cloud",
             "defaultService": "readme",
             "versions": [
+                "v0.57.1",
+                "v0.57.0",
                 "v0.56.0",
                 "v0.55.0",
                 "v0.54.0",

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -30,5 +30,5 @@ class ServiceBuilder extends CoreServiceBuilder
     /**
      * @deprecated
      */
-    const VERSION = '0.56.0';
+    const VERSION = '0.57.1';
 }

--- a/src/Version.php
+++ b/src/Version.php
@@ -22,5 +22,5 @@ namespace Google\Cloud;
  */
 class Version
 {
-    const VERSION = '0.56.0';
+    const VERSION = '0.57.1';
 }


### PR DESCRIPTION
## Google Cloud PHP v0.57.1

The main package's version has been correctly incremented, there are no other changes in this release.