### PR TITLE
[Breaking Change] Rename DocumentSnapshot::fields() to data().

### DIFF
--- a/Firestore/src/DocumentSnapshot.php
+++ b/Firestore/src/DocumentSnapshot.php
@@ -60,7 +60,7 @@ class DocumentSnapshot implements \ArrayAccess
     /**
      * @var array
      */
-    private $fields;
+    private $data;
 
     /**
      * @var bool
@@ -71,20 +71,20 @@ class DocumentSnapshot implements \ArrayAccess
      * @param DocumentReference $reference The document which created the snapshot.
      * @param ValueMapper $valueMapper A Firestore Value Mapper.
      * @param array $info Document information, such as create and update timestamps.
-     * @param array $fields Document field data.
+     * @param array $data Document field data.
      * @param bool $exists Whether the document exists in the Firestore database.
      */
     public function __construct(
         DocumentReference $reference,
         ValueMapper $valueMapper,
         array $info,
-        array $fields,
+        array $data,
         $exists
     ) {
         $this->reference = $reference;
         $this->valueMapper = $valueMapper;
         $this->info = $info;
-        $this->fields = $fields;
+        $this->data = $data;
         $this->exists = $exists;
     }
 
@@ -216,18 +216,20 @@ class DocumentSnapshot implements \ArrayAccess
     }
 
     /**
-     * Returns document field data as an array.
+     * Returns document data as an array, or null if the document does not exist.
      *
      * Example:
      * ```
-     * $fields = $snapshot->fields();
+     * $data = $snapshot->data();
      * ```
      *
-     * @return array
+     * @return array|null
      */
