### PR TITLE
Fix Timestamp subsecond handling.

### DIFF
--- a/Core/src/GrpcTrait.php
+++ b/Core/src/GrpcTrait.php
@@ -24,7 +24,6 @@ use Google\Auth\FetchAuthTokenCache;
 use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\GrpcRequestWrapper;
-use Google\Cloud\Core\Timestamp;
 use Google\Protobuf\NullValue;
 
 /**

--- a/Core/src/GrpcTrait.php
+++ b/Core/src/GrpcTrait.php
@@ -24,6 +24,7 @@ use Google\Auth\FetchAuthTokenCache;
 use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\GrpcRequestWrapper;
+use Google\Cloud\Core\Timestamp;
 use Google\Protobuf\NullValue;
 
 /**
@@ -114,18 +115,7 @@ trait GrpcTrait
      */
     private function formatTimestampFromApi(array $timestamp)
     {
-        $timestamp += [
-            'seconds' => 0,
-            'nanos' => 0
-        ];
-
-        $formattedTime = (new DateTime())
-            ->setTimeZone(new DateTimeZone('UTC'))
-            ->setTimestamp($timestamp['seconds'])
-            ->format('Y-m-d\TH:i:s');
-
-        $timestamp['nanos'] = str_pad($timestamp['nanos'], 9, '0', STR_PAD_LEFT);
-        return $formattedTime .= sprintf('.%sZ', rtrim($timestamp['nanos'], '0'));
+        return Timestamp::formatArrayAsString($timestamp);
     }
 
     /**

--- a/Core/src/TimeTrait.php
+++ b/Core/src/TimeTrait.php
@@ -43,11 +43,7 @@ trait TimeTrait
             $timestamp = str_replace('.'. $subSeconds, '.' . substr($subSeconds, 0, 6), $timestamp);
         }
 
-        $template = isset($matches[1])
-            ? Timestamp::FORMAT
-            : Timestamp::FORMAT_NO_MS;
-
-        $dt = \DateTimeImmutable::createFromFormat($template, $timestamp);
+        $dt = new \DateTimeImmutable($timestamp);
         if (!$dt) {
             throw new \InvalidArgumentException(sprintf(
                 'Could not create a DateTime instance from given timestamp %s.',
@@ -87,7 +83,7 @@ trait TimeTrait
     {
         $dateTime = $dateTime->setTimeZone(new \DateTimeZone('UTC'));
         if ($ns === null) {
-            $result = $dateTime->format(Timestamp::FORMAT);
+            return $dateTime->format(Timestamp::FORMAT);
         } else {
             $ns = (string) $ns;
             $ns = str_pad($ns, 9, '0', STR_PAD_LEFT);
@@ -95,13 +91,11 @@ trait TimeTrait
                 $ns = substr($ns, 0, 6);
             }
 
-            $result = sprintf(
+            return sprintf(
                 $dateTime->format(Timestamp::FORMAT_INTERPOLATE),
                 $ns
             );
         }
-
-        return str_replace('+00:00', 'Z', $result);
     }
 
     /**

--- a/Core/src/TimeTrait.php
+++ b/Core/src/TimeTrait.php
@@ -30,7 +30,7 @@ trait TimeTrait
      * @return array [\DateTimeImmutable, integer]
      * @throws \InvalidArgumentException If the timestamp string is in an unrecognized format.
      */
