### PR TITLE
Check that umbrella version has been bumped

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -161,7 +161,7 @@
     "extra": {
         "component": {
             "id": "google-cloud",
-            "target": "git@github.com:GoogleCloudPlatform/google-cloud-php.git",
+            "target": "GoogleCloudPlatform/google-cloud-php.git",
             "path": "src",
             "entry": [
                 "Version.php",

--- a/dev/src/ComponentIntegration/Command/ComponentIntegration.php
+++ b/dev/src/ComponentIntegration/Command/ComponentIntegration.php
@@ -51,7 +51,10 @@ class ComponentIntegration extends Command
     {
         $this->setName('integration')
             ->setDescription('Test each component individually.')
-            ->addOption('umbrella', 'u', InputOption::VALUE_NONE, 'If set, umbrella version update check will be skipped.');
+            ->addOption('umbrella', 'u', InputOption::VALUE_NONE, 'If set, umbrella version update check will be skipped.')
+            ->addOption('preserve', 'p', InputOption::VALUE_NONE, 'If set, testing directory will not be deleted if an error occurs. ' .
+                'This may be a useful tool when debugging problems.'
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -67,6 +70,13 @@ class ComponentIntegration extends Command
         $dest = $rootPath . DIRECTORY_SEPARATOR . self::TESTING_DIR;
         $this->tmpDir = $dest;
         @mkdir($dest);
+
+        // If `--preserve|-p` is not provided, .testing will be deleted if an error occurs.
+        if (!$input->getOption('preserve')) {
+            register_shutdown_function(function () use ($dest) {
+                $this->deleteTmp($dest);
+            });
+        }
 
         $guzzle = new Client;
 

--- a/dev/src/GetComponentsTrait.php
+++ b/dev/src/GetComponentsTrait.php
@@ -137,11 +137,13 @@ trait GetComponentsTrait
      * @param string $componentId
      * @return array
      */
-    private function getComponentComposer($libraryRootPath, $componentId)
+    private function getComponentComposer($libraryRootPath, $componentId, $defaultComposerPath = null)
     {
-        $defaultComposerPath = isset($this->defaultComponentComposer)
-            ? $this->defaultComponentComposer
-            : null;
+        if (!$defaultComposerPath) {
+            $defaultComposerPath = isset($this->defaultComponentComposer)
+                ? $this->defaultComponentComposer
+                : null;
+        }
 
         $componentsDir = isset($this->components)
             ? $this->components


### PR DESCRIPTION
When running `dev/google-cloud integration`, the new pre-release CLI, the umbrella package (i.e. `google/cloud`) version will be checked. If it has not been bumped for release, the CLI will return a non-zero exit code (i.e. an error).

This check can be disabled for development purposes by providing the `--umbrella|-u` option flag:

```
$ dev/google-cloud integration
$ dev/google-cloud integration -u
```

The version check will, as for each component, execute a Github API request, and thus it is recommended that you authenticate with github by setting the `GH_OAUTH_TOKEN` environment variable to a valid Github API token.

This change also adds a cleanup to remove `.testing` at the end of execution. Previously, in the case of error, the directory was not removed. A new option flag, `--preserve|-p` can be provided to prevent deletion for debugging purposes.