### PR TITLE
Remove stray operator from system test

### DIFF
--- a/Logging/tests/System/ManageSinksTest.php
+++ b/Logging/tests/System/ManageSinksTest.php
@@ -79,7 +79,7 @@ class ManageSinksTest extends LoggingTestCase
     {
         self::setUpBeforeClass();
         $bucket = self::$bucket;
-        $bucket->acl()->add('group-cloud-logs@google.com', 'OWNER');-
+        $bucket->acl()->add('group-cloud-logs@google.com', 'OWNER');
         $bucketDest = sprintf('storage.googleapis.com/%s', $bucket->name());
         $datasetDest = sprintf(
             'bigquery.googleapis.com/projects/%s/datasets/%s',


### PR DESCRIPTION
The `-` causes a warning in PHP 7.1+.