-    private static function parseTimeString($timestamp)
+    private function parseTimeString($timestamp)
     {
         $nanoRegex = '/\d{4}-\d{1,2}-\d{1,2}T\d{1,2}\:\d{1,2}\:\d{1,2}(?:\.(\d{1,}))?/';
 
@@ -64,7 +64,7 @@ trait TimeTrait
      * @param int $seconds The unix timestamp.
      * @return \DateTimeImmutable
      */
-    private static function createDateTimeFromSeconds($seconds)
+    private function createDateTimeFromSeconds($seconds)
     {
         return \DateTimeImmutable::createFromFormat(
             'U',
@@ -109,7 +109,7 @@ trait TimeTrait
      *
      * @return array
      */
-    public function formatTimeAsArray(\DateTimeInterface $value, $nanoSeconds)
+    private function formatTimeAsArray(\DateTimeInterface $value, $nanoSeconds)
     {
         return [
             'seconds' => (int) $value->format('U'),

--- a/Core/src/TimeTrait.php
+++ b/Core/src/TimeTrait.php
@@ -78,21 +78,14 @@ trait TimeTrait
      *
      * @param \DateTimeInterface $dateTime The date time object.
      * @param int $ns The number of nanoseconds.
-     * @param bool $nanosFromDt [optional] Whether the nanoseconds were obtained from the DateTime object.
      * @return string
      */
-    private function formatTimeAsString(\DateTimeInterface $dateTime, $ns, $nanosFromDt = false)
+    private function formatTimeAsString(\DateTimeInterface $dateTime, $ns)
     {
-        if (!preg_match('/[^0]/', $ns)) {
-            $ns = '000000';
-        } else {
-            if (!$nanosFromDt) {
-                $ns = str_pad((string) $ns, 9, '0', STR_PAD_LEFT) ?: '0';
-
-                if (substr($ns, 6, 3) === '000') {
-                    $ns = substr($ns, 0, 6);
-                }
-            }
+        $ns = (string) $ns;
+        $ns = str_pad($ns, 9, '0', STR_PAD_LEFT) ?: '0';
+        if (substr($ns, 6, 3) === '000') {
+            $ns = substr($ns, 0, 6);
         }
 
         $dateTime = $dateTime->setTimeZone(new \DateTimeZone('UTC'));

--- a/Core/src/TimeTrait.php
+++ b/Core/src/TimeTrait.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core;
+
+/**
+ * Helper methods for formatting and converting Timestamps.
+ */
+trait TimeTrait
+{
+    /**
+     * Parse a Timestamp string and return a DateTimeImmutable instance and nanoseconds as an integer.
+     *
+     * @param string $timestamp A string representation of a timestamp, encoded
+     *        in RFC 3339 format (YYYY-MM-DDTHH-MM-SS.000000[000]TZ).
+     * @return array [\DateTimeImmutable, integer]
+     * @throws \InvalidArgumentException If the timestamp string is in an unrecognized format.
+     */
+    private static function parseTimeString($timestamp)
+    {
+        $nanoRegex = '/\d{4}-\d{1,2}-\d{1,2}T\d{1,2}\:\d{1,2}\:\d{1,2}(?:\.(\d{1,}))?/';
+
+        preg_match($nanoRegex, $timestamp, $matches);
+        $subSeconds = isset($matches[1])
+            ? $matches[1]
+            : '0';
+
+        $timestamp = str_replace('.'. $subSeconds, '.' . substr($subSeconds, 0, 6), $timestamp);
+
+        $template = isset($matches[1])
+            ? Timestamp::FORMAT
+            : Timestamp::FORMAT_NO_MS;
+
+        $dt = \DateTimeImmutable::createFromFormat($template, str_replace('..', '.', $timestamp));
+        if (!$dt) {
+            throw new \InvalidArgumentException(sprintf(
+                'Could not create a DateTime instance from given timestamp %s.',
+                $timestamp
+            ));
+        }
+
+        $nanos = (int) str_pad($subSeconds, 9, '0', STR_PAD_RIGHT);
+
+        return [$dt, $nanos];
+    }
+
+    /**
+     * Create a DateTimeImmutable instance from a UNIX timestamp (i.e. seconds since epoch).
+     *
+     * @param int $seconds The unix timestamp.
+     * @return \DateTimeImmutable
+     */
+    private static function createDateTimeFromSeconds($seconds)
+    {
+        return \DateTimeImmutable::createFromFormat(
+            'U',
+            (string) $seconds,
+            new \DateTimeZone('UTC')
+        );
+    }
+
+    /**
+     * Create a Timestamp string in an API-compatible format.
+     *
+     * @param \DateTimeInterface $dateTime The date time object.
+     * @param int $ns The number of nanoseconds.
+     * @param bool $nanosFromDt [optional] Whether the nanoseconds were obtained from the DateTime object.
+     * @return string
+     */
+    private function formatTimeAsString(\DateTimeInterface $dateTime, $ns, $nanosFromDt = false)
+    {
+        if (!preg_match('/[^0]/', $ns)) {
+            $ns = '000000';
+        } else {
+            if (!$nanosFromDt) {
+                $ns = str_pad((string) $ns, 9, '0', STR_PAD_LEFT) ?: '0';
+
+                if (substr($ns, 6, 3) === '000') {
+                    $ns = substr($ns, 0, 6);
+                }
+            }
+        }
+
+        $dateTime = $dateTime->setTimeZone(new \DateTimeZone('UTC'));
+        $timestamp = sprintf(
+            $dateTime->format(Timestamp::FORMAT_INTERPOLATE),
+            $ns
+        );
+
+        return $timestamp;
+    }
+
+    /**
+     * Format a timestamp for the API with nanosecond precision.
+     *
+     * @return array
+     */
+    public function formatTimeAsArray(\DateTimeInterface $value, $nanoSeconds)
+    {
+        return [
+            'seconds' => (int) $value->format('U'),
+            'nanos' => (int) $nanoSeconds
+        ];
+    }
+}

--- a/Core/src/Timestamp.php
+++ b/Core/src/Timestamp.php
@@ -57,7 +57,7 @@ class Timestamp
     /**
      * @var bool
      */
-    private $fromDt = false;
+    private $nanosFromDt = false;
 
     /**
      * @param \DateTimeInterface $value The timestamp value.
@@ -75,7 +75,7 @@ class Timestamp
             $this->nanoSeconds = (int) $nanoSeconds;
         } else {
             $this->nanoSeconds = (int) $value->format('u') * 1000;
-            $this->fromDt = true;
+            $this->nanosFromDt = true;
         }
     }
 
@@ -198,7 +198,7 @@ class Timestamp
         // microsecond precision if the last three digits are zero.
         //
         // Either of these cases take precedent over the user input.
-        if ($this->fromDt) {
+        if ($this->nanosFromDt) {
             $precision = self::PRECISION_MICROSECOND;
         } elseif ((string) substr($ns, strlen($ns) - 3, strlen($ns)) !== '000') {
             $precision = self::PRECISION_NANOSECOND;

--- a/Core/src/Timestamp.php
+++ b/Core/src/Timestamp.php
@@ -30,7 +30,6 @@ namespace Google\Cloud\Core;
  * use Google\Cloud\Core\Timestamp;
  *
  * $timestamp = new Timestamp(new \DateTime('2003-02-05 11:15:02.421827Z'));
- *
  * ```
  *
  * ```
@@ -42,6 +41,8 @@ class Timestamp
 {
     const FORMAT = 'Y-m-d\TH:i:s.u\Z';
     const FORMAT_INTERPOLATE = 'Y-m-d\TH:i:s.%\s\Z';
+    const PRECISION_MICROSECOND = 6;
+    const PRECISION_NANOSECOND = 9;
 
     /**
      * @var \DateTimeInterface
@@ -54,19 +55,96 @@ class Timestamp
     private $nanoSeconds;
 
     /**
+     * @var bool
+     */
+    private $fromDt = false;
+
+    /**
      * @param \DateTimeInterface $value The timestamp value.
-     * @param int $nanoSeconds [optional] The number of nanoseconds in the timestamp.
+     * @param int $nanoSeconds [optional] The number of nanoseconds in the
+     *        timestamp. If omitted, subsecond precision will be obtained from
+     *        the instance of `\DateTimeInterface` provided in the first
+     *        argument. If provided, any precision in `$value` below seconds
+     *        will be disregarded.
      */
     public function __construct(\DateTimeInterface $value, $nanoSeconds = null)
     {
         $this->value = $value;
-        $this->nanoSeconds = $nanoSeconds ?: (int) $this->value->format('u');
+
+        if ($nanoSeconds !== null) {
+            $this->nanoSeconds = (int) $nanoSeconds;
+        } else {
+            $this->nanoSeconds = (int) $value->format('u') * 1000;
+            $this->fromDt = true;
+        }
+    }
+
+    /**
+     * Convert a Timestamp string into a Google Cloud PHP object.
+     *
+     * Example:
+     * ```
+     * use Google\Cloud\Core\Timestamp;
+     *
+     * $timeString = '2018-01-01T23:59:59.000000Z';
+     * $timestamp = Timestamp::createFromString($timeString);
+     * ```
+     *
+     * @param string $timestamp A string representation of a point in time.
+     * @return Timestamp
+     */
+    public static function createFromString($timestamp)
+    {
+        $nanoRegex = '/(?:(\.\d{1,9})Z)|(?:Z)/';
+
+        $matches = [];
+        preg_match($nanoRegex, $timestamp, $matches);
+        $timestamp = preg_replace($nanoRegex, '.000000Z', $timestamp);
+
+        $dt = \DateTimeImmutable::createFromFormat(static::FORMAT, str_replace('..', '.', $timestamp));
+
+        $nanos = isset($matches[1])
+            ? $matches[1] * 1000000000
+            : 0;
+
+        return new static($dt, $nanos);
+    }
+
+    /**
+     * Convert a Timestamp array into a Google Cloud PHP object.
+     *
+     * Example:
+     * ```
+     * use Google\Cloud\Core\Timestamp;
+     *
+     * $timeArray = [
+     *     'seconds' => time(),
+     *     'nanos' => 0
+     * ];
+     * $timestamp = Timestamp::createFromArray($timeArray);
+     * ```
+     *
+     * @param array $timestamp An array representation of a point in time.
+     * @return Timestamp
+     */
+    public static function createFromArray(array $timestamp)
+    {
+        $timestamp += [
+            'seconds' => 0,
+            'nanos' => 0
+        ];
+
+        $dt = \DateTimeImmutable::createFromFormat('U', (string) $timestamp['seconds']);
+        $nanos = $timestamp['nanos'];
+
+        return new static($dt, $nanos);
     }
 
     /**
      * Get the underlying `\DateTimeInterface` implementation.
      *
-     * Please note that nanosecond precision is not present in this method.
+     * Please note that if you provided nanoseconds when creating the timestamp,
+     * they will not be included in this value.
      *
      * Example:
      * ```
@@ -83,6 +161,11 @@ class Timestamp
     /**
      * Return the number of nanoseconds.
      *
+     * Example:
+     * ```
+     * $nanos = $timestamp->nanoSeconds();
+     * ```
+     *
      * @return int
      */
     public function nanoSeconds()
@@ -93,20 +176,54 @@ class Timestamp
     /**
      * Format the value as a string.
      *
-     * This method retains nanosecond precision, if available.
-     *
      * Example:
      * ```
      * $value = $timestamp->formatAsString();
      * ```
      *
+     * @param int $precision [optional] The maximum precision of the subsecond
+     *        portion of the timestamp string. If nanoseconds were not provided
+     *        as a separate constructor argument, this option will be
+     *        disregarded. **Defaults to `6` (microsecond precision).
      * @return string
      */
-    public function formatAsString()
+    public function formatAsString($precision = self::PRECISION_MICROSECOND)
     {
-        $this->value->setTimezone(new \DateTimeZone('UTC'));
-        $ns = str_pad((string) $this->nanoSeconds, 6, '0', STR_PAD_LEFT);
-        return sprintf($this->value->format(self::FORMAT_INTERPOLATE), $ns);
+        $ns = str_pad((string) $this->nanoSeconds, 9, '0', STR_PAD_LEFT) ?: '0';
+
+        // If nanoseconds were obtained from the datetime object, always use μs.
+        // PHP datetime only supports micros, so further precision is unnecessary.
+        //
+        // If nanos were provided separately, we can still safely trim to
+        // microsecond precision if the last three digits are zero.
+        //
+        // Either of these cases take precedent over the user input.
+        if ($this->fromDt) {
+            $precision = self::PRECISION_MICROSECOND;
+        } elseif ((string) substr($ns, strlen($ns) - 3, strlen($ns)) !== '000') {
+            $precision = self::PRECISION_NANOSECOND;
+        }
+
+        return sprintf(
+            $this->value->format(self::FORMAT_INTERPOLATE),
+            substr($ns, 0, (int) $precision)
+        );
+    }
+
+    /**
+     * Set the timezone of the underlying DateTime.
+     *
+     * Example:
+     * ```
+     * $timestamp->setTimeZone(new \DateTimeZone('America/New_York'));
+     * ```
+     *
+     * @param \DateTimeZone $timezone The timezone to use.
+     * @return Timestamp
+     */
+    public function setTimezone(\DateTimeZone $timezone)
+    {
+        $this->value = $this->value->setTimezone($timezone);
     }
 
     /**

--- a/Core/src/Timestamp.php
+++ b/Core/src/Timestamp.php
@@ -43,7 +43,7 @@ class Timestamp
 
     const FORMAT = 'Y-m-d\TH:i:s.uP';
     const FORMAT_NO_MS = 'Y-m-d\TH:i:sP';
-    const FORMAT_INTERPOLATE = 'Y-m-d\TH:i:s.%\s\Z';
+    const FORMAT_INTERPOLATE = 'Y-m-d\TH:i:s.%\sP';
 
     /**
      * @var \DateTimeInterface
@@ -104,9 +104,9 @@ class Timestamp
      */
     public function nanoSeconds()
     {
-        return $this->nanoSeconds !== null
-            ? $this->nanoSeconds
-            : (int) $this->value->format('u') * 1000;
+        return $this->nanoSeconds === null
+            ? (int) $this->value->format('u') * 1000
+            : $this->nanoSeconds;
     }
 
     /**
@@ -123,7 +123,7 @@ class Timestamp
     {
         return $this->formatTimeAsString(
             $this->value,
-            $this->nanoSeconds()
+            $this->nanoSeconds
         );
     }
 

--- a/Core/src/Timestamp.php
+++ b/Core/src/Timestamp.php
@@ -56,11 +56,6 @@ class Timestamp
     private $nanoSeconds;
 
     /**
-     * @var bool
-     */
-    private $nanosFromDt = false;
-
-    /**
      * @param \DateTimeInterface $value The timestamp value. Use of
      *        `DateTimeImmutable` is highly recommended over `DateTime` in order
      *        to avoid side effects.
@@ -74,12 +69,9 @@ class Timestamp
     {
         $this->value = $value;
 
-        if ($nanoSeconds !== null) {
-            $this->nanoSeconds = (int) $nanoSeconds;
-        } else {
-            $this->nanoSeconds = (int) $value->format('u') * 1000;
-            $this->nanosFromDt = true;
-        }
+        $this->nanoSeconds = $nanoSeconds !== null
+            ? (int) $nanoSeconds
+            : null;
     }
 
     /**
@@ -112,7 +104,9 @@ class Timestamp
      */
     public function nanoSeconds()
     {
-        return $this->nanoSeconds;
+        return $this->nanoSeconds !== null
+            ? $this->nanoSeconds
+            : (int) $this->value->format('u') * 1000;
     }
 
     /**
@@ -129,8 +123,7 @@ class Timestamp
     {
         return $this->formatTimeAsString(
             $this->value,
-            $this->nanoSeconds,
-            $this->nanosFromDt
+            $this->nanoSeconds()
         );
     }
 
@@ -152,6 +145,6 @@ class Timestamp
      */
     public function formatForApi()
     {
-        return $this->formatTimeAsArray($this->value, $this->nanoSeconds);
+        return $this->formatTimeAsArray($this->value, $this->nanoSeconds());
     }
 }

--- a/Core/src/Timestamp.php
+++ b/Core/src/Timestamp.php
@@ -83,60 +83,6 @@ class Timestamp
     }
 
     /**
-     * Convert a Timestamp string into a Google Cloud PHP object.
-     *
-     * Example:
-     * ```
-     * use Google\Cloud\Core\Timestamp;
-     *
-     * $timeString = '2018-01-01T23:59:59.000000Z';
-     * $timestamp = Timestamp::createFromString($timeString);
-     * ```
-     *
-     * @param string $timestamp A string representation of a timestamp, encoded
-     *        in RFC 3339 format (YYYY-MM-DDTHH-MM-SS.000000[000]TZ).
-     * @return Timestamp
-     * @throws \InvalidArgumentException If the timestamp string is in an unrecognized format.
-     */
-    public static function createFromString($timestamp)
-    {
-        list($dt, $nanos) = self::parseTimeString($timestamp);
-
-        return new static($dt, $nanos);
-    }
-
-    /**
-     * Convert a Timestamp array into a Google Cloud PHP object.
-     *
-     * Example:
-     * ```
-     * use Google\Cloud\Core\Timestamp;
-     *
-     * $timeArray = [
-     *     'seconds' => time(),
-     *     'nanos' => 0
-     * ];
-     * $timestamp = Timestamp::createFromArray($timeArray);
-     * ```
-     *
-     * @param array $timestamp An array representation of a point in time.
-     * @return Timestamp
-     */
-    public static function createFromArray(array $timestamp)
-    {
-        $timestamp += [
-            'seconds' => 0,
-            'nanos' => 0
-        ];
-
-        $dt = self::createDateTimeFromSeconds($timestamp['seconds']);
-
-        $nanos = $timestamp['nanos'];
-
-        return new static($dt, $nanos);
-    }
-
-    /**
      * Get the underlying `\DateTimeInterface` implementation.
      *
      * Please note that if you provided nanoseconds when creating the timestamp,

--- a/Core/src/Timestamp.php
+++ b/Core/src/Timestamp.php
@@ -41,9 +41,9 @@ class Timestamp
 {
     use TimeTrait;
 
-    const FORMAT = 'Y-m-d\TH:i:s.uP';
-    const FORMAT_NO_MS = 'Y-m-d\TH:i:sP';
-    const FORMAT_INTERPOLATE = 'Y-m-d\TH:i:s.%\sP';
+    const FORMAT = 'Y-m-d\TH:i:s.u\Z';
+    const FORMAT_NO_MS = 'Y-m-d\TH:i:s\Z';
+    const FORMAT_INTERPOLATE = 'Y-m-d\TH:i:s.%\s\Z';
 
     /**
      * @var \DateTimeInterface

--- a/Core/src/Timestamp.php
+++ b/Core/src/Timestamp.php
@@ -223,7 +223,9 @@ class Timestamp
      */
     public function setTimezone(\DateTimeZone $timezone)
     {
+        // use assignment to update possible DateTimeImmutable.
         $this->value = $this->value->setTimezone($timezone);
+        return $this;
     }
 
     /**

--- a/Core/src/ValueMapperTrait.php
+++ b/Core/src/ValueMapperTrait.php
@@ -26,6 +26,10 @@ trait ValueMapperTrait
      * Convert a timestamp (represented as a string or an array) to a Timestamp
      * class with nanosecond support.
      *
+     * @deprecated Use {@see Google\Cloud\Core\Timestamp::createFromString()}
+     *             or {@see Google\Cloud\Core\Timestamp::createFromArray()}
+     *             instead.
+     *
      * @param string|array $timestamp The timestamp as a string or an array.
      * @param string $returnType The type to create and return. Any object used
      *        must provide a constructor compatible with {@see Google\Cloud\Core\Timestamp}.
@@ -34,29 +38,10 @@ trait ValueMapperTrait
      */
     public function createTimestampWithNanos($timestamp, $returnType = Timestamp::class)
     {
-        $nanos = 0;
         if (is_array($timestamp)) {
-            $timestamp = $timestamp + [
-                'seconds' => 0,
-                'nanos' => 0
-            ];
-
-            $dt = \DateTimeImmutable::createFromFormat('U', (string) $timestamp['seconds']);
-            $nanos = $timestamp['nanos'];
+            return $returnType::createFromArray($timestamp);
         } else {
-            $nanoRegex = '/(?:\.(\d{1,9})Z)|(?:Z)/';
-
-            $matches = [];
-            preg_match($nanoRegex, $timestamp, $matches);
-            $timestamp = preg_replace($nanoRegex, '.000000Z', $timestamp);
-
-            $dt = \DateTimeImmutable::createFromFormat(Timestamp::FORMAT, str_replace('..', '.', $timestamp));
-
-            $nanos = isset($matches[1])
-                ? $matches[1]
-                : 0;
+            return $returnType::createFromString($timestamp);
         }
-
-        return new $returnType($dt, $nanos);
     }
 }

--- a/Core/src/ValueMapperTrait.php
+++ b/Core/src/ValueMapperTrait.php
@@ -22,13 +22,13 @@ namespace Google\Cloud\Core;
  */
 trait ValueMapperTrait
 {
+    use TimeTrait;
+
     /**
      * Convert a timestamp (represented as a string or an array) to a Timestamp
      * class with nanosecond support.
      *
-     * @deprecated Use {@see Google\Cloud\Core\Timestamp::createFromString()}
-     *             or {@see Google\Cloud\Core\Timestamp::createFromArray()}
-     *             instead.
+     * @deprecated Use methods on {@see Google\Cloud\Core\TimeTrait}.
      *
      * @param string|array $timestamp The timestamp as a string or an array.
      * @param string $returnType The type to create and return. Any object used
@@ -39,9 +39,17 @@ trait ValueMapperTrait
     public function createTimestampWithNanos($timestamp, $returnType = Timestamp::class)
     {
         if (is_array($timestamp)) {
-            return $returnType::createFromArray($timestamp);
+            $timestamp += [
+                'seconds' => 0,
+                'nanos' => 0
+            ];
+
+            $dt = $this->createDateTimeFromSeconds($timestamp['seconds']);
+            $nanos = $timestamp['nanos'];
         } else {
-            return $returnType::createFromString($timestamp);
+            list ($dt, $nanos) = $this->parseTimeString($timestamp);
         }
+
+        return new $returnType($dt, $nanos);
     }
 }

--- a/Core/tests/Unit/TimestampTest.php
+++ b/Core/tests/Unit/TimestampTest.php
@@ -59,7 +59,7 @@ class TimestampTest extends TestCase
     /**
      * @dataProvider timestampStrings
      */
-    public function testCreateTimestampWithNanosTimestampStrings($timestampStr, $expected)
+    public function testCreateFromStringTimestampStrings($timestampStr, $expected)
     {
         $timestamp = Timestamp::createFromString($timestampStr);
 
@@ -71,7 +71,7 @@ class TimestampTest extends TestCase
     /**
      * @dataProvider timestampStrings
      */
-    public function testCreateTimestampWithNanosTimestampStringsLocale($timestampStr, $expected)
+    public function testCreateFromStringTimestampStringsLocale($timestampStr, $expected)
     {
         setlocale(LC_ALL, 'fr_FR.UTF-8');
 
@@ -137,7 +137,7 @@ class TimestampTest extends TestCase
     /**
      * @dataProvider timestampArrays
      */
-    public function testCreateTimestampWithNanosArrays(array $input)
+    public function testCreateFromStringArrays(array $input)
     {
         $timestamp = Timestamp::createFromArray($input);
         $this->assertInstanceOf(Timestamp::class, $timestamp);
@@ -149,7 +149,7 @@ class TimestampTest extends TestCase
     /**
      * @dataProvider timestampArrays
      */
-    public function testCreateTimestampWithNanosArraysLocale(array $input)
+    public function testCreateFromStringArraysLocale(array $input)
     {
         setlocale(LC_ALL, 'fr_FR.UTF-8');
         try {

--- a/Core/tests/Unit/TimestampTest.php
+++ b/Core/tests/Unit/TimestampTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Tests\Core;
 
 use Google\Cloud\Core\Timestamp;
+use Google\Cloud\Core\TimeTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -26,12 +27,14 @@ use PHPUnit\Framework\TestCase;
  */
 class TimestampTest extends TestCase
 {
+    use TimeTrait;
+
     private $dt;
     private $ts;
 
     public function setUp()
     {
-        $this->dt = new \DateTime('1989-10-11 08:58:00 +00:00');
+        $this->dt = new \DateTime();
         $this->ts = new Timestamp($this->dt);
     }
 
@@ -61,9 +64,8 @@ class TimestampTest extends TestCase
      */
     public function testCreateFromStringTimestampStrings($timestampStr, $expected)
     {
-        $timestamp = Timestamp::createFromString($timestampStr);
-
-        $this->assertInstanceOf(Timestamp::class, $timestamp);
+        $time = $this->parseTimeString($timestampStr);
+        $timestamp = new Timestamp($time[0], $time[1]);
 
         $this->assertEquals($expected, $timestamp->formatAsString());
     }
@@ -76,9 +78,8 @@ class TimestampTest extends TestCase
         setlocale(LC_ALL, 'fr_FR.UTF-8');
 
         try {
-            $timestamp = Timestamp::createFromString($timestampStr);
-
-            $this->assertInstanceOf(Timestamp::class, $timestamp);
+            $time = $this->parseTimeString($timestampStr);
+            $timestamp = new Timestamp($time[0], $time[1]);
 
             $this->assertEquals($expected, $timestamp->formatAsString());
         } finally {
@@ -139,8 +140,10 @@ class TimestampTest extends TestCase
      */
     public function testCreateFromStringArrays(array $input)
     {
-        $timestamp = Timestamp::createFromArray($input);
-        $this->assertInstanceOf(Timestamp::class, $timestamp);
+        $timestamp = new Timestamp(
+            $this->createDateTimeFromSeconds($input['seconds']),
+            $input['nanos']
+        );
 
         $this->assertEquals($input['seconds'], $timestamp->get()->format('U'));
         $this->assertEquals($input['nanos'], $timestamp->nanoSeconds());
@@ -153,8 +156,10 @@ class TimestampTest extends TestCase
     {
         setlocale(LC_ALL, 'fr_FR.UTF-8');
         try {
-            $timestamp = Timestamp::createFromArray($input);
-            $this->assertInstanceOf(Timestamp::class, $timestamp);
+            $timestamp = new Timestamp(
+                $this->createDateTimeFromSeconds($input['seconds']),
+                $input['nanos']
+            );
 
             $this->assertEquals($input['seconds'], $timestamp->get()->format('U'));
             $this->assertEquals($input['nanos'], $timestamp->nanoSeconds());

--- a/Core/tests/Unit/TimestampTest.php
+++ b/Core/tests/Unit/TimestampTest.php
@@ -68,6 +68,24 @@ class TimestampTest extends TestCase
         $this->assertEquals($expected, $timestamp->formatAsString());
     }
 
+    /**
+     * @dataProvider timestampStrings
+     */
+    public function testCreateTimestampWithNanosTimestampStringsLocale($timestampStr, $expected)
+    {
+        setlocale(LC_ALL, 'fr_FR.UTF-8');
+
+        try {
+            $timestamp = Timestamp::createFromString($timestampStr);
+
+            $this->assertInstanceOf(Timestamp::class, $timestamp);
+
+            $this->assertEquals($expected, $timestamp->formatAsString());
+        } finally {
+            setlocale(LC_ALL, null);
+        }
+    }
+
     public function timestampStrings()
     {
         $today = (new \DateTime)->format('Y-m-d\TH:i:s');
@@ -89,6 +107,19 @@ class TimestampTest extends TestCase
     public function testNanosFromApi(Timestamp $timestamp, $expected)
     {
         $this->assertEquals($expected, $timestamp->formatAsString());
+    }
+
+    /**
+     * @dataProvider timestampNanos
+     */
+    public function testNanosFromApiLocale(Timestamp $timestamp, $expected)
+    {
+        setlocale(LC_ALL, 'fr_FR.UTF-8');
+        try {
+            $this->assertEquals($expected, $timestamp->formatAsString());
+        } finally {
+            setlocale(LC_ALL, null);
+        }
     }
 
     public function timestampNanos()
@@ -113,6 +144,23 @@ class TimestampTest extends TestCase
 
         $this->assertEquals($input['seconds'], $timestamp->get()->format('U'));
         $this->assertEquals($input['nanos'], $timestamp->nanoSeconds());
+    }
+
+    /**
+     * @dataProvider timestampArrays
+     */
+    public function testCreateTimestampWithNanosArraysLocale(array $input)
+    {
+        setlocale(LC_ALL, 'fr_FR.UTF-8');
+        try {
+            $timestamp = Timestamp::createFromArray($input);
+            $this->assertInstanceOf(Timestamp::class, $timestamp);
+
+            $this->assertEquals($input['seconds'], $timestamp->get()->format('U'));
+            $this->assertEquals($input['nanos'], $timestamp->nanoSeconds());
+        } finally {
+            setlocale(LC_ALL, null);
+        }
     }
 
     public function timestampArrays()

--- a/Core/tests/Unit/TimestampTest.php
+++ b/Core/tests/Unit/TimestampTest.php
@@ -99,6 +99,35 @@ class TimestampTest extends TestCase
             [$today . '.1234Z',         $today . '.123400Z'],
             [$today . '.004Z',          $today . '.004000Z'],
             [$today . '.020001000Z',    $today . '.020001Z'],
+            [$today . '.012345Z',       $today . '.012345Z'],
+        ];
+    }
+
+    /**
+     * @dataProvider microSeconds
+     */
+    public function testNanoSecondsPadCorrectFromDateTime($micros)
+    {
+        $today = \DateTime::createFromFormat('U.u', time() .'.'. $micros);
+        $timestamp = new Timestamp($today);
+
+        $this->assertEquals($micros * 1000, $timestamp->nanoSeconds());
+        $this->assertEquals(
+            str_replace('+00:00', 'Z', $today->format(Timestamp::FORMAT)),
+            $timestamp->formatAsString()
+        );
+    }
+
+    public function microSeconds()
+    {
+        return [
+            ['012345'],
+            ['000001'],
+            ['123456'],
+            ['000100'],
+            ['101010'],
+            ['100001'],
+            ['001000']
         ];
     }
 

--- a/Core/tests/Unit/TimestampTest.php
+++ b/Core/tests/Unit/TimestampTest.php
@@ -93,7 +93,7 @@ class TimestampTest extends TestCase
 
     public function timestampNanos()
     {
-        $dt = (new \DateTime);
+        $dt = new \DateTime;
         $today = $dt->format('Y-m-d\TH:i:s');
         return [
             [new Timestamp($dt, 1),             $today . '.000000001Z'],

--- a/Core/tests/Unit/TimestampTest.php
+++ b/Core/tests/Unit/TimestampTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Tests\Core;
+namespace Google\Cloud\Core\Tests\Unit;
 
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\TimeTrait;

--- a/Firestore/src/Connection/Grpc.php
+++ b/Firestore/src/Connection/Grpc.php
@@ -55,17 +55,7 @@ class Grpc implements ConnectionInterface
      */
     public function __construct(array $config = [])
     {
-        $this->serializer = new Serializer([
-            'create_time' => function ($v) {
-                return $this->formatTimestampFromApi($v);
-            },
-            'update_time' => function ($v) {
-                return $this->formatTimestampFromApi($v);
-            },
-            'commit_time' => function ($v) {
-                return $this->formatTimestampFromApi($v);
-            },
-        ], [
+        $this->serializer = new Serializer([], [
             'google.protobuf.Value' => function ($v) {
                 return $this->flattenValue($v);
             },
@@ -74,6 +64,9 @@ class Grpc implements ConnectionInterface
             },
             'google.protobuf.Struct' => function ($v) {
                 return $this->flattenStruct($v);
+            },
+            'google.protobuf.Timestamp' => function ($v) {
+                return $this->formatTimestampFromApi($v);
             },
         ]);
 

--- a/Firestore/src/SnapshotTrait.php
+++ b/Firestore/src/SnapshotTrait.php
@@ -86,8 +86,6 @@ trait SnapshotTrait
             ? $valueMapper->decodeValues($this->pluck('fields', $document))
             : [];
 
-        $document = $this->transformSnapshotTimestamps($valueMapper, $document);
-
         return new DocumentSnapshot($reference, $valueMapper, $document, $fields, $exists);
     }
 
@@ -127,30 +125,6 @@ trait SnapshotTrait
         }
 
         return $snapshot['found'];
-    }
-
-    /**
-     * Convert snapshot timestamps to Google Cloud PHP types.
-     *
-     * @param ValueMapper $valueMapper A Firestore Value Mapper
-     * @param array $data The snapshot data.
-     * @return array
-     */
-    private function transformSnapshotTimestamps(ValueMapper $valueMapper, array $data)
-    {
-        $data['createTime'] = isset($data['createTime'])
-            ? Timestamp::createFromArray($data['createTime'])
-            : null;
-
-        $data['updateTime'] = isset($data['updateTime'])
-            ? Timestamp::createFromArray($data['updateTime'])
-            : null;
-
-        $data['readTime'] = isset($data['readTime'])
-            ? Timestamp::createFromArray($data['readTime'])
-            : null;
-
-        return $data;
     }
 
     /**

--- a/Firestore/src/SnapshotTrait.php
+++ b/Firestore/src/SnapshotTrait.php
@@ -20,7 +20,6 @@ namespace Google\Cloud\Firestore;
 use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Timestamp;
-use Google\Cloud\Core\ValueMapperTrait;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\DocumentReference;
 

--- a/Firestore/src/SnapshotTrait.php
+++ b/Firestore/src/SnapshotTrait.php
@@ -139,15 +139,15 @@ trait SnapshotTrait
     private function transformSnapshotTimestamps(ValueMapper $valueMapper, array $data)
     {
         $data['createTime'] = isset($data['createTime'])
-            ? $valueMapper->createTimestampWithNanos($data['createTime'])
+            ? Timestamp::createFromArray($data['createTime'])
             : null;
 
         $data['updateTime'] = isset($data['updateTime'])
-            ? $valueMapper->createTimestampWithNanos($data['updateTime'])
+            ? Timestamp::createFromArray($data['updateTime'])
             : null;
 
         $data['readTime'] = isset($data['readTime'])
-            ? $valueMapper->createTimestampWithNanos($data['readTime'])
+            ? Timestamp::createFromArray($data['readTime'])
             : null;
 
         return $data;

--- a/Firestore/src/ValueMapper.php
+++ b/Firestore/src/ValueMapper.php
@@ -24,7 +24,6 @@ use Google\Cloud\Core\GeoPoint;
 use Google\Cloud\Core\Int64;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\ValidateTrait;
-use Google\Cloud\Core\ValueMapperTrait;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Protobuf\NullValue;
 
@@ -37,7 +36,6 @@ class ValueMapper
     use DebugInfoTrait;
     use PathTrait;
     use ValidateTrait;
-    use ValueMapperTrait;
 
     const VALID_FIELD_PATH = '/^[^*~\/[\]]+$/';
     const UNESCAPED_FIELD_NAME = '/^[_a-zA-Z][_a-zA-Z0-9]*$/';
@@ -279,7 +277,7 @@ class ValueMapper
                     : (int) $value;
 
             case 'timestampValue':
-                return $this->createTimestampWithNanos($value);
+                return Timestamp::createFromArray($value);
                 break;
 
             case 'geoPointValue':

--- a/Firestore/src/ValueMapper.php
+++ b/Firestore/src/ValueMapper.php
@@ -277,7 +277,7 @@ class ValueMapper
                     : (int) $value;
 
             case 'timestampValue':
-                return Timestamp::createFromArray($value);
+                return Timestamp::createFromString($value);
                 break;
 
             case 'geoPointValue':

--- a/Firestore/src/WriteBatch.php
+++ b/Firestore/src/WriteBatch.php
@@ -379,13 +379,13 @@ class WriteBatch
         ]) + $options);
 
         if (isset($response['commitTime'])) {
-            $response['commitTime'] = Timestamp::createFromArray($response['commitTime']);
+            $response['commitTime'] = Timestamp::createFromString($response['commitTime']);
         }
 
         if (isset($response['writeResults'])) {
             foreach ($response['writeResults'] as &$result) {
                 if (isset($result['updateTime'])) {
-                    $result['updateTime'] = Timestamp::createFromArray($result['updateTime']);
+                    $result['updateTime'] = Timestamp::createFromString($result['updateTime']);
                 }
             }
         }

--- a/Firestore/src/WriteBatch.php
+++ b/Firestore/src/WriteBatch.php
@@ -17,10 +17,11 @@
 
 namespace Google\Cloud\Firestore;
 
-use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\ArrayTrait;
-use Google\Cloud\Core\ValidateTrait;
 use Google\Cloud\Core\DebugInfoTrait;
+use Google\Cloud\Core\Timestamp;
+use Google\Cloud\Core\TimeTrait;
+use Google\Cloud\Core\ValidateTrait;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\V1beta1\DocumentTransform_FieldTransform_ServerValue;
 
@@ -44,6 +45,7 @@ class WriteBatch
 {
     use ArrayTrait;
     use DebugInfoTrait;
+    use TimeTrait;
     use ValidateTrait;
 
     const TYPE_UPDATE = 'update';
@@ -379,13 +381,15 @@ class WriteBatch
         ]) + $options);
 
         if (isset($response['commitTime'])) {
-            $response['commitTime'] = Timestamp::createFromString($response['commitTime']);
+            $time = $this->parseTimeString($response['commitTime']);
+            $response['commitTime'] = new Timestamp($time[0], $time[1]);
         }
 
         if (isset($response['writeResults'])) {
             foreach ($response['writeResults'] as &$result) {
                 if (isset($result['updateTime'])) {
-                    $result['updateTime'] = Timestamp::createFromString($result['updateTime']);
+                    $time = $this->parseTimeString($result['updateTime']);
+                    $result['updateTime'] = new Timestamp($time[0], $time[1]);
                 }
             }
         }

--- a/Firestore/src/WriteBatch.php
+++ b/Firestore/src/WriteBatch.php
@@ -379,13 +379,13 @@ class WriteBatch
         ]) + $options);
 
         if (isset($response['commitTime'])) {
-            $response['commitTime'] = $this->valueMapper->createTimestampWithNanos($response['commitTime']);
+            $response['commitTime'] = Timestamp::createFromArray($response['commitTime']);
         }
 
         if (isset($response['writeResults'])) {
             foreach ($response['writeResults'] as &$result) {
                 if (isset($result['updateTime'])) {
-                    $result['updateTime'] = $this->valueMapper->createTimestampWithNanos($result['updateTime']);
+                    $result['updateTime'] = Timestamp::createFromArray($result['updateTime']);
                 }
             }
         }

--- a/Firestore/tests/Snippet/DocumentReferenceTest.php
+++ b/Firestore/tests/Snippet/DocumentReferenceTest.php
@@ -17,7 +17,9 @@
 
 namespace Google\Cloud\Firestore\Tests\Snippet;
 
+use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
+use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\CollectionReference;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\DocumentReference;
@@ -26,7 +28,6 @@ use Google\Cloud\Firestore\FieldValue;
 use Google\Cloud\Firestore\FirestoreClient;
 use Google\Cloud\Firestore\ValueMapper;
 use Google\Cloud\Firestore\WriteBatch;
-use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Prophecy\Argument;
 
 /**
@@ -203,7 +204,7 @@ class DocumentReferenceTest extends SnippetTestCase
                     'found' => [
                         'name' => self::DOCUMENT,
                         'fields' => [],
-                        'readTime' => ['seconds' => time()]
+                        'readTime' => (new \DateTime)->format(Timestamp::FORMAT)
                     ]
                 ]
             ]));

--- a/Firestore/tests/Snippet/FirestoreClientTest.php
+++ b/Firestore/tests/Snippet/FirestoreClientTest.php
@@ -17,20 +17,21 @@
 
 namespace Google\Cloud\Firestore\Tests\Snippet;
 
-use Prophecy\Argument;
 use Google\Cloud\Core\Blob;
 use Google\Cloud\Core\GeoPoint;
-use Google\Cloud\Firestore\FieldPath;
-use Google\Cloud\Core\Testing\GrpcTestTrait;
-use Google\Cloud\Firestore\WriteBatch;
-use Google\Cloud\Firestore\Transaction;
-use Google\Cloud\Firestore\FirestoreClient;
 use Google\Cloud\Core\Iterator\ItemIterator;
-use Google\Cloud\Firestore\DocumentSnapshot;
+use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
-use Google\Cloud\Firestore\DocumentReference;
+use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\CollectionReference;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
+use Google\Cloud\Firestore\DocumentReference;
+use Google\Cloud\Firestore\DocumentSnapshot;
+use Google\Cloud\Firestore\FieldPath;
+use Google\Cloud\Firestore\FirestoreClient;
+use Google\Cloud\Firestore\Transaction;
+use Google\Cloud\Firestore\WriteBatch;
+use Prophecy\Argument;
 
 /**
  * @group firestore
@@ -118,13 +119,13 @@ class FirestoreClientTest extends SnippetTestCase
                         'name' => sprintf($tpl, self::PROJECT, self::DATABASE, 'john'),
                         'fields' => []
                     ],
-                    'readTime' => ['seconds' => time()]
+                    'readTime' => (new \DateTime)->format(Timestamp::FORMAT)
                 ], [
                     'found' => [
                         'name' => sprintf($tpl, self::PROJECT, self::DATABASE, 'dave'),
                         'fields' => []
                     ],
-                    'readTime' => ['seconds' => time()]
+                    'readTime' => (new \DateTime)->format(Timestamp::FORMAT)
                 ]
             ]);
 
@@ -146,7 +147,7 @@ class FirestoreClientTest extends SnippetTestCase
             ->willReturn([
                 [
                     'missing' => sprintf($tpl, self::PROJECT, self::DATABASE, 'deleted-user'),
-                    'readTime' => ['seconds' => time()]
+                    'readTime' => (new \DateTime)->format(Timestamp::FORMAT)
                 ]
             ]);
 
@@ -174,7 +175,7 @@ class FirestoreClientTest extends SnippetTestCase
                 [
                     'found' => [
                         'name' => $from,
-                        'readTime' => ['seconds' => time()],
+                        'readTime' => (new \DateTime)->format(Timestamp::FORMAT),
                         'fields' => [
                             'balance' => [
                                 'doubleValue' => 1000.00
@@ -190,7 +191,7 @@ class FirestoreClientTest extends SnippetTestCase
                 [
                     'found' => [
                         'name' => $to,
-                        'readTime' => ['seconds' => time()],
+                        'readTime' => (new \DateTime)->format(Timestamp::FORMAT),
                         'fields' => [
                             'balance' => [
                                 'doubleValue' => 1000.00

--- a/Firestore/tests/Snippet/TransactionTest.php
+++ b/Firestore/tests/Snippet/TransactionTest.php
@@ -17,7 +17,9 @@
 
 namespace Google\Cloud\Firestore\Tests\Snippet;
 
+use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
+use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\CollectionReference;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\DocumentReference;
@@ -29,7 +31,6 @@ use Google\Cloud\Firestore\QuerySnapshot;
 use Google\Cloud\Firestore\Transaction;
 use Google\Cloud\Firestore\ValueMapper;
 use Google\Cloud\Firestore\WriteBatch;
-use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Prophecy\Argument;
 
 /**
@@ -97,7 +98,7 @@ class TransactionTest extends SnippetTestCase
                     'found' => [
                         'name' => self::DOCUMENT,
                         'fields' => [],
-                        'readTime' => ['seconds' => time()]
+                        'readTime' => (new \DateTime)->format(Timestamp::FORMAT)
                     ]
                 ]
             ]));
@@ -220,13 +221,13 @@ class TransactionTest extends SnippetTestCase
                         'name' => sprintf(self::DOCUMENT_TEMPLATE, self::PROJECT, self::DATABASE_ID, 'john'),
                         'fields' => []
                     ],
-                    'readTime' => ['seconds' => time()]
+                    'readTime' => (new \DateTime)->format(Timestamp::FORMAT)
                 ], [
                     'found' => [
                         'name' => sprintf(self::DOCUMENT_TEMPLATE, self::PROJECT, self::DATABASE_ID, 'dave'),
                         'fields' => []
                     ],
-                    'readTime' => ['seconds' => time()]
+                    'readTime' => (new \DateTime)->format(Timestamp::FORMAT)
                 ]
             ]);
 
@@ -247,7 +248,7 @@ class TransactionTest extends SnippetTestCase
             ->willReturn([
                 [
                     'missing' => sprintf(self::DOCUMENT_TEMPLATE, self::PROJECT, self::DATABASE_ID, 'deleted-user'),
-                    'readTime' => ['seconds' => time()]
+                    'readTime' => (new \DateTime)->format(Timestamp::FORMAT)
                 ]
             ]);
 

--- a/Firestore/tests/System/ValueMapperTest.php
+++ b/Firestore/tests/System/ValueMapperTest.php
@@ -51,6 +51,8 @@ class ValueMapperTest extends FirestoreTestCase
         $snapshot = self::$document->snapshot();
         if ($expectation) {
             $this->assertTrue($expectation($snapshot[self::FIELD]));
+        } elseif ($input instanceof Timestamp) {
+            $this->assertEquals($input->formatAsString(), $snapshot[self::FIELD]->formatAsString());
         } else {
             $this->assertEquals($input, $snapshot[self::FIELD]);
         }

--- a/Firestore/tests/System/WriteTest.php
+++ b/Firestore/tests/System/WriteTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Firestore\Tests\System;
+
+use Google\Cloud\Core\Timestamp;
+
+/**
+ * @group firestore
+ * @group firestore-write
+ */
+class WriteTest extends FirestoreTestCase
+{
+    /**
+     * @dataProvider timestamps
+     */
+    public function testTimestampPrecision($timestamp)
+    {
+        $doc = self::$collection->add([
+            'timestampField' => $timestamp
+        ]);
+
+        $res = $doc->snapshot()['timestampField'];
+
+        // update and read back (what should be the same) value.
+        $doc->set([
+            'timestampField' => $res
+        ], ['merge' => true]);
+
+        $res2 = $doc->snapshot()['timestampField'];
+
+        $this->assertEquals($timestamp->get()->format('U'), $res->get()->format('U'));
+        $this->assertEquals($timestamp->nanoSeconds(), $res->nanoSeconds());
+        $this->assertEquals($timestamp->formatAsString(), $res->formatAsString());
+
+        $this->assertEquals($timestamp->get()->format('U'), $res2->get()->format('U'));
+        $this->assertEquals($timestamp->nanoSeconds(), $res2->nanoSeconds());
+        $this->assertEquals($timestamp->formatAsString(), $res2->formatAsString());
+    }
+
+    public function timestamps()
+    {
+        $today = new \DateTime;
+        $str = $today->format('Y-m-d\TH:i:s');
+        return [
+            [new Timestamp($today)],
+            [new Timestamp($today, 0)],
+            [new Timestamp($today, 1000)],
+            [Timestamp::createFromString($str .'.100000000Z')],
+            [Timestamp::createFromString($str .'.000001Z')],
+            [Timestamp::createFromString($str .'.101999Z')],
+        ];
+    }
+}

--- a/Firestore/tests/System/WriteTest.php
+++ b/Firestore/tests/System/WriteTest.php
@@ -52,6 +52,38 @@ class WriteTest extends FirestoreTestCase
         $this->assertEquals($timestamp->formatAsString(), $res2->formatAsString());
     }
 
+    /**
+     * @dataProvider timestamps
+     */
+    public function testTimestampPrecisionLocale($timestamp)
+    {
+        setlocale(LC_ALL, 'fr_FR.UTF-8');
+        try {
+            $doc = self::$collection->add([
+                'timestampField' => $timestamp
+            ]);
+
+            $res = $doc->snapshot()['timestampField'];
+
+            // update and read back (what should be the same) value.
+            $doc->set([
+                'timestampField' => $res
+            ], ['merge' => true]);
+
+            $res2 = $doc->snapshot()['timestampField'];
+
+            $this->assertEquals($timestamp->get()->format('U'), $res->get()->format('U'));
+            $this->assertEquals($timestamp->nanoSeconds(), $res->nanoSeconds());
+            $this->assertEquals($timestamp->formatAsString(), $res->formatAsString());
+
+            $this->assertEquals($timestamp->get()->format('U'), $res2->get()->format('U'));
+            $this->assertEquals($timestamp->nanoSeconds(), $res2->nanoSeconds());
+            $this->assertEquals($timestamp->formatAsString(), $res2->formatAsString());
+        } finally {
+            setlocale(LC_ALL, null);
+        }
+    }
+
     public function timestamps()
     {
         $today = new \DateTime;

--- a/Firestore/tests/System/WriteTest.php
+++ b/Firestore/tests/System/WriteTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Firestore\Tests\System;
 
 use Google\Cloud\Core\Timestamp;
+use Google\Cloud\Core\TimeTrait;
 
 /**
  * @group firestore
@@ -25,6 +26,8 @@ use Google\Cloud\Core\Timestamp;
  */
 class WriteTest extends FirestoreTestCase
 {
+    use TimeTrait;
+
     /**
      * @dataProvider timestamps
      */
@@ -88,13 +91,15 @@ class WriteTest extends FirestoreTestCase
     {
         $today = new \DateTime;
         $str = $today->format('Y-m-d\TH:i:s');
+
+        $r = new \ReflectionClass(Timestamp::class);
         return [
             [new Timestamp($today)],
             [new Timestamp($today, 0)],
             [new Timestamp($today, 1000)],
-            [Timestamp::createFromString($str .'.100000000Z')],
-            [Timestamp::createFromString($str .'.000001Z')],
-            [Timestamp::createFromString($str .'.101999Z')],
+            [$r->newInstanceArgs($this->parseTimeString($str .'.100000000Z'))],
+            [$r->newInstanceArgs($this->parseTimeString($str .'.000001Z'))],
+            [$r->newInstanceArgs($this->parseTimeString($str .'.101999Z'))],
         ];
     }
 }

--- a/Firestore/tests/Unit/DocumentReferenceTest.php
+++ b/Firestore/tests/Unit/DocumentReferenceTest.php
@@ -253,8 +253,8 @@ class DocumentReferenceTest extends TestCase
     public function testWriteResult()
     {
         $time = time();
-        $ts = new Timestamp($this->createDateTimeFromSeconds($time), 0);
-        $ts2 = new Timestamp($this->createDateTimeFromSeconds($time + 100), 0);
+        $ts = \DateTime::createFromFormat('U', $time)->format(Timestamp::FORMAT);
+        $ts2 = \DateTime::createFromFormat('U', $time+100)->format(Timestamp::FORMAT);
 
         $this->connection->commit(Argument::any())
             ->shouldBeCalled()

--- a/Firestore/tests/Unit/DocumentReferenceTest.php
+++ b/Firestore/tests/Unit/DocumentReferenceTest.php
@@ -250,22 +250,20 @@ class DocumentReferenceTest extends TestCase
     public function testWriteResult()
     {
         $time = time();
+        $ts = Timestamp::createFromArray(['seconds' => $time]);
+        $ts2 = Timestamp::createFromArray(['seconds' => $time + 100]);
 
         $this->connection->commit(Argument::any())
             ->shouldBeCalled()
             ->willReturn([
                 'writeResults' => [
                     [
-                        'updateTime' => [
-                            'seconds' => $time
-                        ]
+                        'updateTime' => $ts
                     ], [
-                        'updateTime' => [
-                            'seconds' => $time + 100
-                        ]
+                        'updateTime' => $ts2
                     ]
                 ],
-                'commitTime' => ['seconds' => $time]
+                'commitTime' => $ts
             ]);
 
         $this->document->___setProperty('connection', $this->connection->reveal());

--- a/Firestore/tests/Unit/DocumentReferenceTest.php
+++ b/Firestore/tests/Unit/DocumentReferenceTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Firestore\Tests\Unit;
 
 use Google\Cloud\Core\Timestamp;
+use Google\Cloud\Core\TimeTrait;
 use Google\Cloud\Firestore\CollectionReference;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\DocumentReference;
@@ -33,6 +34,8 @@ use Prophecy\Argument;
  */
 class DocumentReferenceTest extends TestCase
 {
+    use TimeTrait;
+
     const PROJECT = 'example_project';
     const DATABASE = '(default)';
     const COLLECTION = 'projects/example_project/databases/(default)/documents/a';
@@ -250,8 +253,8 @@ class DocumentReferenceTest extends TestCase
     public function testWriteResult()
     {
         $time = time();
-        $ts = Timestamp::createFromArray(['seconds' => $time]);
-        $ts2 = Timestamp::createFromArray(['seconds' => $time + 100]);
+        $ts = new Timestamp($this->createDateTimeFromSeconds($time), 0);
+        $ts2 = new Timestamp($this->createDateTimeFromSeconds($time + 100), 0);
 
         $this->connection->commit(Argument::any())
             ->shouldBeCalled()

--- a/Firestore/tests/Unit/FirestoreClientTest.php
+++ b/Firestore/tests/Unit/FirestoreClientTest.php
@@ -191,13 +191,13 @@ class FirestoreClientTest extends TestCase
                         ]
                     ]
                 ],
-                'readTime' => ['seconds' => 1, 'nanos' => 0]
+                'readTime' => Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT))
             ], [
                 'missing' => $names[1],
-                'readTime' => ['seconds' => 1, 'nanos' => 0]
+                'readTime' => Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT))
             ], [
                 'missing' => $names[2],
-                'readTime' => ['seconds' => 1, 'nanos' => 0]
+                'readTime' => Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT))
             ]
         ];
 
@@ -269,13 +269,13 @@ class FirestoreClientTest extends TestCase
         $res = [
             [
                 'missing' => $names[2],
-                'readTime' => ['seconds' => 1, 'nanos' => 0]
+                'readTime' => Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT))
             ], [
                 'missing' => $names[1],
-                'readTime' => ['seconds' => 1, 'nanos' => 0]
+                'readTime' => Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT))
             ], [
                 'missing' => $names[0],
-                'readTime' => ['seconds' => 1, 'nanos' => 0]
+                'readTime' => Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT))
             ]
         ];
 
