### PR TITLE
Introduce Cloud KMS key name support

### DIFF
--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -204,6 +204,18 @@ class Bucket
      * );
      * ```
      *
+     * ```
+     * // Upload an object utilizing an encryption key managed by the Cloud Key Management Service (KMS).
+     * $object = $bucket->upload(
+     *     fopen(__DIR__ . '/image.jpg', 'r'),
+     *     [
+     *         'metadata' => [
+     *             'kmsKeyName' => 'projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key'
+     *         ]
+     *     ]
+     * );
+     * ```
+     *
      * @see https://cloud.google.com/storage/docs/json_api/v1/how-tos/upload#resumable Learn more about resumable
      * uploads.
      * @see https://cloud.google.com/storage/docs/json_api/v1/objects/insert Objects insert API documentation.
@@ -242,7 +254,9 @@ class Bucket
      *           at the [JSON API docs](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request-body).
      *     @type array $metadata['metadata'] User-provided metadata, in key/value pairs.
      *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
-     *           encryption key.
+     *           encryption key. If you would prefer to manage encryption
+     *           utilizing the Cloud Key Management Service (KMS) please use the
+     *           $metadata['kmsKeyName'] setting.
      *     @type string $encryptionKeySHA256 Base64 encoded SHA256 hash of the
      *           customer-supplied encryption key. This value will be calculated
      *           from the `encryptionKey` on your behalf if not provided, but
@@ -318,7 +332,9 @@ class Bucket
      *     @type array $metadata The available options for metadata are outlined
      *           at the [JSON API docs](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request-body).
      *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
-     *           encryption key.
+     *           encryption key. If you would prefer to manage encryption
+     *           utilizing the Cloud Key Management Service (KMS) please use the
+     *           $metadata['kmsKeyName'] setting.
      *     @type string $encryptionKeySHA256 Base64 encoded SHA256 hash of the
      *           customer-supplied encryption key. This value will be calculated
      *           from the `encryptionKey` on your behalf if not provided, but
@@ -391,7 +407,9 @@ class Bucket
      *     @type array $metadata The available options for metadata are outlined
      *           at the [JSON API docs](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request-body).
      *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
-     *           encryption key.
+     *           encryption key. If you would prefer to manage encryption
+     *           utilizing the Cloud Key Management Service (KMS) please use the
+     *           $metadata['kmsKeyName'] setting.
      *     @type string $encryptionKeySHA256 Base64 encoded SHA256 hash of the
      *           customer-supplied encryption key. This value will be calculated
      *           from the `encryptionKey` on your behalf if not provided, but
@@ -770,12 +788,18 @@ class Bucket
      *     @type array $versioning The bucket's versioning configuration.
      *     @type array $website The bucket's website configuration.
      *     @type array $billing The bucket's billing configuration.
-     *     @type bool $billing['requesterPays'] When `true`, requests to this bucket
+     *     @type bool $billing.requesterPays When `true`, requests to this bucket
      *           and objects within it must provide a project ID to which the
      *           request will be billed.
      *     @type array $labels The Bucket labels. Labels are represented as an
      *           array of keys and values. To remove an existing label, set its
      *           value to `null`.
+     *     @type array $encryption Encryption configuration used by default for
+     *           newly inserted objects.
+     *     @type string $encryption.defaultKmsKeyName A Cloud KMS Key used to
+     *           encrypt objects uploaded into this bucket. Should be in the
+     *           format
+     *           `projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key`.
      * }
      * @return array
      */

--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -257,7 +257,7 @@ class Bucket
      *           encryption key. If you would prefer to manage encryption
      *           utilizing the Cloud Key Management Service (KMS) please use the
      *           $metadata['kmsKeyName'] setting. Please note if using KMS the
-     *           key ring should use the same location as the bucket.
+     *           key ring must use the same location as the bucket.
      *     @type string $encryptionKeySHA256 Base64 encoded SHA256 hash of the
      *           customer-supplied encryption key. This value will be calculated
      *           from the `encryptionKey` on your behalf if not provided, but
@@ -336,7 +336,7 @@ class Bucket
      *           encryption key. If you would prefer to manage encryption
      *           utilizing the Cloud Key Management Service (KMS) please use the
      *           $metadata['kmsKeyName'] setting. Please note if using KMS the
-     *           key ring should use the same location as the bucket.
+     *           key ring must use the same location as the bucket.
      *     @type string $encryptionKeySHA256 Base64 encoded SHA256 hash of the
      *           customer-supplied encryption key. This value will be calculated
      *           from the `encryptionKey` on your behalf if not provided, but
@@ -412,7 +412,7 @@ class Bucket
      *           encryption key. If you would prefer to manage encryption
      *           utilizing the Cloud Key Management Service (KMS) please use the
      *           $metadata['kmsKeyName'] setting. Please note if using KMS the
-     *           key ring should use the same location as the bucket.
+     *           key ring must use the same location as the bucket.
      *     @type string $encryptionKeySHA256 Base64 encoded SHA256 hash of the
      *           customer-supplied encryption key. This value will be calculated
      *           from the `encryptionKey` on your behalf if not provided, but
@@ -803,8 +803,8 @@ class Bucket
      *           encrypt objects uploaded into this bucket. Should be in the
      *           format
      *           `projects/my-project/locations/kr-location/keyRings/my-kr/cryptoKeys/my-key`.
-     *           Please note the KMS key ring should use the same location as
-     *           the bucket.
+     *           Please note the KMS key ring must use the same location as the
+     *           bucket.
      * }
      * @return array
      */

--- a/Storage/src/Bucket.php
+++ b/Storage/src/Bucket.php
@@ -210,7 +210,7 @@ class Bucket
      *     fopen(__DIR__ . '/image.jpg', 'r'),
      *     [
      *         'metadata' => [
-     *             'kmsKeyName' => 'projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key'
+     *             'kmsKeyName' => 'projects/my-project/locations/kr-location/keyRings/my-kr/cryptoKeys/my-key'
      *         ]
      *     ]
      * );
@@ -256,7 +256,8 @@ class Bucket
      *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
      *           encryption key. If you would prefer to manage encryption
      *           utilizing the Cloud Key Management Service (KMS) please use the
-     *           $metadata['kmsKeyName'] setting.
+     *           $metadata['kmsKeyName'] setting. Please note if using KMS the
+     *           key ring should use the same location as the bucket.
      *     @type string $encryptionKeySHA256 Base64 encoded SHA256 hash of the
      *           customer-supplied encryption key. This value will be calculated
      *           from the `encryptionKey` on your behalf if not provided, but
@@ -334,7 +335,8 @@ class Bucket
      *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
      *           encryption key. If you would prefer to manage encryption
      *           utilizing the Cloud Key Management Service (KMS) please use the
-     *           $metadata['kmsKeyName'] setting.
+     *           $metadata['kmsKeyName'] setting. Please note if using KMS the
+     *           key ring should use the same location as the bucket.
      *     @type string $encryptionKeySHA256 Base64 encoded SHA256 hash of the
      *           customer-supplied encryption key. This value will be calculated
      *           from the `encryptionKey` on your behalf if not provided, but
@@ -409,7 +411,8 @@ class Bucket
      *     @type string $encryptionKey A base64 encoded AES-256 customer-supplied
      *           encryption key. If you would prefer to manage encryption
      *           utilizing the Cloud Key Management Service (KMS) please use the
-     *           $metadata['kmsKeyName'] setting.
+     *           $metadata['kmsKeyName'] setting. Please note if using KMS the
+     *           key ring should use the same location as the bucket.
      *     @type string $encryptionKeySHA256 Base64 encoded SHA256 hash of the
      *           customer-supplied encryption key. This value will be calculated
      *           from the `encryptionKey` on your behalf if not provided, but
@@ -799,7 +802,9 @@ class Bucket
      *     @type string $encryption.defaultKmsKeyName A Cloud KMS Key used to
      *           encrypt objects uploaded into this bucket. Should be in the
      *           format
-     *           `projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key`.
+     *           `projects/my-project/locations/kr-location/keyRings/my-kr/cryptoKeys/my-key`.
+     *           Please note the KMS key ring should use the same location as
+     *           the bucket.
      * }
      * @return array
      */

--- a/Storage/src/StorageClient.php
+++ b/Storage/src/StorageClient.php
@@ -292,8 +292,8 @@ class StorageClient
      *           encrypt objects uploaded into this bucket. Should be in the
      *           format
      *           `projects/my-project/locations/kr-location/keyRings/my-kr/cryptoKeys/my-key`.
-     *           Please note the KMS key ring should use the same location as
-     *           the bucket.
+     *           Please note the KMS key ring must use the same location as the
+     *           bucket.
      * }
      * @return Bucket
      * @throws GoogleException When a project ID has not been detected.

--- a/Storage/src/StorageClient.php
+++ b/Storage/src/StorageClient.php
@@ -291,7 +291,9 @@ class StorageClient
      *     @type string $encryption.defaultKmsKeyName A Cloud KMS Key used to
      *           encrypt objects uploaded into this bucket. Should be in the
      *           format
-     *           `projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key`.
+     *           `projects/my-project/locations/kr-location/keyRings/my-kr/cryptoKeys/my-key`.
+     *           Please note the KMS key ring should use the same location as
+     *           the bucket.
      * }
      * @return Bucket
      * @throws GoogleException When a project ID has not been detected.

--- a/Storage/src/StorageClient.php
+++ b/Storage/src/StorageClient.php
@@ -273,7 +273,7 @@ class StorageClient
      *     @type array $versioning The bucket's versioning configuration.
      *     @type array $website The bucket's website configuration.
      *     @type array $billing The bucket's billing configuration.
-     *     @type bool $billing['requesterPays'] When `true`, requests to this bucket
+     *     @type bool $billing.requesterPays When `true`, requests to this bucket
      *           and objects within it must provide a project ID to which the
      *           request will be billed.
      *     @type array $labels The Bucket labels. Labels are represented as an
@@ -286,6 +286,12 @@ class StorageClient
      *           If false, `$options.userProject` will be used ONLY for the
      *           createBucket operation. If `$options.userProject` is not set,
      *           this option has no effect. **Defaults to** `true`.
+     *     @type array $encryption Encryption configuration used by default for
+     *           newly inserted objects.
+     *     @type string $encryption.defaultKmsKeyName A Cloud KMS Key used to
+     *           encrypt objects uploaded into this bucket. Should be in the
+     *           format
+     *           `projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key`.
      * }
      * @return Bucket
      * @throws GoogleException When a project ID has not been detected.

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -404,7 +404,9 @@ class StorageObject
      *           calculated SHA.
      *     @type string $destinationKmsKeyName Name of the Cloud KMS key that
      *           will be used to encrypt the object. Should be in the format
-     *           `projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key`.
+     *           `projects/my-project/locations/kr-location/keyRings/my-kr/cryptoKeys/my-key`.
+     *           Please note the KMS key ring should use the same location as
+     *           the destination bucket.
      *     @type string $ifGenerationMatch Makes the operation conditional on
      *           whether the destination object's current generation matches the
      *           given value.

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -402,6 +402,9 @@ class StorageObject
      *           your behalf if not provided, but for best performance it is
      *           recommended to pass in a cached version of the already
      *           calculated SHA.
+     *     @type string $destinationKmsKeyName Name of the Cloud KMS key that
+     *           will be used to encrypt the object. Should be in the format
+     *           `projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key`.
      *     @type string $ifGenerationMatch Makes the operation conditional on
      *           whether the destination object's current generation matches the
      *           given value.

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -405,8 +405,8 @@ class StorageObject
      *     @type string $destinationKmsKeyName Name of the Cloud KMS key that
      *           will be used to encrypt the object. Should be in the format
      *           `projects/my-project/locations/kr-location/keyRings/my-kr/cryptoKeys/my-key`.
-     *           Please note the KMS key ring should use the same location as
-     *           the destination bucket.
+     *           Please note the KMS key ring must use the same location as the
+     *           destination bucket.
      *     @type string $ifGenerationMatch Makes the operation conditional on
      *           whether the destination object's current generation matches the
      *           given value.

--- a/Storage/tests/Snippet/BucketTest.php
+++ b/Storage/tests/Snippet/BucketTest.php
@@ -196,7 +196,7 @@ class BucketTest extends SnippetTestCase
 
         $this->connection->insertObject([
                 'metadata' => [
-                    'kmsKeyName' => 'projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key'
+                    'kmsKeyName' => 'projects/my-project/locations/kr-location/keyRings/my-kr/cryptoKeys/my-key'
                 ],
                 'bucket' => self::BUCKET,
                 'userProject' => null,

--- a/Storage/tests/Snippet/BucketTest.php
+++ b/Storage/tests/Snippet/BucketTest.php
@@ -178,6 +178,39 @@ class BucketTest extends SnippetTestCase
         $this->assertInstanceOf(StorageObject::class, $res->returnVal());
     }
 
+    public function testUploadKms()
+    {
+        $snippet = $this->snippetFromMethod(Bucket::class, 'upload', 3);
+        $snippet->addLocal('bucket', $this->bucket);
+        $fh = fopen('php://temp', 'r');
+        $snippet->addLocal('fh', $fh);
+        $snippet->replace("fopen(__DIR__ . '/image.jpg', 'r')", '$fh');
+
+        $uploader = $this->prophesize(MultipartUploader::class);
+        $uploader->upload()
+            ->shouldBeCalled()
+            ->willReturn([
+                'name' => 'Foo',
+                'generation' => 'Bar'
+            ]);
+
+        $this->connection->insertObject([
+                'metadata' => [
+                    'kmsKeyName' => 'projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key'
+                ],
+                'bucket' => self::BUCKET,
+                'userProject' => null,
+                'data' => $fh
+            ])
+            ->shouldBeCalled()
+            ->willReturn($uploader->reveal());
+
+        $this->bucket->___setProperty('connection', $this->connection->reveal());
+
+        $res = $snippet->invoke('object');
+        $this->assertInstanceOf(StorageObject::class, $res->returnVal());
+    }
+
     public function testGetResumableUploader()
     {
         $snippet = $this->snippetFromMethod(Bucket::class, 'getResumableUploader');

--- a/Storage/tests/System/KmsTest.php
+++ b/Storage/tests/System/KmsTest.php
@@ -71,6 +71,8 @@ class KmsTest extends StorageTestCase
         self::$bucket->update([
             'encryption' => null
         ]);
+
+        $this->assertArrayNotHasKey('encryption', self::$bucket->info());
     }
 
     public function testUploadExplicitKmsKeyOverridesDefaultOnBucket()
@@ -94,6 +96,8 @@ class KmsTest extends StorageTestCase
         self::$bucket->update([
             'encryption' => null
         ]);
+
+        $this->assertArrayNotHasKey('encryption', self::$bucket->info());
     }
 
     public function testRotatesKmsKeys()

--- a/Storage/tests/System/KmsTest.php
+++ b/Storage/tests/System/KmsTest.php
@@ -30,8 +30,8 @@ class KmsTest extends StorageTestCase
 {
     const DATA = 'data';
     const KEY_RING_ID = 'kms-kr';
-    const KEY_NAME_1 = 'key1';
-    const KEY_NAME_2 = 'key2';
+    const CRYPTO_KEY_ID_1 = 'key1';
+    const CRYPTO_KEY_ID_2 = 'key2';
 
     private static $keyName1;
     private static $keyName2;
@@ -41,8 +41,8 @@ class KmsTest extends StorageTestCase
         parent::setUpBeforeClass();
         list(self::$keyName1, self::$keyName2) = self::getKeyNames(
             self::KEY_RING_ID,
-            self::KEY_NAME_1,
-            self::KEY_NAME_2
+            self::CRYPTO_KEY_ID_1,
+            self::CRYPTO_KEY_ID_2
         );
     }
 

--- a/Storage/tests/System/KmsTest.php
+++ b/Storage/tests/System/KmsTest.php
@@ -54,7 +54,7 @@ class KmsTest extends StorageTestCase
         $this->assertEquals(self::DATA, $object->downloadAsString());
     }
 
-    public function testUploadWithDefaultNameOnBucket()
+    public function testUploadWithDefaultKmsKeyNameOnBucket()
     {
         self::$bucket->update([
             'encryption' => [

--- a/Storage/tests/System/KmsTest.php
+++ b/Storage/tests/System/KmsTest.php
@@ -213,7 +213,7 @@ class KmsTest extends StorageTestCase
                 new Request(
                     'POST',
                     sprintf(
-                        'https://cloudkms.googleapis.com/v1/projects/%s/locations/global/keyRings?keyRingId=%s',
+                        'https://cloudkms.googleapis.com/v1/projects/%s/locations/us-west1/keyRings?keyRingId=%s',
                         $projectId,
                         $keyRingId
                     )
@@ -246,7 +246,7 @@ class KmsTest extends StorageTestCase
                 new Request(
                     'POST',
                     sprintf(
-                        'https://cloudkms.googleapis.com/v1/projects/%s/locations/global/keyRings/%s/cryptoKeys?cryptoKeyId=%s',
+                        'https://cloudkms.googleapis.com/v1/projects/%s/locations/us-west1/keyRings/%s/cryptoKeys?cryptoKeyId=%s',
                         $projectId,
                         $keyRingId,
                         $cryptoKeyId
@@ -259,7 +259,7 @@ class KmsTest extends StorageTestCase
             $name = json_decode((string) $response->getBody(), true)['name'];
         } catch (ConflictException $ex) {
             $name = sprintf(
-                'projects/%s/locations/global/keyRings/%s/cryptoKeys/%s',
+                'projects/%s/locations/us-west1/keyRings/%s/cryptoKeys/%s',
                 $projectId,
                 $keyRingId,
                 $cryptoKeyId
@@ -283,7 +283,7 @@ class KmsTest extends StorageTestCase
             new Request(
                 'POST',
                 sprintf(
-                    'https://cloudkms.googleapis.com/v1/projects/%s/locations/global/keyRings/%s/cryptoKeys/%s:setIamPolicy',
+                    'https://cloudkms.googleapis.com/v1/projects/%s/locations/us-west1/keyRings/%s/cryptoKeys/%s:setIamPolicy',
                     $projectId,
                     $keyRingId,
                     $cryptoKeyId

--- a/Storage/tests/System/KmsTest.php
+++ b/Storage/tests/System/KmsTest.php
@@ -1,0 +1,279 @@
+<?php
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage\Tests\System;
+
+use Google\Cloud\Core\Exception\ConflictException;
+use Google\Cloud\Core\RequestWrapper;
+use Google\Cloud\Storage\StorageObject;
+use GuzzleHttp\Psr7\Request;
+
+/**
+ * @group storage
+ * @group storage-kms
+ */
+class KmsTest extends StorageTestCase
+{
+    const DATA = 'data';
+    const KEY_RING_ID = 'kms-kr';
+    const KEY_NAME_1 = 'key1';
+    const KEY_NAME_2 = 'key2';
+
+    private static $keyName1;
+    private static $keyName2;
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        list(self::$keyName1, self::$keyName2) = self::getKeyNames(
+            self::KEY_RING_ID,
+            self::KEY_NAME_1,
+            self::KEY_NAME_2
+        );
+    }
+
+    public function testUpload()
+    {
+        $object = $this->upload();
+
+        $this->assertContains(self::$keyName1, $object->info()['kmsKeyName']);
+        $this->assertEquals(self::DATA, $object->downloadAsString());
+    }
+
+    public function testUploadWithDefaultNameOnBucket()
+    {
+        self::$bucket->update([
+            'encryption' => [
+                'defaultKmsKeyName' => self::$keyName1
+            ]
+        ]);
+
+        $object = $this->upload(['metadata' => null]);
+
+        $this->assertContains(self::$keyName1, $object->info()['kmsKeyName']);
+        $this->assertEquals(self::DATA, $object->downloadAsString());
+
+        // Reset default to none
+        self::$bucket->update([
+            'encryption' => null
+        ]);
+    }
+
+    public function testUploadExplicitKmsKeyOverridesDefaultOnBucket()
+    {
+        self::$bucket->update([
+            'encryption' => [
+                'defaultKmsKeyName' => self::$keyName1
+            ]
+        ]);
+
+        $object = $this->upload([
+            'metadata' => [
+                'kmsKeyName' => self::$keyName2
+            ]
+        ]);
+
+        $this->assertContains(self::$keyName2, $object->info()['kmsKeyName']);
+        $this->assertEquals(self::DATA, $object->downloadAsString());
+
+        // Reset default to none
+        self::$bucket->update([
+            'encryption' => null
+        ]);
+    }
+
+    public function testRotatesKmsKeys()
+    {
+        $object = $this->upload();
+        $rewriteOptions = [
+            'name' => uniqid(self::TESTING_PREFIX),
+            'destinationKmsKeyName' => self::$keyName2
+        ];
+        $rewrittenObject = $object->rewrite(self::$bucket, $rewriteOptions);
+
+        $this->assertContains(self::$keyName2, $rewrittenObject->info()['kmsKeyName']);
+        $this->assertEquals(self::DATA, $rewrittenObject->downloadAsString());
+    }
+
+    public function testRotatesCustomerSuppliedEncrpytionToKms()
+    {
+        $key = base64_encode(openssl_random_pseudo_bytes(32));
+        $object = $this->upload(['encryptionKey' => $key, 'metadata' => null]);
+        $rewriteOptions = [
+            'name' => uniqid(self::TESTING_PREFIX),
+            'encryptionKey' => $key,
+            'destinationKmsKeyName' => self::$keyName1
+        ];
+        $rewrittenObject = $object->rewrite(self::$bucket, $rewriteOptions);
+
+        $this->assertContains(self::$keyName1, $rewrittenObject->info()['kmsKeyName']);
+        $this->assertEquals(self::DATA, $rewrittenObject->downloadAsString());
+    }
+
+    public function testRotatesKmsToCustomerSuppliedEncrpytion()
+    {
+        $key = base64_encode(openssl_random_pseudo_bytes(32));
+        $sha = base64_encode(hash('SHA256', base64_decode($key), true));
+        $object = $this->upload([
+            'metadata' => [
+                'kmsKeyName' => self::$keyName1
+            ]
+        ]);
+        $rewriteOptions = [
+            'name' => uniqid(self::TESTING_PREFIX),
+            'destinationEncryptionKey' => $key
+        ];
+        $rewrittenObject = $object->rewrite(self::$bucket, $rewriteOptions);
+
+        $this->assertEquals($sha, $rewrittenObject->info()['customerEncryption']['keySha256']);
+        $this->assertEquals(self::DATA, $rewrittenObject->downloadAsString());
+    }
+
+    /**
+     * @param array $options
+     * @return StorageObject
+     */
+    private function upload(array $options = [])
+    {
+        return self::$bucket->upload(self::DATA, $options + [
+            'name' => uniqid(self::TESTING_PREFIX),
+            'metadata' => [
+                'kmsKeyName' => self::$keyName1
+            ]
+        ]);
+    }
+
+    /**
+     * A helper to get KMS keys and set correct permissions.
+     *
+     * @param string $keyRingId
+     * @param string $cryptoKeyId1
+     * @param string $cryptoKeyId2
+     * @return array
+     */
+    private static function getKeyNames($keyRingId, $cryptoKeyId1, $cryptoKeyId2)
+    {
+        $keyNames = [];
+        $keyFilePath = getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH');
+        $wrapper = new RequestWrapper([
+            'keyFile' => json_decode(file_get_contents($keyFilePath), true),
+            'scopes' => ['https://www.googleapis.com/auth/cloud-platform']
+        ]);
+        $projectId = self::getProjectId($keyFilePath);
+
+        self::buildKeyRing($wrapper, $projectId, $keyRingId);
+        $keyNames[] = self::getCryptoKeyName($wrapper, $projectId, $keyRingId, $cryptoKeyId1);
+        $keyNames[] = self::getCryptoKeyName($wrapper, $projectId, $keyRingId, $cryptoKeyId2);
+
+        return $keyNames;
+    }
+
+    /**
+     * @param RequestWrapper $wrapper
+     * @param string $projectId
+     * @param string $keyRingId
+     */
+    private static function buildKeyRing(
+        RequestWrapper $wrapper,
+        $projectId,
+        $keyRingId
+    ) {
+        try {
+            $wrapper->send(
+                new Request(
+                    'POST',
+                    sprintf(
+                        'https://cloudkms.googleapis.com/v1/projects/%s/locations/global/keyRings?keyRingId=%s',
+                        $projectId,
+                        $keyRingId
+                    )
+                )
+            );
+        } catch (ConflictException $ex) {
+            // If it already exists, great!
+        }
+    }
+
+    /**
+     * @param RequestWrapper $wrapper
+     * @param string $projectId
+     * @param string $keyRingId
+     * @param string $cryptoKeyId
+     * @return string
+     */
+    private static function getCryptoKeyName(
+        RequestWrapper $wrapper,
+        $projectId,
+        $keyRingId,
+        $cryptoKeyId
+    ) {
+        $name = null;
+
+        try {
+            $response = $wrapper->send(
+                new Request(
+                    'POST',
+                    sprintf(
+                        'https://cloudkms.googleapis.com/v1/projects/%s/locations/global/keyRings/%s/cryptoKeys?cryptoKeyId=%s',
+                        $projectId,
+                        $keyRingId,
+                        $cryptoKeyId
+                    ),
+                    [],
+                    json_encode(['purpose' => 'ENCRYPT_DECRYPT'])
+                )
+            );
+
+            $name = json_decode((string) $response->getBody(), true)['name'];
+        } catch (ConflictException $ex) {
+            $name = sprintf(
+                'projects/%s/locations/global/keyRings/%s/cryptoKeys/%s',
+                $projectId,
+                $keyRingId,
+                $cryptoKeyId
+            );
+        }
+
+        $policy = [
+            'policy' => [
+                'bindings' => [
+                    [
+                        'role' => 'roles/cloudkms.cryptoKeyEncrypterDecrypter',
+                        'members' => [
+                            "serviceAccount:$projectId@gs-project-accounts.iam.gserviceaccount.com"
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $wrapper->send(
+            new Request(
+                'POST',
+                sprintf(
+                    'https://cloudkms.googleapis.com/v1/projects/%s/locations/global/keyRings/%s/cryptoKeys/%s:setIamPolicy',
+                    $projectId,
+                    $keyRingId,
+                    $cryptoKeyId
+                ),
+                [],
+                json_encode($policy)
+            )
+        );
+
+        return $name;
+    }
+}

--- a/Storage/tests/System/ManageNotificationsTest.php
+++ b/Storage/tests/System/ManageNotificationsTest.php
@@ -27,9 +27,7 @@ class ManageNotificationsTest extends StorageTestCase
     {
         $created = [];
         $topic = self::createTopic(self::$pubsubClient, uniqid(self::TESTING_PREFIX));
-        $keyFilePath = getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH');
-        $data = json_decode(file_get_contents($keyFilePath), true);
-        $projectId = $data['project_id'];
+        $projectId = self::getProjectId(getenv('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH'));
         $policy = $topic->iam()->policy();
         $policy['bindings'] = [
             [

--- a/Storage/tests/System/StorageTestCase.php
+++ b/Storage/tests/System/StorageTestCase.php
@@ -19,9 +19,9 @@ namespace Google\Cloud\Storage\Tests\System;
 
 use Google\Cloud\Core\AnonymousCredentials;
 use Google\Cloud\Core\Exception\NotFoundException;
+use Google\Cloud\Core\Testing\System\SystemTestCase;
 use Google\Cloud\PubSub\PubSubClient;
 use Google\Cloud\Storage\StorageClient;
-use Google\Cloud\Core\Testing\System\SystemTestCase;
 
 /**
  * Refer to README.md in this directory for some important information
@@ -62,5 +62,11 @@ class StorageTestCase extends SystemTestCase
         self::$object = self::$bucket->upload('somedata', ['name' => uniqid(self::TESTING_PREFIX)]);
 
         self::$hasSetUp = true;
+    }
+
+    protected static function getProjectId($keyFilePath)
+    {
+        $data = json_decode(file_get_contents($keyFilePath), true);
+        return $data['project_id'];
     }
 }

--- a/Storage/tests/System/StorageTestCase.php
+++ b/Storage/tests/System/StorageTestCase.php
@@ -58,7 +58,11 @@ class StorageTestCase extends SystemTestCase
         self::$pubsubClient = new PubSubClient($config);
 
         self::$mainBucketName = getenv('BUCKET') ?: uniqid(self::TESTING_PREFIX);
-        self::$bucket = self::createBucket(self::$client, self::$mainBucketName);
+        self::$bucket = self::createBucket(
+            self::$client,
+            self::$mainBucketName,
+            ['location' => 'us-west1']
+        );
         self::$object = self::$bucket->upload('somedata', ['name' => uniqid(self::TESTING_PREFIX)]);
 
         self::$hasSetUp = true;


### PR DESCRIPTION
With this change set users can now supply a KMS key name while uploading or rewriting objects in order to take advantage of the KMS service.

Example:

```php
$fileHandle = fopen(__DIR__ . '/image.jpg', 'r');
$object = $bucket->upload($fileHandle, [
    'metadata' => [
        'kmsKeyName' => 'projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key'
    ]
]);
```