### PR TITLE
[Debugger] Add Daemon options to Agent

### DIFF
--- a/Debugger/src/Agent.php
+++ b/Debugger/src/Agent.php
@@ -85,10 +85,15 @@ class Agent
      *            **Defaults to** the directory of the calling file.
      *      @type LoggerInterface $logger PSR-3 compliant logger used to write
      *            logpoint records. **Defaults to** a new Stackdriver logger.
+     *      @type array $daemonOptions Additional options to provide to the
+     *            Daemon when registering.
      * }
      */
     public function __construct(array $options = [])
     {
+        $options += [
+            'daemonOptions' => []
+        ];
         $storage = isset($options['storage'])
             ? $options['storage']
             : $this->defaultStorage();
@@ -98,7 +103,7 @@ class Agent
             : dirname(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0]['file']);
 
         if ($this->shouldStartDaemon()) {
-            $daemon = new Daemon([
+            $daemon = new Daemon($options['daemonOptions'] + [
                 'sourceRoot' => $this->sourceRoot,
                 'storage' => $storage,
                 'register' => true

--- a/Debugger/src/Agent.php
+++ b/Debugger/src/Agent.php
@@ -92,15 +92,13 @@ class Agent
     public function __construct(array $options = [])
     {
         $options += [
-            'daemonOptions' => []
+            'daemonOptions' => [],
+            'storage' => null,
+            'sourceRoot' => null
         ];
-        $storage = isset($options['storage'])
-            ? $options['storage']
-            : $this->defaultStorage();
-
-        $this->sourceRoot = isset($options['sourceRoot'])
-            ? $options['sourceRoot']
-            : dirname(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0]['file']);
+        $storage = $options['storage'] ?: $this->defaultStorage();
+        $this->sourceRoot = $options['sourceRoot']
+            ?: dirname(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0]['file']);
 
         if ($this->shouldStartDaemon()) {
             $daemon = new Daemon($options['daemonOptions'] + [

--- a/Debugger/tests/Unit/AgentTest.php
+++ b/Debugger/tests/Unit/AgentTest.php
@@ -17,10 +17,13 @@
 
 namespace Google\Cloud\Debugger\Tests\Unit;
 
+use Google\Cloud\Core\Batch\ConfigStorageInterface;
+use Google\Cloud\Core\Batch\JobConfig;
 use Google\Cloud\Debugger\Agent;
 use Google\Cloud\Debugger\Debuggee;
 use Google\Cloud\Debugger\BreakpointStorage\BreakpointStorageInterface;
 use Psr\Log\LoggerInterface;
+use Prophecy\Argument;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -29,9 +32,13 @@ use PHPUnit\Framework\TestCase;
 class AgentTest extends TestCase
 {
     private $storage;
+    private $oldDaemonEnv;
 
     public function setUp()
     {
+        parent::setUp();
+        $this->oldDaemonEnv = getenv('IS_BATCH_DAEMON_RUNNING');
+
         if (PHP_MAJOR_VERSION < 7) {
             $this->markTestSkipped('Can only run the Agent on PHP 7+');
         }
@@ -43,31 +50,61 @@ class AgentTest extends TestCase
         $this->storage = $this->prophesize(BreakpointStorageInterface::class);
     }
 
+    public function tearDown()
+    {
+        if ($this->oldDaemonEnv === false) {
+            putenv('IS_BATCH_DAEMON_RUNNING');
+        } else {
+            putenv('IS_BATCH_DAEMON_RUNNING=' . $this->oldDaemonEnv);
+        }
+        parent::tearDown();
+    }
+
     public function testSpecifyStorage()
     {
-        $this->storage->load()->willReturn('debuggeeId', []);
+        $this->storage->load()->willReturn(['debuggeeId', []])->shouldBeCalled();
         $agent = new Agent(['storage' => $this->storage->reveal()]);
     }
 
     public function testSpecifyLogger()
     {
-        $this->storage->load()->willReturn('debuggeeId', []);
+        $this->storage->load()->willReturn(['debuggeeId', []])->shouldBeCalled();
         $logger = $this->prophesize(LoggerInterface::class);
+        $logger->log('INFO', 'LOGPOINT: message', ['context' => 'value'])->shouldBeCalled();
 
         $agent = new Agent([
             'storage' => $this->storage->reveal(),
             'logger' => $logger->reveal()
         ]);
+        $agent->handleLogpoint('INFO', 'message', ['context' => 'value']);
     }
 
-    public function testSpecifyDebuggee()
+    /**
+     * @group focus
+     */
+    public function testDaemonOptions()
     {
-        $this->storage->load()->willReturn('debuggeeId', []);
-        $debuggee = $this->prophesize(Debuggee::class);
+        putenv('IS_BATCH_DAEMON_RUNNING=true');
+        $this->storage->load()->willReturn('debuggeeId', [])->shouldBeCalled();
+        $configStorage = $this->prophesize(ConfigStorageInterface::class);
+        $configStorage->lock()->willReturn(true)->shouldBeCalled();
+
+        $jobConfig = $this->prophesize(JobConfig::class);
+        $jobConfig->registerJob(
+            Argument::any(),
+            Argument::any()
+        );
+        $config = $jobConfig->reveal();
+        $configStorage->load()->willReturn($config)->shouldBeCalled();
+        $configStorage->unlock()->shouldBeCalled();
+        $configStorage->save($config)->shouldBeCalled();
 
         $agent = new Agent([
             'storage' => $this->storage->reveal(),
-            'debuggee' => $debuggee->reveal()
+            'daemonOptions' => [
+                'uniquifier' => 'some-value',
+                'configStorage' => $configStorage->reveal()
+            ]
         ]);
     }
 }


### PR DESCRIPTION
When using the background batch runner, the Agent configures the Daemon's configuration. We should allow you to configure the Daemon's settings at this time.