@@ -294,7 +294,7 @@ class FirestoreClientTest extends TestCase
     public function testRunTransaction()
     {
         $transactionId = 'foobar';
-        $timestamp = ['seconds' => date('U')];
+        $timestamp = Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT));
 
         $this->connection->beginTransaction([
             'database' => 'projects/'. self::PROJECT .'/databases/'. self::DATABASE
@@ -316,7 +316,7 @@ class FirestoreClientTest extends TestCase
     {
         $transactionId = 'foobar';
         $transactionId2 = 'barfoo';
-        $timestamp = ['seconds' => date('U')];
+        $timestamp = Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT));
 
         $this->connection->beginTransaction([
             'database' => 'projects/'. self::PROJECT .'/databases/'. self::DATABASE
@@ -374,7 +374,7 @@ class FirestoreClientTest extends TestCase
     public function testRunTransactionNotRetryable()
     {
         $transactionId = 'foobar';
-        $timestamp = ['seconds' => date('U')];
+        $timestamp = Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT));
 
         $this->connection->beginTransaction([
             'database' => 'projects/'. self::PROJECT .'/databases/'. self::DATABASE
@@ -400,7 +400,7 @@ class FirestoreClientTest extends TestCase
     public function testRunTransactionExceedsMaxRetries()
     {
         $transactionId = 'foobar';
-        $timestamp = ['seconds' => date('U')];
+        $timestamp = Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT));
 
         $this->connection->beginTransaction(Argument::any())->shouldBeCalledTimes(6)->willReturn([
             'transaction' => $transactionId
@@ -427,7 +427,7 @@ class FirestoreClientTest extends TestCase
     public function testRunTransactionExceedsMaxRetriesLowerLimit()
     {
         $transactionId = 'foobar';
-        $timestamp = ['seconds' => date('U')];
+        $timestamp = Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT));
 
         $this->connection->beginTransaction(Argument::any())->shouldBeCalledTimes(3)->willReturn([
             'transaction' => $transactionId

--- a/Firestore/tests/Unit/FirestoreClientTest.php
+++ b/Firestore/tests/Unit/FirestoreClientTest.php
@@ -191,13 +191,13 @@ class FirestoreClientTest extends TestCase
                         ]
                     ]
                 ],
-                'readTime' => Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT))
+                'readTime' => new Timestamp(new \DateTimeImmutable)
             ], [
                 'missing' => $names[1],
-                'readTime' => Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT))
+                'readTime' => new Timestamp(new \DateTimeImmutable)
             ], [
                 'missing' => $names[2],
-                'readTime' => Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT))
+                'readTime' => new Timestamp(new \DateTimeImmutable)
             ]
         ];
 
