### PR TITLE
RFC: Reduce constructor options

### DIFF
--- a/PubSub/src/V1/Gapic/PublisherGapicClient.php
+++ b/PubSub/src/V1/Gapic/PublisherGapicClient.php
@@ -252,6 +252,9 @@ class PublisherGapicClient
      *     defaults for serviceAddress, scopes, and other settings. For the full list of options,
      *     see the documentation on GapicClientTrait::setClientOptions.
      *
+     *     @type string $serviceAddress
+     *           The address of the API remote host, for example "example.googleapis.com. May also
+     *           include the port, for example "example.googleapis.com:443"
      *     @type bool $disableRetries Determines whether or not retries defined
      *           by the client configuration should be disabled. Defaults to `false`.
      *     @type string|array $clientConfig
@@ -259,18 +262,33 @@ class PublisherGapicClient
      *           path to a JSON file, or a PHP array containing the decoded JSON data.
      *           By default this settings points to the default client config file, which is provided
      *           in the resources folder.
-     *     @type mixed $auth
-     *           This option is used to configure auth for the client object, and accepts any of
-     *           the following as input:
-     *           - decoded credentials file as a PHP array
-     *           - path to a credentials file as a string
-     *           - a \Google\Auth\FetchAuthTokenInterface object
-     *           - a \Google\Auth\CredentialsLoader object
-     *           - an AuthWrapper object
-     *     @type string|TransportInterface $transport The transport used for executing network
-     *           requests. May be either the string `rest` or `grpc`. Additionally, it is possible
-     *           to pass in an already instantiated transport. Defaults to `grpc` if gRPC support is
-     *           detected on the system.
+     *     @type string|array $auth
+     *           The credentials to be used by the client to authorize API calls. This option
+     *           accepts either a path to a credentials file, or a decoded credentials file as a
+     *           PHP array.
+     *           *Advanced usage*: In addition, this option can also accept a pre-constructed
+     *           \Google\Auth\FetchAuthTokenInterface object or \Google\ApiCore\AuthWrapper
+     *           object. Note that when one of these objects are provided, any settings in
+     *           $authConfig will be ignored.
+     *     @type array $authConfig
+     *           Options used to configure auth, including auth token caching, for the client. For
+     *           a full list of supporting configuration options, see \Google\ApiCore\Auth::build.
+     *     @type string $transport The transport used for executing network
+     *           requests. May be either the string `rest` or `grpc`. Defaults to `grpc` if gRPC
+     *           support is detected on the system.
+     *           *Advanced usage*: Additionally, it is possible to pass in an already instantiated
+     *           TransportInterface object. Note that when this objects is provided, any settings in
+     *           $transportConfig, and any $serviceAddress setting, will be ignored.
+     *     @type array $transportConfig
+     *           Configuration options that will be used to construct the transport. Options for
+     *           each supported transport type should be passed in a key for that transport. For
+     *           example:
+     *           $transportConfig = [
+     *               'grpc' => [...],
+     *               'rest' => [...]
+     *           ];
+     *           See the GapicClientTrait::buildGrpcTransport and GapicClientTrait::buildRestTransport
+     *           methods for the supported options.
      * }
      * @experimental
      */

