### PR TITLE
Debugger: De-dup arrays and string in VariableTable

### DIFF
--- a/Debugger/src/Breakpoint.php
+++ b/Debugger/src/Breakpoint.php
@@ -535,7 +535,8 @@ class Breakpoint implements \JsonSerializable
 
         foreach ($stackFrameData['locals'] as $local) {
             $value = isset($local['value']) ? $local['value'] : null;
-            $variable = $this->addVariable($local['name'], $value);
+            $hash = isset($local['id']) ? $local['id'] : null;
+            $variable = $this->addVariable($local['name'], $value, $hash);
             $sf->addLocal($variable);
         }
 
@@ -615,10 +616,10 @@ class Breakpoint implements \JsonSerializable
         );
     }
 
-    private function addVariable($name, $value)
+    private function addVariable($name, $value, $hash = null)
     {
         $this->variableTable = $this->variableTable ?: new VariableTable();
-        return $this->variableTable->register($name, $value);
+        return $this->variableTable->register($name, $value, $hash);
     }
 
     private function ensureExtensionLoaded()

--- a/Debugger/src/VariableTable.php
+++ b/Debugger/src/VariableTable.php
@@ -159,8 +159,7 @@ class VariableTable implements \JsonSerializable
     {
         $members = [];
         if ($depth < self::MAX_MEMBER_DEPTH) {
-            foreach ($array as $key => $member)
-            {
+            foreach ($array as $key => $member) {
                 $members[] = $this->doRegister($key, $member, $depth + 1, null);
             }
         }

--- a/Debugger/tests/Unit/VariableTableTest.php
+++ b/Debugger/tests/Unit/VariableTableTest.php
@@ -91,12 +91,11 @@ class VariableTableTest extends TestCase
 
     public function testRegistersArrayAsSameObjects()
     {
-        $this->markTestSkipped('Array deduping NYI');
         $variableTable = new VariableTable();
         $object = ['abc', 123];
 
-        $variable1 = $variableTable->register('int', $object);
-        $variable2 = $variableTable->register('int2', $object);
+        $variable1 = $variableTable->register('int', $object, 'hashid');
+        $variable2 = $variableTable->register('int2', $object, 'hashid');
 
         $data1 = $variable1;
         $this->assertEquals(0, $data1->jsonSerialize()['varTableIndex']);
@@ -134,5 +133,41 @@ class VariableTableTest extends TestCase
             [1234.2, 'double', '1234.2'],
             [NULL, 'NULL', 'NULL']
         ];
+    }
+
+    public function testRegisterObjectWithId()
+    {
+        $variableTable = new VariableTable();
+        $object = new Int64('123');
+        $object2 = new Int64('123');
+
+        $variable1 = $variableTable->register('int', $object, 'hashid');
+        $variable2 = $variableTable->register('int2', $object2, 'hashid');
+
+        $data1 = $variable1;
+        $this->assertEquals(0, $data1->jsonSerialize()['varTableIndex']);
+
+        $data2 = $variable2;
+        $this->assertEquals(0, $data2->jsonSerialize()['varTableIndex']);
+
+        $this->assertCount(1, $variableTable->variables());
+    }
+
+    public function testRegisterSameStrings()
+    {
+        $variableTable = new VariableTable();
+        $string = 'Hello world';
+        $string2 = 'Hello world';
+
+        $variable1 = $variableTable->register('int', $string, 'hashid');
+        $variable2 = $variableTable->register('int2', $string2, 'hashid');
+
+        $data1 = $variable1;
+        $this->assertEquals(0, $data1->jsonSerialize()['varTableIndex']);
+
+        $data2 = $variable2;
+        $this->assertEquals(0, $data2->jsonSerialize()['varTableIndex']);
+
+        $this->assertCount(1, $variableTable->variables());
     }
 }


### PR DESCRIPTION
This is an optimization to reduce the payload size and time spent by the debugger.

stackdriver_debugger 0.2.0 adds an `id` field for captured variables (arrays, strings, objects). Implemented [here](https://github.com/GoogleCloudPlatform/stackdriver-debugger-php-extension/pull/41).

If provided, use that `id` to de-dup variables in the `VariableTable` (previously we used `spl_object_hash` which is only available for objects).

This is useful for large arrays (like `$_SERVER`) so that we don't need to have multiple copies of the same nested data structure when reporting variables to stackdriver.