@@ -269,13 +269,13 @@ class FirestoreClientTest extends TestCase
         $res = [
             [
                 'missing' => $names[2],
-                'readTime' => Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT))
+                'readTime' => new Timestamp(new \DateTimeImmutable)
             ], [
                 'missing' => $names[1],
-                'readTime' => Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT))
+                'readTime' => new Timestamp(new \DateTimeImmutable)
             ], [
                 'missing' => $names[0],
-                'readTime' => Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT))
+                'readTime' => new Timestamp(new \DateTimeImmutable)
             ]
         ];
 
@@ -294,7 +294,7 @@ class FirestoreClientTest extends TestCase
     public function testRunTransaction()
     {
         $transactionId = 'foobar';
-        $timestamp = Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT));
+        $timestamp = new Timestamp(new \DateTimeImmutable);
 
         $this->connection->beginTransaction([
             'database' => 'projects/'. self::PROJECT .'/databases/'. self::DATABASE
@@ -316,7 +316,7 @@ class FirestoreClientTest extends TestCase
     {
         $transactionId = 'foobar';
         $transactionId2 = 'barfoo';
-        $timestamp = Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT));
+        $timestamp = new Timestamp(new \DateTimeImmutable);
 
         $this->connection->beginTransaction([
             'database' => 'projects/'. self::PROJECT .'/databases/'. self::DATABASE
@@ -374,7 +374,7 @@ class FirestoreClientTest extends TestCase
     public function testRunTransactionNotRetryable()
     {
         $transactionId = 'foobar';
-        $timestamp = Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT));
+        $timestamp = new Timestamp(new \DateTimeImmutable);
 
         $this->connection->beginTransaction([
             'database' => 'projects/'. self::PROJECT .'/databases/'. self::DATABASE
@@ -400,7 +400,7 @@ class FirestoreClientTest extends TestCase
     public function testRunTransactionExceedsMaxRetries()
     {
         $transactionId = 'foobar';
-        $timestamp = Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT));
+        $timestamp = new Timestamp(new \DateTimeImmutable);
 
         $this->connection->beginTransaction(Argument::any())->shouldBeCalledTimes(6)->willReturn([
             'transaction' => $transactionId
@@ -427,7 +427,7 @@ class FirestoreClientTest extends TestCase
     public function testRunTransactionExceedsMaxRetriesLowerLimit()
     {
         $transactionId = 'foobar';
-        $timestamp = Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT));
+        $timestamp = new Timestamp(new \DateTimeImmutable);
 
         $this->connection->beginTransaction(Argument::any())->shouldBeCalledTimes(3)->willReturn([
             'transaction' => $transactionId

--- a/Firestore/tests/Unit/QueryTest.php
+++ b/Firestore/tests/Unit/QueryTest.php
@@ -17,16 +17,17 @@
 
 namespace Google\Cloud\Firestore\Tests\Unit;
 
+use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\CollectionReference;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\DocumentReference;
 use Google\Cloud\Firestore\DocumentSnapshot;
 use Google\Cloud\Firestore\FirestoreClient;
 use Google\Cloud\Firestore\Query;
-use Google\Cloud\Firestore\ValueMapper;
 use Google\Cloud\Firestore\V1beta1\StructuredQuery_CompositeFilter_Operator;
 use Google\Cloud\Firestore\V1beta1\StructuredQuery_Direction;
 use Google\Cloud\Firestore\V1beta1\StructuredQuery_FieldFilter_Operator;
+use Google\Cloud\Firestore\ValueMapper;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
@@ -87,9 +88,7 @@ class QueryTest extends TestCase
                             ]
                         ]
                     ],
-                    'readTime' => [
-                        'seconds' => time()
-                    ]
+                    'readTime' => Timestamp::createFromArray(['seconds' => time()])
                 ],
                 []
             ]));