-    public function fields()
+    public function data()
     {
-        return $this->fields;
+        return $this->exists
+            ? $this->data
+            : null;
     }
 
     /**
@@ -285,7 +287,7 @@ class DocumentSnapshot implements \ArrayAccess
 
         $len = count($parts);
 
-        $fields = $this->fields;
+        $fields = $this->data;
         foreach ($parts as $idx => $part) {
             if ($idx === $len-1 && isset($fields[$part])) {
                 $res = $fields[$part];
@@ -315,7 +317,7 @@ class DocumentSnapshot implements \ArrayAccess
      */
     public function offsetExists($offset)
     {
-        return isset($this->fields[$offset]);
+        return isset($this->data[$offset]);
     }
 
     /**
@@ -342,6 +344,6 @@ class DocumentSnapshot implements \ArrayAccess
             // @codeCoverageIgnoreEnd
         }
 
-        return $this->fields[$offset];
+        return $this->data[$offset];
     }
 }

--- a/Firestore/tests/Snippet/DocumentSnapshotTest.php
+++ b/Firestore/tests/Snippet/DocumentSnapshotTest.php
@@ -53,7 +53,7 @@ class DocumentSnapshotTest extends SnippetTestCase
             [],
             [],
             true
-        ], ['info', 'fields', 'exists']);
+        ], ['info', 'data', 'exists']);
     }
 
     public function testClass()
@@ -79,7 +79,7 @@ class DocumentSnapshotTest extends SnippetTestCase
     public function testClassArrayAccess()
     {
         $fields = ['wallet' => ['cryptoCurrency' => ['bitcoin' => 1]]];
-        $this->snapshot->___setProperty('fields', $fields);
+        $this->snapshot->___setProperty('data', $fields);
 
         $snippet = $this->snippetFromClass(DocumentSnapshot::class, 1);
         $snippet->addLocal('snapshot', $this->snapshot);
@@ -154,14 +154,14 @@ class DocumentSnapshotTest extends SnippetTestCase
         ];
     }
 
-    public function testFields()
+    public function testData()
     {
-        $fields = ['foo' => 'bar'];
-        $this->snapshot->___setProperty('fields', $fields);
-        $snippet = $this->snippetFromMethod(DocumentSnapshot::class, 'fields');
+        $data = ['foo' => 'bar'];
+        $this->snapshot->___setProperty('data', $data);
+        $snippet = $this->snippetFromMethod(DocumentSnapshot::class, 'data');
         $snippet->addLocal('snapshot', $this->snapshot);
-        $res = $snippet->invoke('fields');
-        $this->assertEquals($fields, $res->returnVal());
+        $res = $snippet->invoke('data');
+        $this->assertEquals($data, $res->returnVal());
     }
 
     public function testExists()
@@ -182,7 +182,7 @@ class DocumentSnapshotTest extends SnippetTestCase
             ]
         ];
 
-        $this->snapshot->___setProperty('fields', $fields);
+        $this->snapshot->___setProperty('data', $fields);
         $snippet = $this->snippetFromMethod(DocumentSnapshot::class, 'get');
         $snippet->addLocal('snapshot', $this->snapshot);
         $res = $snippet->invoke('value');
@@ -199,7 +199,7 @@ class DocumentSnapshotTest extends SnippetTestCase
             ]
         ];
 
-        $this->snapshot->___setProperty('fields', $fields);
+        $this->snapshot->___setProperty('data', $fields);
         $snippet = $this->snippetFromMethod(DocumentSnapshot::class, 'get', 1);
         $snippet->addLocal('snapshot', $this->snapshot);
         $res = $snippet->invoke('value');

--- a/Firestore/tests/System/DocumentAndCollectionTest.php
+++ b/Firestore/tests/System/DocumentAndCollectionTest.php
@@ -45,7 +45,7 @@ class DocumentAndCollectionTest extends FirestoreTestCase
         self::$deletionQueue->add($document);
         $document->create(['firstName' => 'Kate']);
         $this->assertTrue($document->snapshot()->exists());
-        $this->assertEquals(['firstName' => 'Kate'], $document->snapshot()->fields());
+        $this->assertEquals(['firstName' => 'Kate'], $document->snapshot()->data());
     }
 
     public function testUpdate()
@@ -66,7 +66,7 @@ class DocumentAndCollectionTest extends FirestoreTestCase
         $this->assertEquals([
             'firstName' => 'John',
             'country' => 'USA'
-        ], $this->document->snapshot()->fields());
+        ], $this->document->snapshot()->data());
 
         $this->document->set([
             'firstName' => 'Dave'
@@ -88,7 +88,7 @@ class DocumentAndCollectionTest extends FirestoreTestCase
         $this->assertEquals([
             'firstName' => 'John',
             'country' => 'USA'
-        ], $this->document->snapshot()->fields());
+        ], $this->document->snapshot()->data());
 
         $this->document->set([
             'firstName' => 'Dave'

--- a/Firestore/tests/System/QueryTest.php
+++ b/Firestore/tests/System/QueryTest.php
@@ -42,7 +42,7 @@ class QueryTest extends FirestoreTestCase
 
         $expected = ['foo', 'good'];
         $res = $this->getQueryRow($this->query->select($expected));
-        $actual = array_keys($res->fields());
+        $actual = array_keys($res->data());
 
         $this->assertEmpty(array_merge(
             array_diff($expected, $actual),
@@ -57,7 +57,7 @@ class QueryTest extends FirestoreTestCase
         ]);
 
         $res = $this->getQueryRow($this->query->select([]));
-        $this->assertEmpty($res->fields());
+        $this->assertEmpty($res->data());
     }
 
     public function testWhere()

--- a/Firestore/tests/System/TransactionTest.php
+++ b/Firestore/tests/System/TransactionTest.php
@@ -60,7 +60,7 @@ class TransactionTest extends FirestoreTestCase
         $this->assertEquals([
             'foo' => 'bar',
             'bat' => 'baz'
-        ], $this->document->snapshot()->fields());
+        ], $this->document->snapshot()->data());
     }
 
     public function testSet()
@@ -77,7 +77,7 @@ class TransactionTest extends FirestoreTestCase
 
         $this->assertEquals([
             'bat' => 'baz'
-        ], $this->document->snapshot()->fields());
+        ], $this->document->snapshot()->data());
     }
 
     public function testSetMerge()
@@ -95,7 +95,7 @@ class TransactionTest extends FirestoreTestCase
         $this->assertEquals([
             'foo' => 'bar',
             'bat' => 'baz'
-        ], $this->document->snapshot()->fields());
+        ], $this->document->snapshot()->data());
     }
 
     public function testDelete()

--- a/Firestore/tests/Unit/DocumentSnapshotTest.php
+++ b/Firestore/tests/Unit/DocumentSnapshotTest.php
@@ -47,7 +47,7 @@ class DocumentSnapshotTest extends TestCase
             $ref->reveal(),
             new ValueMapper($this->prophesize(ConnectionInterface::class)->reveal(), false),
             [], [], true
-        ], ['info', 'fields', 'exists']);
+        ], ['info', 'data', 'exists']);
     }
 
     public function testReference()
@@ -98,12 +98,22 @@ class DocumentSnapshotTest extends TestCase
         ];
     }
 
-    public function testFields()
+    public function testData()
     {
-        $fields = ['foo' => 'bar'];
+        $data = ['foo' => 'bar'];
 
-        $this->snapshot->___setProperty('fields', $fields);
-        $this->assertEquals($fields, $this->snapshot->fields());
+        $this->snapshot->___setProperty('data', $data);
+        $this->assertEquals($data, $this->snapshot->data());
+    }
+
+    public function testDataDocumentDoesntExist()
+    {
+        $data = ['foo' => 'bar'];
+
+        $this->snapshot->___setProperty('data', $data);
+        $this->snapshot->___setProperty('exists', false);
+
+        $this->assertNull($this->snapshot->data());
     }
 
     public function testExists()
@@ -125,7 +135,7 @@ class DocumentSnapshotTest extends TestCase
             ]
         ];
 
-        $this->snapshot->___setProperty('fields', $fields);
+        $this->snapshot->___setProperty('data', $fields);
 
         $this->assertEquals('bar', $this->snapshot->get('foo'));
         $this->assertEquals('c', $this->snapshot->get('a.b'));
@@ -144,7 +154,7 @@ class DocumentSnapshotTest extends TestCase
             ]
         ];
 
-        $this->snapshot->___setProperty('fields', $fields);
+        $this->snapshot->___setProperty('data', $fields);
 
         $this->assertEquals('bar', $this->snapshot->get(new FieldPath(['foo'])));
         $this->assertEquals('c', $this->snapshot->get(new FieldPath(['a', 'b'])));
@@ -169,7 +179,7 @@ class DocumentSnapshotTest extends TestCase
 
     public function testArrayAccessRead()
     {
-        $this->snapshot->___setProperty('fields', ['foo' => 'bar']);
+        $this->snapshot->___setProperty('data', ['foo' => 'bar']);
         $this->assertEquals('bar', $this->snapshot['foo']);
         $this->assertArrayHasKey('foo', $this->snapshot);
         $this->assertArrayNotHasKey('baz', $this->snapshot);


### PR DESCRIPTION
Closes #990.

Rename DocumentSnapshot::fields() to data(), and return null if document doesn't exist.