### PR TITLE
Remove unused proto class prophesy

### DIFF
--- a/Spanner/tests/Unit/Connection/GrpcTest.php
+++ b/Spanner/tests/Unit/Connection/GrpcTest.php
@@ -265,8 +265,6 @@ class GrpcTest extends TestCase
         $mutation->setInsert($operation);
         $insertMutationsArr[] = $mutation;
 
-        $deleteSessionRequest = $this->prophesize(DeleteSessionRequest::class)->reveal();
-
         return [
             [
                 'listInstanceConfigs',


### PR DESCRIPTION
The prophesy of `DeleteSessionRequest` is not used, and causes issues when running the unit tests with `ext-protobuf` enabled.