--- a/Firestore/tests/Unit/QueryTest.php
+++ b/Firestore/tests/Unit/QueryTest.php
@@ -88,7 +88,7 @@ class QueryTest extends TestCase
                             ]
                         ]
                     ],
-                    'readTime' => new Timestamp(new \DateTimeImmutable, 0)
+                    'readTime' => (new \DateTime)->format(Timestamp::FORMAT)
                 ],
                 []
             ]));
@@ -102,6 +102,38 @@ class QueryTest extends TestCase
         $current = $res->rows()[0];
         $this->assertEquals($name, $current->name());
         $this->assertEquals('world', $current['hello']);
+    }
+
+    public function testDocumentsMetadata()
+    {
+        $name = self::PARENT .'/foo';
+
+        $ts = (new \DateTime)->format(Timestamp::FORMAT);
+        $this->connection->runQuery(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn(new \ArrayIterator([
+                [
+                    'document' => [
+                        'name' => $name,
+                        'fields' => [
+                            'hello' => [
+                                'stringValue' => 'world'
+                            ]
+                        ],
+                        'createTime' => $ts,
+                        'updateTime' => $ts
+                    ],
+                    'readTime' => $ts
+                ],
+                []
+            ]));
+
+        $this->query->___setProperty('connection', $this->connection->reveal());
+
+        $res = $this->query->documents()->rows()[0];
+        $this->assertInstanceOf(Timestamp::class, $res->createTime());
+        $this->assertInstanceOf(Timestamp::class, $res->updateTime());
+        $this->assertInstanceOf(Timestamp::class, $res->readTime());
     }
 
     public function testSelect()

--- a/Firestore/tests/Unit/QueryTest.php
+++ b/Firestore/tests/Unit/QueryTest.php
@@ -88,7 +88,7 @@ class QueryTest extends TestCase
                             ]
                         ]
                     ],
-                    'readTime' => Timestamp::createFromArray(['seconds' => time()])
+                    'readTime' => new Timestamp(new \DateTimeImmutable, 0)
                 ],
                 []
             ]));

--- a/Firestore/tests/Unit/SnapshotTraitTest.php
+++ b/Firestore/tests/Unit/SnapshotTraitTest.php
@@ -164,47 +164,4 @@ class SnapshotTraitTest extends TestCase
             self::NAME
         ]);
     }
-
-    public function testTransformSnapshotTimestampsEmpty()
-    {
-        $res = $this->impl->call('transformSnapshotTimestamps', [
-            $this->valueMapper,
-            []
-        ]);
-        $this->assertEquals([
-            'createTime' => null,
-            'updateTime' => null,
-            'readTime' => null
-        ], $res);
-    }
-
-    public function testTransformSnapshotTimestamps()
-    {
-        $now = time();
-        $ts = [
-            'seconds' => $now,
-            'nanos' => 100
-        ];
-
-        $input = [
-            'createTime' => $ts,
-            'updateTime' => $ts,
-            'readTime' => $ts
-        ];
-
-        $res = $this->impl->call('transformSnapshotTimestamps', [
-            $this->valueMapper,
-            $input
-        ]);
-
-        $timestamp = new Timestamp(\DateTimeImmutable::createFromFormat('U', (string) $now), $ts['nanos']);
-
-        $expected = [
-            'createTime' => $timestamp,
-            'updateTime' => $timestamp,
-            'readTime' => $timestamp
-        ];
-
-        $this->assertEquals($expected, $res);
-    }
 }

--- a/Firestore/tests/Unit/TransactionTest.php
+++ b/Firestore/tests/Unit/TransactionTest.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Firestore\Tests\Unit;
 
+use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\DocumentReference;
 use Google\Cloud\Firestore\DocumentSnapshot;
@@ -206,6 +207,8 @@ class TransactionTest extends TestCase
      */
     public function testDocuments(array $input, array $names)
     {
+        $timestamp = Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT));
+
         $res = [
             [
                 'found' => [
@@ -216,13 +219,13 @@ class TransactionTest extends TestCase
                         ]
                     ]
                 ],
-                'readTime' => ['seconds' => 1, 'nanos' => 0]
+                'readTime' => $timestamp
             ], [
                 'missing' => $names[1],
-                'readTime' => ['seconds' => 1, 'nanos' => 0]
+                'readTime' => $timestamp
             ], [
                 'missing' => $names[2],
-                'readTime' => ['seconds' => 1, 'nanos' => 0]
+                'readTime' => $timestamp
             ]
         ];
 
