### PR TITLE
Add support array empty

### DIFF
--- a/Core/src/ArrayTrait.php
+++ b/Core/src/ArrayTrait.php
@@ -76,7 +76,8 @@ trait ArrayTrait
      */
     private function isAssoc(array $arr)
     {
-        return array_keys($arr) !== range(0, count($arr) - 1);
+        $keys = array_keys($arr);
+        return isset($keys[0]) && $keys !== range(0, count($arr) - 1);
     }
 
     /**


### PR DESCRIPTION
As it is now, I can not represent an empty array ...

When I use $doc->set(['array'=> []]), I expect {"array":[]}, but I get {"array":{}}

If an empty object is needed I should use new \stdClass(), not new Array();