### PR TITLE
Encode empty arrays as firestore arrays

### DIFF
--- a/Firestore/src/ValueMapper.php
+++ b/Firestore/src/ValueMapper.php
@@ -366,7 +366,7 @@ class ValueMapper
                 break;
 
             case 'array':
-                if ($this->isAssoc($value)) {
+                if (!empty($value) && $this->isAssoc($value)) {
                     return $this->encodeAssociativeArrayValue($value);
                 }
 

--- a/Firestore/tests/Unit/ValueMapperTest.php
+++ b/Firestore/tests/Unit/ValueMapperTest.php
@@ -328,7 +328,17 @@ class ValueMapperTest extends TestCase
                 function ($val) use ($docName) {
                     $this->assertEquals($docName, $val['referenceValue']);
                 }
-            ]
+            ], [
+                [],
+                function ($val) {
+                    $this->assertEquals(['values' => []], $val['arrayValue']);
+                }
+            ],  [
+                (object) [],
+                function ($val) {
+                    $this->assertEquals(['fields' => []], $val['mapValue']);
+                }
+            ],
         ];
     }
 


### PR DESCRIPTION
Currently it is not possible to encode an empty array as a Firestore [ArrayValue](https://cloud.google.com/firestore/docs/reference/rpc/google.firestore.v1beta1#google.firestore.v1beta1.ArrayValue). This change will encode `[]` as `ArrayValue`, and `(object) []` as [`MapValue`](https://cloud.google.com/firestore/docs/reference/rpc/google.firestore.v1beta1#google.firestore.v1beta1.MapValue). This is in line with changes made in other areas of the library, namely Datastore in #974.

This issue was first reported in #996.