@@ -288,6 +291,7 @@ class TransactionTest extends TestCase
 
     public function testDocumentsOrdered()
     {
+        $timestamp = Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT));
         $tpl = 'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/%s';
         $names = [
             sprintf($tpl, 'a'),
@@ -298,13 +302,13 @@ class TransactionTest extends TestCase
         $res = [
             [
                 'missing' => $names[2],
-                'readTime' => ['seconds' => 1, 'nanos' => 0]
+                'readTime' => $timestamp
             ], [
                 'missing' => $names[1],
-                'readTime' => ['seconds' => 1, 'nanos' => 0]
+                'readTime' => $timestamp
             ], [
                 'missing' => $names[0],
-                'readTime' => ['seconds' => 1, 'nanos' => 0]
+                'readTime' => $timestamp
             ]
         ];
 

--- a/Firestore/tests/Unit/TransactionTest.php
+++ b/Firestore/tests/Unit/TransactionTest.php
@@ -207,7 +207,7 @@ class TransactionTest extends TestCase
      */
     public function testDocuments(array $input, array $names)
     {
-        $timestamp = Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT));
+        $timestamp = (new Timestamp(new \DateTimeImmutable))->formatAsString();
 
         $res = [
             [
@@ -291,7 +291,7 @@ class TransactionTest extends TestCase
 
     public function testDocumentsOrdered()
     {
-        $timestamp = Timestamp::createFromString((new \DateTime())->format(Timestamp::FORMAT));
+        $timestamp = (new Timestamp(new \DateTimeImmutable))->formatAsString();
         $tpl = 'projects/'. self::PROJECT .'/databases/'. self::DATABASE .'/documents/a/%s';
         $names = [
             sprintf($tpl, 'a'),

--- a/Firestore/tests/Unit/ValueMapperTest.php
+++ b/Firestore/tests/Unit/ValueMapperTest.php
@@ -21,6 +21,7 @@ use Google\Cloud\Core\Blob;
 use Google\Cloud\Core\GeoPoint;
 use Google\Cloud\Core\Int64;
 use Google\Cloud\Core\Timestamp;
+use Google\Cloud\Core\TimeTrait;
 use Google\Cloud\Firestore\CollectionReference;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\DocumentReference;
@@ -36,6 +37,8 @@ use PHPUnit\Framework\TestCase;
  */
 class ValueMapperTest extends TestCase
 {
+    use TimeTrait;
+
     private $connection;
     private $mapper;
 
@@ -99,7 +102,7 @@ class ValueMapperTest extends TestCase
                     $this->assertEquals(15, $val);
                 }
             ], [
-                ['timestampValue' => Timestamp::createFromArray(['seconds' => $now, 'nanos' => 10])],
+                ['timestampValue' => new Timestamp($this->createDateTimeFromSeconds($now), 10)],
                 function ($val) use ($now) {
                     $this->assertInstanceOf(Timestamp::class, $val);
                     $ts = new Timestamp(\DateTimeImmutable::createFromFormat('U', (string) $now), 10);

--- a/Firestore/tests/Unit/ValueMapperTest.php
+++ b/Firestore/tests/Unit/ValueMapperTest.php
@@ -99,7 +99,7 @@ class ValueMapperTest extends TestCase
                     $this->assertEquals(15, $val);
                 }
             ], [
-                ['timestampValue' => ['seconds' => $now, 'nanos' => 10]],
+                ['timestampValue' => Timestamp::createFromArray(['seconds' => $now, 'nanos' => 10])],
                 function ($val) use ($now) {
                     $this->assertInstanceOf(Timestamp::class, $val);
                     $ts = new Timestamp(\DateTimeImmutable::createFromFormat('U', (string) $now), 10);
@@ -192,10 +192,9 @@ class ValueMapperTest extends TestCase
         $blob = new Blob($blobValue);
 
         $datetime = \DateTimeImmutable::createFromFormat('U.u', microtime(true));
+        $timestamp = new Timestamp($datetime);
         $now = (string) $datetime->format('U');
-        $micros = (int) $datetime->format('u');
-        $nanos = (int) $datetime->format('u') * 1000 + 10;
-        $timestamp = new Timestamp(\DateTimeImmutable::createFromFormat('U', $now), $nanos);
+        $nanos = (int) $datetime->format('u') * 1000;
 
         $lat = 100.01;
         $lng = 100.25;
@@ -301,10 +300,10 @@ class ValueMapperTest extends TestCase
                 }
             ], [
                 $datetime,
-                function ($val) use ($now, $micros) {
+                function ($val) use ($now, $nanos) {
                     $this->assertEquals([
                         'seconds' => $now,
-                        'nanos' => intval($micros * 1000)
+                        'nanos' => $nanos
                     ], $val['timestampValue']);
                 }
             ], [

--- a/Firestore/tests/Unit/WriteBatchTest.php
+++ b/Firestore/tests/Unit/WriteBatchTest.php
@@ -339,12 +339,7 @@ class WriteBatchTest extends TestCase
         $now = time();
         $nanos = 10;
 
-        $timestamp = [
-            'seconds' => $now,
-            'nanos' => $nanos
-        ];
-
-        $tsObj = new Timestamp(\DateTimeImmutable::createFromFormat('U', (string) $now), $nanos);
+        $timestamp = new Timestamp(\DateTimeImmutable::createFromFormat('U', (string) $now), $nanos);
 
         $this->connection->commit(Argument::any())
             ->shouldBeCalled()
@@ -363,9 +358,9 @@ class WriteBatchTest extends TestCase
 
         $res = $this->batch->commit();
 
-        $this->assertEquals($tsObj, $res['commitTime']);
-        $this->assertEquals($tsObj, $res['writeResults'][0]['updateTime']);
-        $this->assertEquals($tsObj, $res['writeResults'][1]['updateTime']);
+        $this->assertEquals($timestamp, $res['commitTime']);
+        $this->assertEquals($timestamp, $res['writeResults'][0]['updateTime']);
+        $this->assertEquals($timestamp, $res['writeResults'][1]['updateTime']);
     }
 
     public function testCommitWithTransaction()

--- a/Spanner/src/Batch/BatchClient.php
+++ b/Spanner/src/Batch/BatchClient.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Spanner\Batch;
 
+use Google\Cloud\Core\TimeTrait;
 use Google\Cloud\Spanner\Operation;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\TransactionConfigurationTrait;
@@ -102,6 +103,7 @@ use Google\Cloud\Spanner\TransactionConfigurationTrait;
  */
 class BatchClient
 {
+    use TimeTrait;
     use TransactionConfigurationTrait;
 
     const PARTITION_TYPE_KEY = '__partitionTypeName';
@@ -213,9 +215,10 @@ class BatchClient
 
         $session = $this->operation->session($data['sessionName']);
 
+        $readTime = $this->parseTimeString($data['readTimestamp']);
         return $this->operation->createSnapshot($session, [
             'id' => $data['transactionId'],
-            'readTimestamp' => Timestamp::createFromString($data['readTimestamp'])
+            'readTimestamp' => new Timestamp($readTime[0], $readTime[1])
         ], BatchSnapshot::class);
     }
 

--- a/Spanner/src/Batch/BatchClient.php
+++ b/Spanner/src/Batch/BatchClient.php
@@ -215,7 +215,7 @@ class BatchClient
 
         return $this->operation->createSnapshot($session, [
             'id' => $data['transactionId'],
-            'readTimestamp' => Timestamp::createFromString($data['readTimestamp'], Timestamp::PRECISION_NANOSECOND)
+            'readTimestamp' => Timestamp::createFromString($data['readTimestamp'])
         ], BatchSnapshot::class);
     }
 

--- a/Spanner/src/Batch/BatchClient.php
+++ b/Spanner/src/Batch/BatchClient.php
@@ -17,7 +17,6 @@
 
 namespace Google\Cloud\Spanner\Batch;
 
-use Google\Cloud\Core\ValueMapperTrait;
 use Google\Cloud\Spanner\Operation;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\TransactionConfigurationTrait;
@@ -104,7 +103,6 @@ use Google\Cloud\Spanner\TransactionConfigurationTrait;
 class BatchClient
 {
     use TransactionConfigurationTrait;
-    use ValueMapperTrait;
 
     const PARTITION_TYPE_KEY = '__partitionTypeName';
 
@@ -217,7 +215,7 @@ class BatchClient
 
         return $this->operation->createSnapshot($session, [
             'id' => $data['transactionId'],
-            'readTimestamp' => $this->createTimestampWithNanos($data['readTimestamp'], Timestamp::class)
+            'readTimestamp' => Timestamp::createFromString($data['readTimestamp'], Timestamp::PRECISION_NANOSECOND)
         ], BatchSnapshot::class);
     }
 

--- a/Spanner/src/Batch/BatchClient.php
+++ b/Spanner/src/Batch/BatchClient.php
@@ -218,7 +218,7 @@ class BatchClient
         $readTime = $this->parseTimeString($data['readTimestamp']);
         return $this->operation->createSnapshot($session, [
             'id' => $data['transactionId'],
-            'readTimestamp' => new Timestamp($readTime[0], $readTime[1])
+            'readTimestamp' => $data['readTimestamp']
         ], BatchSnapshot::class);
     }
 

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -134,7 +134,7 @@ class Operation
             'database' => $session->info()['database']
         ]) + $options);
 
