### PR TITLE
Serialize empty objects in arrays as entities

### DIFF
--- a/Datastore/src/EntityMapper.php
+++ b/Datastore/src/EntityMapper.php
@@ -413,6 +413,9 @@ class EntityMapper
 
                 break;
 
+            case $value instanceof \stdClass:
+                return $this->convertArrayToEntityValue((array) $value);
+
             default:
                 throw new InvalidArgumentException(
                     sprintf('Value of type `%s` could not be serialized', get_class($value))
@@ -432,6 +435,13 @@ class EntityMapper
     {
         $values = [];
         foreach ($value as $val) {
+            // ListValues may not contain nested ListValues.
+            // Therefore, if an empty array is provided as part of an array,
+            // we can encode it as an EntityValue.
+            if (is_array($val) && empty($val)) {
+                $val = (object) $val;
+            }
+
             $values[] = $this->valueObject($val);
         }
 
@@ -458,6 +468,10 @@ class EntityMapper
                 $val,
                 in_array($key, $excludes)
             );
+        }
+
+        if (!$properties) {
+            $properties = (object) $properties;
         }
 
         return [

--- a/Datastore/src/EntityMapper.php
+++ b/Datastore/src/EntityMapper.php
@@ -207,7 +207,11 @@ class EntityMapper
                 break;
 
             case 'entityValue':
-                $decoded = $this->responseToEntityProperties($value['properties']);
+                $properties = isset($value['properties'])
+                    ? $value['properties']
+                    : [];
+
+                $decoded = $this->responseToEntityProperties($properties);
                 $props = $decoded['properties'];
                 $excludes = $decoded['excludes'];
 
@@ -228,7 +232,7 @@ class EntityMapper
                 } else {
                     $result = [];
 
-                    foreach ($value['properties'] as $key => $property) {
+                    foreach ($properties as $key => $property) {
                         $result[$key] = $this->getPropertyValue($property);
                     }
 

--- a/Datastore/tests/System/SaveAndModifyTest.php
+++ b/Datastore/tests/System/SaveAndModifyTest.php
@@ -133,4 +133,25 @@ class SaveAndModifyTest extends DatastoreTestCase
         $e = self::$client->lookup($key);
         $this->assertEquals(['hello'], $e['foo'][Entity::EXCLUDE_FROM_INDEXES]);
     }
+
+    public function testEmptyArraySemantics()
+    {
+        $entity = self::$client->entity('Person', [
+            'listVal' => [],
+            'entityVal' => (object) [],
+            'n' => [
+                'foo',
+                []
+            ]
+        ]);
+        self::$client->insert($entity);
+
+        $key = $entity->key();
+        self::$localDeletionQueue->add($key);
+
+        $e = self::$client->lookup($key);
+        $this->assertEquals([], $e['listVal']);
+        $this->assertEquals([], $e['entityVal']);
+        $this->assertEquals([], $e['n'][1]);
+    }
 }

--- a/Datastore/tests/Unit/EntityMapperTest.php
+++ b/Datastore/tests/Unit/EntityMapperTest.php
@@ -27,6 +27,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @group datastore
+ * @group datastore-entity-mapper
  */
 class EntityMapperTest extends TestCase
 {
@@ -566,6 +567,21 @@ class EntityMapperTest extends TestCase
         $null = $this->mapper->valueObject(null);
 
         $this->assertNull($null['nullValue']);
+    }
+
+    public function testValueObjectNestedArrays()
+    {
+        $res = $this->mapper->valueObject([
+            'foo' => [
+                ['a' => 'b'],
+                ['a' => 'c'],
+                (object) [],
+                []
+            ]
+        ]);
+
+        $this->assertEmpty((array) $res['entityValue']['properties']['foo']['arrayValue']['values'][2]['entityValue']['properties']);
+        $this->assertEmpty((array) $res['entityValue']['properties']['foo']['arrayValue']['values'][3]['entityValue']['properties']);
     }
 
     public function testValueObjectResource()


### PR DESCRIPTION
Fixes #970.

ListValue cannot be nested within ListValue. Therefore we can assume that if an empty array is provided within a ListValue, it must be encoded as EntityValue to prevent error.

```php
$datastore->insert($datastore->entity($key, [
    'arr' => [
        ['foo'], // This would raise an error. Can't nest ListValues inside ListValue.
        [], // This will be encoded as an EntityValue.
    ]
]));
```

The behavior for top-level values is a bit different. This will also hold true in embedded entities. To encode empty arrays as EntityValue, you must use an object cast.

```php
$datastore->insert($datastore->entity($key, [
    'arr' => [], // This will encode as a ListValue.
    'obj' => (object) [] // This will encode as an EntityValue.
]));
```