--- a/PubSub/src/V1/Gapic/PublisherGapicClient.php
+++ b/PubSub/src/V1/Gapic/PublisherGapicClient.php
@@ -247,49 +247,26 @@ class PublisherGapicClient
      * Constructor.
      *
      * @param array $options {
-     *                       Optional. Options for configuring the service API wrapper.
+     *                       Optional. Options for configuring the service API wrapper. In addition
+     *     to the options documented here, you can also provide options to override the client
+     *     defaults for serviceAddress, scopes, and other settings. For the full list of options,
+     *     see the documentation on GapicClientTrait::setClientOptions.
      *
-     *     @type string $serviceAddress The domain name of the API remote host.
-     *                                  Default 'pubsub.googleapis.com'.
-     *     @type mixed $port The port on which to connect to the remote host. Default 443.
-     *     @type Channel $channel
-     *           A `Channel` object. If not specified, a channel will be constructed.
-     *           NOTE: This option is only valid when utilizing the gRPC transport.
-     *     @type ChannelCredentials $sslCreds
-     *           A `ChannelCredentials` object for use with an SSL-enabled channel.
-     *           Default: a credentials object returned from
-     *           \Grpc\ChannelCredentials::createSsl().
-     *           NOTE: This option is only valid when utilizing the gRPC transport. Also, if the $channel
-     *           optional argument is specified, then this argument is unused.
-     *     @type bool $forceNewChannel
-     *           If true, this forces gRPC to create a new channel instead of using a persistent channel.
-     *           Defaults to false.
-     *           NOTE: This option is only valid when utilizing the gRPC transport. Also, if the $channel
-     *           optional argument is specified, then this option is unused.
-     *     @type CredentialsLoader $credentialsLoader
-     *           A CredentialsLoader object created using the Google\Auth library.
-     *     @type string[] $scopes A string array of scopes to use when acquiring credentials.
-     *                          Defaults to the scopes for the Google Cloud Pub/Sub API.
-     *     @type string $clientConfigPath
-     *           Path to a JSON file containing client method configuration, including retry settings.
-     *           Specify this setting to specify the retry behavior of all methods on the client.
+     *     @type bool $disableRetries Determines whether or not retries defined
+     *           by the client configuration should be disabled. Defaults to `false`.
+     *     @type string|array $clientConfig
+     *           Client method configuration, including retry settings. This option can be either a
+     *           path to a JSON file, or a PHP array containing the decoded JSON data.
      *           By default this settings points to the default client config file, which is provided
-     *           in the resources folder. The retry settings provided in this option can be overridden
-     *           by settings in $retryingOverride
-     *     @type array $retryingOverride
-     *           An associative array in which the keys are method names (e.g. 'createFoo'), and
-     *           the values are retry settings to use for that method. The retry settings for each
-     *           method can be a {@see Google\ApiCore\RetrySettings} object, or an associative array
-     *           of retry settings parameters. See the documentation on {@see Google\ApiCore\RetrySettings}
-     *           for example usage. Passing a value of null is equivalent to a value of
-     *           ['retriesEnabled' => false]. Retry settings provided in this setting override the
-     *           settings in $clientConfigPath.
-     *     @type callable $authHttpHandler A handler used to deliver PSR-7 requests specifically
-     *           for authentication. Should match a signature of
-     *           `function (RequestInterface $request, array $options) : ResponseInterface`.
-     *     @type callable $httpHandler A handler used to deliver PSR-7 requests. Should match a
-     *           signature of `function (RequestInterface $request, array $options) : PromiseInterface`.
-     *           NOTE: This option is only valid when utilizing the REST transport.
+     *           in the resources folder.
+     *     @type mixed $auth
+     *           This option is used to configure auth for the client object, and accepts any of
+     *           the following as input:
+     *           - decoded credentials file as a PHP array
+     *           - path to a credentials file as a string
+     *           - a \Google\Auth\FetchAuthTokenInterface object
+     *           - a \Google\Auth\CredentialsLoader object
+     *           - an AuthWrapper object
      *     @type string|TransportInterface $transport The transport used for executing network
      *           requests. May be either the string `rest` or `grpc`. Additionally, it is possible
      *           to pass in an already instantiated transport. Defaults to `grpc` if gRPC support is

--- a/PubSub/src/V1/Gapic/PublisherGapicClient.php
+++ b/PubSub/src/V1/Gapic/PublisherGapicClient.php
@@ -247,10 +247,7 @@ class PublisherGapicClient
      * Constructor.
      *
      * @param array $options {
-     *                       Optional. Options for configuring the service API wrapper. In addition
-     *     to the options documented here, you can also provide options to override the client
-     *     defaults for serviceAddress, scopes, and other settings. For the full list of options,
-     *     see the documentation on GapicClientTrait::setClientOptions.
+     *                       Optional. Options for configuring the service API wrapper.
      *
      *     @type string $serviceAddress
      *           The address of the API remote host, for example "example.googleapis.com. May also


### PR DESCRIPTION
A followup to @dwsupplee 's original RFC here: https://github.com/GoogleCloudPlatform/google-cloud-php/pull/899

This would:
- dramatically reduce the documented options; serviceAddress, scopes, and others would still be accepted, but only be documented on the `GapicClientTrait::setClientOptions` method
- add an `$auth` option, which accepts many different formats, including `keyFile` and `keyFilePath`

The corresponding changes in gax would be to:
- remove transport-specific options like `channel`, `sslcreds` from `setClientOptions`, and instead have easy-to-use transport construction helper methods
- remove auth-specific options like 'authCache', 'authCacheOptions', 'enableCaching', and instead have easy-to-use AuthWrapper construction helper methods. e.g. `<API>Client::buildAuth($scopes)`, and maybe even something like `<API>Client::buildAuthWithAmazingCache()`

WDYT?