-        return $this->mapper->createTimestampWithNanos($res['commitTimestamp'], Timestamp::class);
+        return Timestamp::createFromString($res['commitTimestamp'], Timestamp::PRECISION_NANOSECOND);
     }
 
     /**
@@ -350,7 +350,7 @@ class Operation
         ];
 
         if ($res['readTimestamp']) {
-            $res['readTimestamp'] = $this->mapper->createTimestampWithNanos($res['readTimestamp'], Timestamp::class);
+            $res['readTimestamp'] = Timestamp::createFromString($res['readTimestamp'], Timestamp::PRECISION_NANOSECOND);
         }
 
         return new $className($this, $session, $res);

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -134,7 +134,7 @@ class Operation
             'database' => $session->info()['database']
         ]) + $options);
 
-        return Timestamp::createFromString($res['commitTimestamp'], Timestamp::PRECISION_NANOSECOND);
+        return Timestamp::createFromString($res['commitTimestamp']);
     }
 
     /**
@@ -350,7 +350,7 @@ class Operation
         ];
 
         if ($res['readTimestamp']) {
-            $res['readTimestamp'] = Timestamp::createFromString($res['readTimestamp'], Timestamp::PRECISION_NANOSECOND);
+            $res['readTimestamp'] = Timestamp::createFromString($res['readTimestamp']);
         }
 
         return new $className($this, $session, $res);

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -353,8 +353,10 @@ class Operation
         ];
 
         if ($res['readTimestamp']) {
-            $time = $this->parseTimeString($res['readTimestamp']);
-            $res['readTimestamp'] = new Timestamp($time[0], $time[1]);
+            if (!($res['readTimestamp'] instanceof Timestamp)) {
+                $time = $this->parseTimeString($res['readTimestamp']);
+                $res['readTimestamp'] = new Timestamp($time[0], $time[1]);
+            }
         }
 
         return new $className($this, $session, $res);

--- a/Spanner/src/Operation.php
+++ b/Spanner/src/Operation.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Spanner;
 
 use Google\Cloud\Core\ArrayTrait;
+use Google\Cloud\Core\TimeTrait;
 use Google\Cloud\Core\ValidateTrait;
 use Google\Cloud\Spanner\Batch\QueryPartition;
 use Google\Cloud\Spanner\Batch\ReadPartition;
@@ -39,6 +40,7 @@ use Google\Cloud\Spanner\V1\SpannerClient as GapicSpannerClient;
 class Operation
 {
     use ArrayTrait;
+    use TimeTrait;
     use ValidateTrait;
 
     const OP_INSERT = 'insert';
@@ -134,7 +136,8 @@ class Operation
             'database' => $session->info()['database']
         ]) + $options);
 
-        return Timestamp::createFromString($res['commitTimestamp']);
+        $time = $this->parseTimeString($res['commitTimestamp']);
+        return new Timestamp($time[0], $time[1]);
     }
 
     /**
@@ -350,7 +353,8 @@ class Operation
         ];
 
         if ($res['readTimestamp']) {
-            $res['readTimestamp'] = Timestamp::createFromString($res['readTimestamp']);
+            $time = $this->parseTimeString($res['readTimestamp']);
+            $res['readTimestamp'] = new Timestamp($time[0], $time[1]);
         }
 
         return new $className($this, $session, $res);

--- a/Spanner/src/ValueMapper.php
+++ b/Spanner/src/ValueMapper.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Spanner;
 
 use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\Int64;
+use Google\Cloud\Core\TimeTrait;
 use Google\Cloud\Spanner\V1\TypeCode;
 
 /**
@@ -27,6 +28,7 @@ use Google\Cloud\Spanner\V1\TypeCode;
 class ValueMapper
 {
     use ArrayTrait;
+    use TimeTrait;
 
     const TYPE_BOOL = TypeCode::BOOL;
     const TYPE_INT64 = TypeCode::INT64;
@@ -204,7 +206,8 @@ class ValueMapper
                 break;
 
             case self::TYPE_TIMESTAMP:
-                $value = Timestamp::createFromString($value);
+                $value = $this->parseTimeString($value);
+                $value = new Timestamp($value[0], $value[1]);
                 break;
 
             case self::TYPE_DATE:

--- a/Spanner/src/ValueMapper.php
+++ b/Spanner/src/ValueMapper.php
@@ -204,7 +204,7 @@ class ValueMapper
                 break;
 
             case self::TYPE_TIMESTAMP:
-                $value = Timestamp::createFromString($value, Timestamp::PRECISION_NANOSECOND);
+                $value = Timestamp::createFromString($value);
                 break;
 
             case self::TYPE_DATE:

--- a/Spanner/src/ValueMapper.php
+++ b/Spanner/src/ValueMapper.php
@@ -365,7 +365,8 @@ class ValueMapper
 
             default:
                 throw new \InvalidArgumentException(sprintf(
-                    'Unrecognized value type %s. Please ensure you are using the latest version of google/cloud.',
+                    'Unrecognized value type %s. ' .
+                    'Please ensure you are using the latest version of google/cloud or google/cloud-spanner.',
                     $phpType
                 ));
                 break;
@@ -391,7 +392,8 @@ class ValueMapper
         }
 
         throw new \InvalidArgumentException(sprintf(
-            'Unrecognized value type %s. Please ensure you are using the latest version of google/cloud.',
+            'Unrecognized value type %s. ' .
+            'Please ensure you are using the latest version of google/cloud or google/cloud-spanner.',
             get_class($value)
         ));
     }

--- a/Spanner/src/ValueMapper.php
+++ b/Spanner/src/ValueMapper.php
@@ -19,7 +19,6 @@ namespace Google\Cloud\Spanner;
 
 use Google\Cloud\Core\ArrayTrait;
 use Google\Cloud\Core\Int64;
-use Google\Cloud\Core\ValueMapperTrait;
 use Google\Cloud\Spanner\V1\TypeCode;
 
 /**
@@ -28,7 +27,6 @@ use Google\Cloud\Spanner\V1\TypeCode;
 class ValueMapper
 {
     use ArrayTrait;
-    use ValueMapperTrait;
 
     const TYPE_BOOL = TypeCode::BOOL;
     const TYPE_INT64 = TypeCode::INT64;
@@ -206,7 +204,7 @@ class ValueMapper
                 break;
 
             case self::TYPE_TIMESTAMP:
-                $value = $this->createTimestampWithNanos($value, Timestamp::class);
+                $value = Timestamp::createFromString($value, Timestamp::PRECISION_NANOSECOND);
                 break;
 
             case self::TYPE_DATE:

--- a/Spanner/tests/Snippet/Batch/BatchClientTest.php
+++ b/Spanner/tests/Snippet/Batch/BatchClientTest.php
@@ -164,10 +164,7 @@ class BatchClientTest extends SnippetTestCase
             ->shouldBeCalled()
             ->willReturn([
                 'id' => self::TRANSACTION,
-                'readTimestamp' => [
-                    'seconds' => $time,
-                    'nanos' => 0
-                ]
+                'readTimestamp' => \DateTime::createFromFormat('U', (string) $time)->format(Timestamp::FORMAT)
             ]);
 
         $this->connection->deleteSession(Argument::any())
@@ -205,10 +202,7 @@ class BatchClientTest extends SnippetTestCase
             ->shouldBeCalled()
             ->willReturn([
                 'id' => self::TRANSACTION,
-                'readTimestamp' => [
-                    'seconds' => $time,
-                    'nanos' => 0
-                ]
+                'readTimestamp' => \DateTime::createFromFormat('U', (string) $time)->format(Timestamp::FORMAT)
             ]);
 
         $this->refreshOperation($this->client, $this->connection->reveal());

--- a/Spanner/tests/Snippet/Batch/BatchSnapshotTest.php
+++ b/Spanner/tests/Snippet/Batch/BatchSnapshotTest.php
@@ -85,10 +85,7 @@ class BatchSnapshotTest extends SnippetTestCase
             ->shouldBeCalled()
             ->willReturn([
                 'id' => self::TRANSACTION,
-                'readTimestamp' => [
-                    'seconds' => $this->time,
-                    'nanos' => 0
-                ]
+                'readTimestamp' => \DateTime::createFromFormat('U', (string) $this->time)->format(Timestamp::FORMAT)
             ]);
 
         $client = TestHelpers::stub(BatchClient::class, [

--- a/Spanner/tests/Snippet/Batch/QueryPartitionTest.php
+++ b/Spanner/tests/Snippet/Batch/QueryPartitionTest.php
@@ -24,6 +24,7 @@ use Google\Cloud\Spanner\Batch\BatchClient;
 use Google\Cloud\Spanner\Batch\QueryPartition;
 use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Operation;
+use Google\Cloud\Spanner\Timestamp;
 use Prophecy\Argument;
 
 /**
@@ -63,10 +64,7 @@ class QueryPartitionTest extends SnippetTestCase
             ->shouldBeCalled()
             ->willReturn([
                 'id' => self::TRANSACTION,
-                'readTimestamp' => [
-                    'seconds' => $this->time,
-                    'nanos' => 0
-                ]
+                'readTimestamp' => \DateTime::createFromFormat('U', (string) $this->time)->format(Timestamp::FORMAT)
             ]);
         $connection->partitionQuery(Argument::any())
             ->shouldBeCalled()

--- a/Spanner/tests/Snippet/Batch/ReadPartitionTest.php
+++ b/Spanner/tests/Snippet/Batch/ReadPartitionTest.php
@@ -25,6 +25,7 @@ use Google\Cloud\Spanner\Batch\ReadPartition;
 use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\KeySet;
 use Google\Cloud\Spanner\Operation;
+use Google\Cloud\Spanner\Timestamp;
 use Prophecy\Argument;
 
 /**
@@ -71,10 +72,7 @@ class ReadPartitionTest extends SnippetTestCase
             ->shouldBeCalled()
             ->willReturn([
                 'id' => self::TRANSACTION,
-                'readTimestamp' => [
-                    'seconds' => $this->time,
-                    'nanos' => 0
-                ]
+                'readTimestamp' => \DateTime::createFromFormat('U', (string) $this->time)->format(Timestamp::FORMAT)
             ]);
         $connection->partitionRead(Argument::any())
             ->shouldBeCalled()

--- a/Spanner/tests/Snippet/CommitTimestampTest.php
+++ b/Spanner/tests/Snippet/CommitTimestampTest.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Spanner\Tests\Snippet;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Core\Testing\TestHelpers;
+use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Spanner\CommitTimestamp;
 use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\SpannerClient;
@@ -60,7 +61,7 @@ class CommitTimestampTest extends SnippetTestCase
         ];
 
         $conn->commit(Argument::withEntry('mutations', [$mutation]))->shouldBeCalled()->willReturn([
-            'commitTimestamp' => ['seconds' => time()]
+            'commitTimestamp' => \DateTime::createFromFormat('U', (string) time())->format(Timestamp::FORMAT)
         ]);
 
         $client->___setProperty('connection', $conn->reveal());

--- a/Spanner/tests/System/WriteTest.php
+++ b/Spanner/tests/System/WriteTest.php
@@ -539,9 +539,12 @@ class WriteTest extends SpannerTestCase
         $today = new \DateTime;
         $str = $today->format('Y-m-d\TH:i:s');
 
+        $todayLowMs = \DateTime::createFromFormat('U.u', time() .'.012345');
+
         $r = new \ReflectionClass(Timestamp::class);
         return [
             [new Timestamp($today)],
+            [new Timestamp($todayLowMs)],
             [new Timestamp($today, 0)],
             [new Timestamp($today, 1)],
             [new Timestamp($today, 000000001)],

--- a/Spanner/tests/System/WriteTest.php
+++ b/Spanner/tests/System/WriteTest.php
@@ -101,7 +101,12 @@ class WriteTest extends SpannerTestCase
         $keyset = new KeySet(['keys' => [$id]]);
         $read = $db->read(self::TABLE_NAME, $keyset, [$field]);
         $row = $read->rows()->current();
-        $this->assertEquals($value, $row[$field]);
+
+        if ($value instanceof Timestamp) {
+            $this->assertEquals($value->formatAsString(), $row[$field]->formatAsString());
+        } else {
+            $this->assertEquals($value, $row[$field]);
+        }
 
         // test result from executeSql
         $exec = $db->execute(sprintf('SELECT %s FROM %s WHERE id = @id', $field, self::TABLE_NAME), [
@@ -111,7 +116,11 @@ class WriteTest extends SpannerTestCase
         ]);
 
         $row = $exec->rows()->current();
-        $this->assertEquals($value, $row[$field]);
+        if ($value instanceof Timestamp) {
+            $this->assertEquals($value->formatAsString(), $row[$field]->formatAsString());
+        } else {
+            $this->assertEquals($value, $row[$field]);
+        }
     }
 
     /**

--- a/Spanner/tests/System/WriteTest.php
+++ b/Spanner/tests/System/WriteTest.php
@@ -17,11 +17,12 @@
 
 namespace Google\Cloud\Spanner\Tests\System;
 
-use Google\Cloud\Spanner\Timestamp;
+use Google\Cloud\Core\TimeTrait;
 use Google\Cloud\Spanner\Bytes;
 use Google\Cloud\Spanner\CommitTimestamp;
 use Google\Cloud\Spanner\Date;
 use Google\Cloud\Spanner\KeySet;
+use Google\Cloud\Spanner\Timestamp;
 
 /**
  * @group spanner
@@ -29,6 +30,8 @@ use Google\Cloud\Spanner\KeySet;
  */
 class WriteTest extends SpannerTestCase
 {
+    use TimeTrait;
+
     const TABLE_NAME = 'Writes';
     const COMMIT_TIMESTAMP_TABLE_NAME = 'CommitTimestamps';
 
@@ -535,14 +538,16 @@ class WriteTest extends SpannerTestCase
     {
         $today = new \DateTime;
         $str = $today->format('Y-m-d\TH:i:s');
+
+        $r = new \ReflectionClass(Timestamp::class);
         return [
             [new Timestamp($today)],
             [new Timestamp($today, 0)],
             [new Timestamp($today, 1)],
             [new Timestamp($today, 000000001)],
-            [Timestamp::createFromString($str .'.100000000Z')],
-            [Timestamp::createFromString($str .'.000000001Z')],
-            [Timestamp::createFromString($str .'.101999119Z')],
+            [$r->newInstanceArgs($this->parseTimeString($str .'.100000000Z'))],
+            [$r->newInstanceArgs($this->parseTimeString($str .'.000000001Z'))],
+            [$r->newInstanceArgs($this->parseTimeString($str .'.101999119Z'))],
         ];
     }
 }

--- a/Spanner/tests/Unit/Batch/BatchClientTest.php
+++ b/Spanner/tests/Unit/Batch/BatchClientTest.php
@@ -89,6 +89,9 @@ class BatchClientTest extends TestCase
         $this->assertInstanceOf(BatchSnapshot::class, $snapshot);
     }
 
+    /**
+     * @group foo
+     */
     public function testSnapshotFromString()
     {
         $time = time();

--- a/Spanner/tests/Unit/Batch/BatchClientTest.php
+++ b/Spanner/tests/Unit/Batch/BatchClientTest.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Spanner\Tests\Unit\Batch;
 
 use Google\Cloud\Core\Testing\SpannerOperationRefreshTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
+use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Spanner\Batch\BatchClient;
 use Google\Cloud\Spanner\Batch\BatchSnapshot;
 use Google\Cloud\Spanner\Batch\QueryPartition;
@@ -77,10 +78,7 @@ class BatchClientTest extends TestCase
         }))->shouldBeCalled()
             ->willReturn([
                 'id' => self::TRANSACTION,
-                'readTimestamp' => [
-                    'seconds' => $time,
-                    'nanos' => 0
-                ]
+                'readTimestamp' => \DateTime::createFromFormat('U', (string) $time)->format(Timestamp::FORMAT)
             ]);
 
         $this->refreshOperation($this->client, $this->connection->reveal());
@@ -96,7 +94,7 @@ class BatchClientTest extends TestCase
         $identifier = base64_encode(json_encode([
             'sessionName' => self::SESSION,
             'transactionId' => self::TRANSACTION,
-            'readTimestamp' => ['seconds' => $time, 'nanos' => 0]
+            'readTimestamp' => \DateTime::createFromFormat('U', (string) $time)->format(Timestamp::FORMAT)
         ]));
 
         $snapshot = $this->client->snapshotFromString($identifier);

--- a/Spanner/tests/Unit/Batch/BatchClientTest.php
+++ b/Spanner/tests/Unit/Batch/BatchClientTest.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Spanner\Tests\Unit\Batch;
 use Google\Cloud\Core\Testing\SpannerOperationRefreshTrait;
 use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Core\Timestamp;
+use Google\Cloud\Core\TimeTrait;
 use Google\Cloud\Spanner\Batch\BatchClient;
 use Google\Cloud\Spanner\Batch\BatchSnapshot;
 use Google\Cloud\Spanner\Batch\QueryPartition;
@@ -38,6 +39,7 @@ use Prophecy\Argument;
 class BatchClientTest extends TestCase
 {
     use SpannerOperationRefreshTrait;
+    use TimeTrait;
 
     const DATABASE = 'projects/example_project/instances/example_instance/databases/example_database';
     const SESSION = 'projects/example_project/instances/example_instance/databases/example_database/sessions/session-id';

--- a/Spanner/tests/Unit/TimestampTest.php
+++ b/Spanner/tests/Unit/TimestampTest.php
@@ -48,7 +48,7 @@ class TimestampTest extends TestCase
     {
         $this->assertEquals(
             (new \DateTime($this->dt->format(Timestamp::FORMAT)))->format('U'),
-            (new \DateTime($this->ts->formatAsString()))->format('U')
+            (new \DateTime($this->ts->formatAsString(6)))->format('U')
         );
     }
 
@@ -56,7 +56,7 @@ class TimestampTest extends TestCase
     {
         $this->assertEquals(
             (new \DateTime($this->dt->format(Timestamp::FORMAT)))->format('U'),
-            (new \DateTime((string)$this->ts))->format('U')
+            (new \DateTime(str_replace('000000000', '000000', (string)$this->ts)))->format('U')
         );
     }
 

--- a/Spanner/tests/Unit/TimestampTest.php
+++ b/Spanner/tests/Unit/TimestampTest.php
@@ -48,7 +48,7 @@ class TimestampTest extends TestCase
     {
         $this->assertEquals(
             (new \DateTime($this->dt->format(Timestamp::FORMAT)))->format('U'),
-            (new \DateTime($this->ts->formatAsString(6)))->format('U')
+            (new \DateTime($this->ts->formatAsString()))->format('U')
         );
     }
 

--- a/Spanner/tests/Unit/TransactionConfigurationTraitTest.php
+++ b/Spanner/tests/Unit/TransactionConfigurationTraitTest.php
@@ -106,7 +106,7 @@ class TransactionConfigurationTraitTest extends TestCase
      */
     public function testConfigureSnapshotOptionsMinReadTimestamp($timestamp, $expected = null)
     {
-        $ts = Timestamp::createFromString($timestamp, Timestamp::PRECISION_NANOSECOND);
+        $ts = Timestamp::createFromString($timestamp);
         $args = ['minReadTimestamp' => $ts, 'singleUse' => true];
         $res = $this->impl->proxyConfigureSnapshotOptions($args);
         $this->assertEquals($expected ?: $timestamp, $res['readOnly']['minReadTimestamp']);
@@ -117,7 +117,7 @@ class TransactionConfigurationTraitTest extends TestCase
      */
     public function testConfigureSnapshotOptionsReadTimestamp($timestamp, $expected = null)
     {
-        $ts = Timestamp::createFromString($timestamp, Timestamp::PRECISION_NANOSECOND);
+        $ts = Timestamp::createFromString($timestamp);
         $args = ['readTimestamp' => $ts];
         $res = $this->impl->proxyConfigureSnapshotOptions($args);
         $this->assertEquals($expected ?: $timestamp, $res['readOnly']['readTimestamp']);

--- a/Spanner/tests/Unit/TransactionConfigurationTraitTest.php
+++ b/Spanner/tests/Unit/TransactionConfigurationTraitTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Spanner\Tests\Unit;
 
 use Google\Cloud\Core\Testing\GrpcTestTrait;
+use Google\Cloud\Core\TimeTrait;
 use Google\Cloud\Spanner\Duration;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
 use Google\Cloud\Spanner\Timestamp;
@@ -31,6 +32,7 @@ use PHPUnit\Framework\TestCase;
 class TransactionConfigurationTraitTest extends TestCase
 {
     use GrpcTestTrait;
+    use TimeTrait;
 
     const TRANSACTION = 'my-transaction';
 
@@ -106,7 +108,8 @@ class TransactionConfigurationTraitTest extends TestCase
      */
     public function testConfigureSnapshotOptionsMinReadTimestamp($timestamp, $expected = null)
     {
-        $ts = Timestamp::createFromString($timestamp);
+        $time = $this->parseTimeString($timestamp);
+        $ts = new Timestamp($time[0], $time[1]);
         $args = ['minReadTimestamp' => $ts, 'singleUse' => true];
         $res = $this->impl->proxyConfigureSnapshotOptions($args);
         $this->assertEquals($expected ?: $timestamp, $res['readOnly']['minReadTimestamp']);
@@ -117,7 +120,8 @@ class TransactionConfigurationTraitTest extends TestCase
      */
     public function testConfigureSnapshotOptionsReadTimestamp($timestamp, $expected = null)
     {
-        $ts = Timestamp::createFromString($timestamp);
+        $time = $this->parseTimeString($timestamp);
+        $ts = new Timestamp($time[0], $time[1]);
         $args = ['readTimestamp' => $ts];
         $res = $this->impl->proxyConfigureSnapshotOptions($args);
         $this->assertEquals($expected ?: $timestamp, $res['readOnly']['readTimestamp']);

--- a/Spanner/tests/Unit/TransactionConfigurationTraitTest.php
+++ b/Spanner/tests/Unit/TransactionConfigurationTraitTest.php
@@ -118,13 +118,13 @@ class TransactionConfigurationTraitTest extends TestCase
     /**
      * @dataProvider timestamps
      */
-    public function testConfigureSnapshotOptionsReadTimestamp($timestamp, $expected = null)
+    public function testConfigureSnapshotOptionsReadTimestamp($timestamp)
     {
         $time = $this->parseTimeString($timestamp);
         $ts = new Timestamp($time[0], $time[1]);
         $args = ['readTimestamp' => $ts];
         $res = $this->impl->proxyConfigureSnapshotOptions($args);
-        $this->assertEquals($expected ?: $timestamp, $res['readOnly']['readTimestamp']);
+        $this->assertEquals($timestamp, $res['readOnly']['readTimestamp']);
     }
 
     public function testConfigureSnapshotOptionsMaxStaleness()

--- a/Spanner/tests/Unit/TransactionTypeTest.php
+++ b/Spanner/tests/Unit/TransactionTypeTest.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Spanner\Tests\Unit;
 
 use Google\Cloud\Core\LongRunning\LongRunningConnectionInterface;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
+use Google\Cloud\Core\TimeTrait;
 use Google\Cloud\Spanner\Admin\Instance\V1\InstanceAdminClient;
 use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Database;
@@ -42,6 +43,7 @@ class TransactionTypeTest extends TestCase
 {
     use GrpcTestTrait;
     use ResultTestTrait;
+    use TimeTrait;
 
     const PROJECT = 'my-project';
     const INSTANCE = 'my-instance';
@@ -181,7 +183,8 @@ class TransactionTypeTest extends TestCase
         $seconds = 1;
         $nanos = 2;
 
-        $timestamp = Timestamp::createFromString($this->timestamp);
+        $time = $this->parseTimeString($this->timestamp);
+        $timestamp = new Timestamp($time[0], $time[1]);
         $duration = new Duration($seconds, $nanos);
 
         $this->connection->beginTransaction(Argument::any())
@@ -215,7 +218,8 @@ class TransactionTypeTest extends TestCase
      */
     public function testDatabasePreAllocatedSnapshotMinReadTimestamp()
     {
-        $timestamp = Timestamp::createFromString($this->timestamp);
+        $time = $this->parseTimeString($this->timestamp);
+        $timestamp = new Timestamp($time[0], $time[1]);
 
         $this->connection->beginTransaction(Argument::any())
             ->shouldNotbeCalled();
@@ -261,7 +265,8 @@ class TransactionTypeTest extends TestCase
         $seconds = 1;
         $nanos = 2;
 
-        $timestamp = Timestamp::createFromString($this->timestamp);
+        $time = $this->parseTimeString($this->timestamp);
+        $timestamp = new Timestamp($time[0], $time[1]);
         $duration = new Duration($seconds, $nanos);
 
         $this->connection->beginTransaction(Argument::any())
@@ -300,7 +305,8 @@ class TransactionTypeTest extends TestCase
         $seconds = 1;
         $nanos = 2;
 
-        $timestamp = Timestamp::createFromString($this->timestamp);
+        $time = $this->parseTimeString($this->timestamp);
+        $timestamp = new Timestamp($time[0], $time[1]);
         $duration = new Duration($seconds, $nanos);
 
         $this->connection->beginTransaction(Argument::allOf(

--- a/Spanner/tests/Unit/TransactionTypeTest.php
+++ b/Spanner/tests/Unit/TransactionTypeTest.php
@@ -18,6 +18,8 @@
 namespace Google\Cloud\Spanner\Tests\Unit;
 
 use Google\Cloud\Core\LongRunning\LongRunningConnectionInterface;
+use Google\Cloud\Core\Testing\GrpcTestTrait;
+use Google\Cloud\Core\ValueMapperTrait;
 use Google\Cloud\Spanner\Admin\Instance\V1\InstanceAdminClient;
 use Google\Cloud\Spanner\Connection\ConnectionInterface;
 use Google\Cloud\Spanner\Database;
@@ -30,17 +32,18 @@ use Google\Cloud\Spanner\Snapshot;
 use Google\Cloud\Spanner\Timestamp;
 use Google\Cloud\Spanner\Transaction;
 use Google\Cloud\Spanner\V1\SpannerClient;
-use Google\Cloud\Core\Testing\GrpcTestTrait;
-use Prophecy\Argument;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 
 /**
  * @group spanner
+ * @group spanner-transaction-type
  */
 class TransactionTypeTest extends TestCase
 {
     use GrpcTestTrait;
     use ResultTestTrait;
+    use ValueMapperTrait;
 
     const PROJECT = 'my-project';
     const INSTANCE = 'my-instance';
@@ -56,7 +59,7 @@ class TransactionTypeTest extends TestCase
     {
         $this->checkAndSkipGrpcTests();
 
-        $this->timestamp = (new \DateTimeImmutable)->format(Timestamp::FORMAT);
+        $this->timestamp = (new Timestamp(new \DateTime))->formatAsString();
 
         $this->connection = $this->prophesize(ConnectionInterface::class);
 
@@ -180,7 +183,7 @@ class TransactionTypeTest extends TestCase
         $seconds = 1;
         $nanos = 2;
 
-        $timestamp = new Timestamp(new \DateTimeImmutable($this->timestamp));
+        $timestamp = $this->createTimestampWithNanos($this->timestamp, Timestamp::class);
         $duration = new Duration($seconds, $nanos);
 
         $this->connection->beginTransaction(Argument::any())
@@ -212,7 +215,7 @@ class TransactionTypeTest extends TestCase
      */
     public function testDatabasePreAllocatedSnapshotMinReadTimestamp()
     {
-        $timestamp = new Timestamp(new \DateTimeImmutable($this->timestamp));
+        $timestamp = $this->createTimestampWithNanos($this->timestamp, Timestamp::class);
 
         $this->connection->beginTransaction(Argument::any())
             ->shouldNotbeCalled();
@@ -258,7 +261,7 @@ class TransactionTypeTest extends TestCase
         $seconds = 1;
         $nanos = 2;
 
-        $timestamp = new Timestamp(new \DateTimeImmutable($this->timestamp));
+        $timestamp = $this->createTimestampWithNanos($this->timestamp, Timestamp::class);
         $duration = new Duration($seconds, $nanos);
 
         $this->connection->beginTransaction(Argument::any())
@@ -293,7 +296,7 @@ class TransactionTypeTest extends TestCase
         $seconds = 1;
         $nanos = 2;
 
-        $timestamp = new Timestamp(new \DateTimeImmutable($this->timestamp));
+        $timestamp = $this->createTimestampWithNanos($this->timestamp, Timestamp::class);
         $duration = new Duration($seconds, $nanos);
 
         $this->connection->beginTransaction(Argument::that(function ($arg) use ($seconds, $nanos) {

--- a/Spanner/tests/Unit/ValueMapperTest.php
+++ b/Spanner/tests/Unit/ValueMapperTest.php
@@ -334,14 +334,16 @@ class ValueMapperTest extends TestCase
     public function testDecodeValuesTimestamp()
     {
         $dt = new \DateTime;
+        $str = str_replace('+00:00', 'Z', $dt->format(Timestamp::FORMAT));
+
         $res = $this->mapper->decodeValues(
             $this->createField(Database::TYPE_TIMESTAMP),
-            $this->createRow($dt->format(Timestamp::FORMAT)),
+            $this->createRow($str),
             Result::RETURN_ASSOCIATIVE
         );
 
         $this->assertInstanceOf(Timestamp::class, $res['rowName']);
-        $this->assertEquals($dt->format(Timestamp::FORMAT), $res['rowName']->formatAsString());
+        $this->assertEquals($str, $res['rowName']->formatAsString());
     }
 
     public function testDecodeValuesDate()

--- a/Spanner/tests/Unit/ValueMapperTest.php
+++ b/Spanner/tests/Unit/ValueMapperTest.php
@@ -152,8 +152,7 @@ class ValueMapperTest extends TestCase
 
     public function testEncodeValuesAsSimpleType()
     {
-        $dt = (new \DateTime)->format(Timestamp::FORMAT);
-        $timestamp = Timestamp::createFromString($dt);
+        $timestamp = new Timestamp(new \DateTimeImmutable);
 
         $vals = [];
         $vals['bool'] = true;

--- a/Spanner/tests/Unit/ValueMapperTest.php
+++ b/Spanner/tests/Unit/ValueMapperTest.php
@@ -333,7 +333,7 @@ class ValueMapperTest extends TestCase
     public function testDecodeValuesTimestamp()
     {
         $dt = new \DateTime;
-        $str = str_replace('+00:00', 'Z', $dt->format(Timestamp::FORMAT));
+        $str = $dt->format(Timestamp::FORMAT);
 
         $res = $this->mapper->decodeValues(
             $this->createField(Database::TYPE_TIMESTAMP),

--- a/Spanner/tests/Unit/ValueMapperTest.php
+++ b/Spanner/tests/Unit/ValueMapperTest.php
@@ -153,7 +153,7 @@ class ValueMapperTest extends TestCase
     public function testEncodeValuesAsSimpleType()
     {
         $dt = (new \DateTime)->format(Timestamp::FORMAT);
-        $timestamp = Timestamp::createFromString($dt, Timestamp::PRECISION_NANOSECOND);
+        $timestamp = Timestamp::createFromString($dt);
 
         $vals = [];
         $vals['bool'] = true;
@@ -175,7 +175,7 @@ class ValueMapperTest extends TestCase
         $this->assertEquals((string) $vals['int'], $res[2]);
         $this->assertEquals($vals['float'], $res[3]);
         $this->assertEquals('Infinity', $res[5]);
-        $this->assertEquals($timestamp->get()->format(Timestamp::FORMAT), $res[6]);
+        $this->assertEquals($timestamp->formatAsString(), $res[6]);
         $this->assertEquals($timestamp->get()->format(Date::FORMAT), $res[7]);
         $this->assertEquals($vals['string'], $res[8]);
         $this->assertEquals(base64_encode('hello world'), $res[9]);

--- a/Spanner/tests/Unit/ValueMapperTest.php
+++ b/Spanner/tests/Unit/ValueMapperTest.php
@@ -29,6 +29,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @group spanner
+ * @group spanner-value-mapper
  */
 class ValueMapperTest extends TestCase
 {
@@ -151,7 +152,8 @@ class ValueMapperTest extends TestCase
 
     public function testEncodeValuesAsSimpleType()
     {
-        $dt = new \DateTime;
+        $dt = (new \DateTime)->format(Timestamp::FORMAT);
+        $timestamp = Timestamp::createFromString($dt, Timestamp::PRECISION_NANOSECOND);
 
         $vals = [];
         $vals['bool'] = true;
@@ -160,8 +162,8 @@ class ValueMapperTest extends TestCase
         $vals['float'] = 3.1415;
         $vals['nan'] = NAN;
         $vals['inf'] = INF;
-        $vals['timestamp'] = new Timestamp($dt);
-        $vals['date'] = new Date($dt);
+        $vals['timestamp'] = $timestamp;
+        $vals['date'] = new Date($timestamp->get());
         $vals['string'] = 'foo';
         $vals['bytes'] = new Bytes('hello world');
         $vals['array'] = ['foo', 'bar'];
@@ -173,8 +175,8 @@ class ValueMapperTest extends TestCase
         $this->assertEquals((string) $vals['int'], $res[2]);
         $this->assertEquals($vals['float'], $res[3]);
         $this->assertEquals('Infinity', $res[5]);
-        $this->assertEquals($dt->format(Timestamp::FORMAT), $res[6]);
-        $this->assertEquals($dt->format(Date::FORMAT), $res[7]);
+        $this->assertEquals($timestamp->get()->format(Timestamp::FORMAT), $res[6]);
+        $this->assertEquals($timestamp->get()->format(Date::FORMAT), $res[7]);
         $this->assertEquals($vals['string'], $res[8]);
         $this->assertEquals(base64_encode('hello world'), $res[9]);
         $this->assertEquals($vals['array'], $res[10]);


### PR DESCRIPTION
Closes #933.

I added system tests to Firestore and Spanner which write a timestamp, reads it back, writes the read value and reads it back again, and compares the three values to prove that data is persisted back correctly. I also updated Firestore to make sure it handled timestamps in a consistent manner throughout the client. The firestore change is purely internal and does not impact users.