### PR TITLE
Add Bigtable row buffer

### DIFF
--- a/Bigtable/src/V2/BigtableCellBuffer.php
+++ b/Bigtable/src/V2/BigtableCellBuffer.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Google\Cloud\Bigtable\V2;
+
+use Google\Cloud\Bigtable\V2\Exception\InvalidChunkException;
+
+class BigtableCellBuffer
+{
+    const NEW_CELL = 0;
+    const IN_PROGRESS = 1;
+    const COMPLETE = 2;
+
+    private $rowKey;
+    private $familyName;
+    private $columnName;
+    private $timestampMicros;
+    private $valueBuffer;
+    private $isCommitRowCell;
+    private $state;
+
+    public function __construct()
+    {
+        $this->rowKey = null;
+        $this->familyName = null;
+        $this->columnName = null;
+        $this->resetValueBuffer();
+    }
+
+    /**
+     * Merge a cell chunk into this buffer.
+     *
+     * @param ReadRowsResponse_CellChunk $chunk
+     *
+     * @throws InvalidChunkException if the chunk is invalid,
+     * or this buffer enters an inconsistent state.
+     */
+    public function merge($chunk)
+    {
+        $rowKey = $chunk->getRowKey();
+        $qualifier = $chunk->getQualifier();
+        $familyName = $chunk->getFamilyName();
+        $timestampMicros = $chunk->getTimestampMicros();
+
+        if (!is_null($rowKey) && $rowKey != '') {
+            $this->rowKey = $rowKey;
+        };
+
+        if (!is_null($qualifier)) {
+            InvalidChunkException::assert($this->state === self::NEW_CELL);
+            $this->columnName = $qualifier->getValue();
+        };
+
+        if (!is_null($familyName)) {
+            InvalidChunkException::assert($this->state === self::NEW_CELL);
+            $this->familyName = $familyName->getValue();
+        };
+
+        if ($timestampMicros != 0) {
+            InvalidChunkException::assert($this->state === self::NEW_CELL);
+            $this->timestampMicros = $timestampMicros;
+        }
+
+        $this->valueBuffer .= $chunk->getValue();
+
+        if ($chunk->getCommitRow()) {
+            $this->validateCommitRowChunk($chunk);
+            $this->isCommitRowCell = true;
+        };
+
+        if ($chunk->getValueSize() === 0) {
+            $this->validateCellComplete();
+            $this->state = self::COMPLETE;
+        } else {
+            $this->state = self::IN_PROGRESS;
+        }
+    }
+
+    /**
+     * Return a Cell representation of this buffer.
+     *
+     * @returns Cell $chunk
+     *
+     * @throws \RuntimeException if this buffer is not complete.
+     */
+    public function asCell()
+    {
+        $cell = new Cell();
+        $cell->setTimestampMicros($this->timestampMicros);
+        $cell->setValue($this->getValue());
+
+        return $cell;
+    }
+
+    /**
+     * Reset the current value state, but keep the current
+     * row/column/column family context.
+     */
+    public function resetValueBuffer()
+    {
+        $this->valueBuffer = '';
+        $this->timestampMicros = 0;
+        $this->isCommitRowCell = false;
+        $this->state = self::NEW_CELL;
+    }
+
+    /**
+     * @param ReadRowsResponse_CellChunk $chunk
+     *
+     * @throws InvalidChunkException
+     */
+    private function validateCommitRowChunk($chunk)
+    {
+        InvalidChunkException::assert($chunk->getValueSize() === 0);
+    }
+
+    /**
+     * @param ReadRowsResponse_CellChunk $chunk
+     *
+     * @throws InvalidChunkException
+     */
+    private function validateCellComplete()
+    {
+        InvalidChunkException::assert(!is_null($this->familyName));
+        InvalidChunkException::assert(!is_null($this->columnName));
+    }
+
+    public function getRowKey()
+    {
+        return $this->rowKey;
+    }
+
+    public function getFamilyName()
+    {
+        return $this->familyName;
+    }
+
+    public function getColumnName()
+    {
+        return $this->columnName;
+    }
+
+    public function getValue()
+    {
+        if ($this->state != self::COMPLETE) {
+            throw new \RuntimeException("Attempted to read incomplete cell value");
+        }
+        return $this->valueBuffer;
+    }
+
+    public function getIsCommitRowCell()
+    {
+        return $this->isCommitRowCell;
+    }
+
+    public function getState()
+    {
+        return $this->state;
+    }
+}

--- a/Bigtable/src/V2/BigtableReadRowsBuffer.php
+++ b/Bigtable/src/V2/BigtableReadRowsBuffer.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Google\Cloud\Bigtable\V2;
+
+use Google\Cloud\Bigtable\V2\Exception\InvalidChunkException;
+use Google\ApiCore\ServerStream;
+
+class BigtableReadRowsBuffer
+{
+    /**
+     * @var BigtableRowBuffer
+     */
+    private $rowBuffer;
+
+    /**
+     * @var BigtableCellBuffer
+     */
+    private $cellBuffer;
+
+    public function __construct()
+    {
+        $this->reset();
+    }
+
+    private function reset()
+    {
+        $this->rowBuffer = new BigtableRowBuffer();
+        $this->cellBuffer = new BigtableCellBuffer();
+    }
+
+    /**
+     * Ensure that the chunk is a valid reset row chunk.
+     *
+     * @param ReadRowsResponse_CellChunk $chunk
+     *
+     * @throws InvalidChunkException if the chunk is invalid
+     */
+    private function validateResetRowChunk($chunk)
+    {
+        InvalidChunkException::assert($chunk->getRowKey() === '');
+        InvalidChunkException::assert(is_null($chunk->getFamilyName()));
+        InvalidChunkException::assert(is_null($chunk->getQualifier()));
+        InvalidChunkException::assert($chunk->getLabels()->count() === 0);
+        InvalidChunkException::assert($chunk->getValueSize() === 0);
+        InvalidChunkException::assert($chunk->getValue() === '');
+    }
+
+    /**
+     * Read the cell chunks, yielding rows as they complete.
+     *
+     * @param ReadRowsResponse_CellChunk[] $chunks
+     *
+     * @return \Generator of BigtableRowBuffer
+     *
+     * @throws InvalidChunkException if the stream reaches an inconsistent state
+     */
+    public function consumeCellChunks($chunks)
+    {
+        foreach ($chunks as $chunk) {
+            if ($chunk->getResetRow()) {
+                $this->validateResetRowChunk($chunk);
+                $this->reset();
+                continue;
+            };
+
+            $this->cellBuffer->merge($chunk);
+
+            if ($this->cellBuffer->getState() === BigtableCellBuffer::COMPLETE) {
+                $this->rowBuffer->merge($this->cellBuffer);
+            }
+
+            if ($this->rowBuffer->getState() === BigtableRowBuffer::COMPLETE) {
+                yield $this->rowBuffer;
+                $this->reset();
+            }
+        };
+    }
+
+    /**
+     * @param ServerStream $stream stream of ReadRowsResponse to consume
+     *
+     * @return \Generator of BigtableRowBuffer
+     *
+     * @throws InvalidChunkException if the stream reaches an inconsistent state
+     */
+    public function consumeStream(ServerStream $stream)
+    {
+        foreach ($stream->readAll() as $response) {
+            $this->consumeCellChunks($response->getChunks());
+        }
+    }
+}

--- a/Bigtable/src/V2/BigtableRowBuffer.php
+++ b/Bigtable/src/V2/BigtableRowBuffer.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Google\Cloud\Bigtable\V2;
+
+use Google\Cloud\Bigtable\V2\Exception\InvalidChunkException;
+
+class BigtableRowBuffer
+{
+    const NEW_ROW = 0;
+    const IN_PROGRESS = 1;
+    const COMPLETE = 2;
+
+    private $rowKey;
+    private $cells;
+    private $state;
+
+    public function __construct()
+    {
+        $this->rowKey = null;
+        $this->cells = [];
+        $this->state = self::NEW_ROW;
+    }
+
+    /**
+     * Merge a cell buffer into this buffer.
+     *
+     * @param BigtableCellBuffer $cellBuffer
+     *
+     * @throws InvalidChunkException if this buffer enters an inconsistent state.
+     */
+    public function merge($cellBuffer)
+    {
+        $familyName = $cellBuffer->getFamilyName();
+        $columnName = $cellBuffer->getColumnName();
+
+        if (!array_key_exists($familyName, $this->cells)) {
+            $this->cells[$familyName] = [];
+        };
+
+        $family = $this->cells[$familyName];
+        if (!array_key_exists($columnName, $family)) {
+            $family[$columnName] = [];
+        };
+
+        if ($this->state === self::IN_PROGRESS) {
+            InvalidChunkException::assert($cellBuffer->getRowKey() === $this->rowKey);
+        } else {
+            $this->rowKey = $cellBuffer->getRowKey();
+        };
+
+        $this->cells[$familyName][$columnName][] = $cellBuffer->asCell();
+
+        if ($cellBuffer->getIsCommitRowCell()) {
+            $this->state = self::COMPLETE;
+        } else {
+            $this->state = self::IN_PROGRESS;
+        }
+
+        $cellBuffer->resetValueBuffer();
+    }
+
+    public function getRowKey()
+    {
+        return $this->rowKey;
+    }
+
+    /**
+     * @return array An associative array where the top-level keys
+     * are column family names, the second-level keys are column names,
+     * and the values are Cells.
+     */
+    public function getCells()
+    {
+        if ($this->state != self::COMPLETE) {
+            throw new RuntimeException("Attempted to read incomplete row");
+        };
+        return $this->cells;
+    }
+
+    public function getState()
+    {
+        return $this->state;
+    }
+}

--- a/Bigtable/src/V2/Exception/InvalidChunkException.php
+++ b/Bigtable/src/V2/Exception/InvalidChunkException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Google\Cloud\Bigtable\V2\Exception;
+
+class InvalidChunkException extends \RuntimeException
+{
+    public static function assert($predicate, $message = "")
+    {
+        if (!$predicate) {
+            throw new InvalidChunkException($message);
+        };
+    }
+}

--- a/Bigtable/tests/Unit/BigtableReadRowsBufferTest.php
+++ b/Bigtable/tests/Unit/BigtableReadRowsBufferTest.php
@@ -1,0 +1,368 @@
+<?php
+
+namespace Google\Cloud\Bigtable\Tests\Unit;
+
+use \Google\Cloud\Bigtable\V2\ReadRowsResponse_CellChunk;
+use \Google\Cloud\Bigtable\V2\BigtableReadRowsBuffer;
+use \Google\Protobuf\StringValue;
+use \Google\Protobuf\BytesValue;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group bigtable
+ */
+class BigtableReadRowsBufferTest extends TestCase
+{
+    public function setupCellChunk($args)
+    {
+        $cellChunk = new ReadRowsResponse_CellChunk();
+
+        if (array_key_exists('row_key', $args)) {
+            $cellChunk->setRowKey($args['row_key']);
+        }
+
+        if (array_key_exists('family_name', $args)) {
+            $familyNameStringValue = new StringValue();
+            $familyNameStringValue->setValue($args['family_name']);
+            $cellChunk->setFamilyName($familyNameStringValue);
+        }
+
+        if (array_key_exists('col_name', $args)) {
+            $colNameBytesValue = new BytesValue();
+            $colNameBytesValue->setValue($args['col_name']);
+            $cellChunk->setQualifier($colNameBytesValue);
+        }
+
+        if (array_key_exists('timestamp', $args)) {
+            $cellChunk->setTimestampMicros($args['timestamp']);
+        }
+
+        if (array_key_exists('value', $args)) {
+            $cellChunk->setValue($args['value']);
+        }
+
+        if (array_key_exists('commit_row', $args)) {
+            $cellChunk->setCommitRow($args['commit_row']);
+        }
+
+        if (array_key_exists('value_size', $args)) {
+            $cellChunk->setValueSize($args['value_size']);
+        }
+
+        if (array_key_exists('reset_row', $args)) {
+            $cellChunk->setResetRow($args['reset_row']);
+        }
+
+        return $cellChunk;
+    }
+
+    public function assertColumnSingleCellValue(
+        $rowData,
+        $familyName,
+        $colName,
+        $expectedVal,
+        $expectedTimestamp = 0
+    ) {
+
+        $cells = $rowData->getCells()[$familyName][$colName];
+        $this->assertCount(1, $cells);
+        $this->assertEquals($expectedVal, $cells[0]->getValue());
+        $this->assertEquals($expectedTimestamp, $cells[0]->getTimestampMicros());
+    }
+
+    public function consumeSingleRow($chunks)
+    {
+        $buffer = new BigtableReadRowsBuffer();
+        $rows = $buffer->consumeCellChunks($chunks);
+        $rowArray = iterator_to_array($rows);
+        $this->assertCount(1, $rowArray);
+        return $rowArray[0];
+    }
+
+    public function testConsumeSingleCellChunk()
+    {
+        $cellChunk = $this->setupCellChunk(
+            [
+            'value' => 'val1',
+            'row_key' => 'key1',
+            'family_name' => 'family1',
+            'col_name' => 'col1',
+            'timestamp' => 1000
+            ]
+        );
+
+        $cellChunk->setCommitRow(true);
+
+        $row = $this->consumeSingleRow([$cellChunk]);
+
+        $this->assertEquals($row->getRowKey(), 'key1');
+        $this->assertColumnSingleCellValue($row, 'family1', 'col1', 'val1', 1000);
+    }
+
+    public function testConsumeSingleValueMultipleChunks()
+    {
+        $val1 = 'hello';
+        $val2 = 'world';
+        $finalVal = $val1.$val2;
+
+        $chunk1 = $this->setupCellChunk(
+            [
+            'value' => $val1,
+            'row_key' => 'key1',
+            'family_name' => 'family1',
+            'col_name' => 'col1',
+            'timestamp' => 1000,
+            'valueSize' => strlen($finalVal)
+            ]
+        );
+
+        $chunk1->setValueSize(strlen($finalVal));
+        $chunk2 = $this->setupCellChunk(['value' => $val2, 'commit_row' => true]);
+
+        $row = $this->consumeSingleRow([$chunk1, $chunk2]);
+
+        $this->assertEquals($row->getRowKey(), 'key1');
+        $this->assertColumnSingleCellValue($row, 'family1', 'col1', $finalVal, 1000);
+    }
+
+    public function testConsumeMultipleColumns()
+    {
+        $chunk1 = $this->setupCellChunk(
+            [
+            'value' => 'val1',
+            'row_key' => 'key1',
+            'family_name' => 'family1',
+            'col_name' => 'col1',
+            'timestamp' => 1000
+            ]
+        );
+
+        $chunk2 = $this->setupCellChunk(
+            [
+            'value' => 'val2',
+            'col_name' => 'col2',
+            'timestamp' => 1000,
+            'commit_row' => true
+            ]
+        );
+
+        $row = $this->consumeSingleRow([$chunk1, $chunk2]);
+
+        $this->assertEquals($row->getRowKey(), 'key1');
+        $this->assertCount(1, $row->getCells());
+
+        $this->assertColumnSingleCellValue($row, 'family1', 'col1', 'val1', 1000);
+        $this->assertColumnSingleCellValue($row, 'family1', 'col2', 'val2', 1000);
+    }
+
+    public function testConsumeMultipleColumnFamilies()
+    {
+        $chunk1 = $this->setupCellChunk(
+            [
+            'value' => 'val1',
+            'row_key' => 'key1',
+            'family_name' => 'family1',
+            'col_name' => 'col1',
+            'timestamp' => 1000
+            ]
+        );
+
+        $chunk2 = $this->setupCellChunk(
+            [
+            'value' => 'val2',
+            'family_name' => 'family2',
+            'col_name' => 'col2',
+            'timestamp' => 1000,
+            'commit_row' => true
+            ]
+        );
+
+        $row = $this->consumeSingleRow([$chunk1, $chunk2]);
+
+        $this->assertEquals($row->getRowKey(), 'key1');
+        $this->assertCount(2, $row->getCells());
+
+        $this->assertColumnSingleCellValue($row, 'family1', 'col1', 'val1', 1000);
+        $this->assertColumnSingleCellValue($row, 'family2', 'col2', 'val2', 1000);
+    }
+
+    public function testConsumeMultipleCells()
+    {
+        $chunk1 = $this->setupCellChunk(
+            [
+            'value' => 'val1',
+            'row_key' => 'key1',
+            'family_name' => 'family1',
+            'col_name' => 'col1',
+            'timestamp' => 1000
+            ]
+        );
+
+        $chunk2 = $this->setupCellChunk(
+            [
+            'value' => 'val2',
+            'timestamp' => 2000,
+            'commit_row' => true
+            ]
+        );
+
+        $row = $this->consumeSingleRow([$chunk1, $chunk2]);
+
+        $this->assertEquals($row->getRowKey(), 'key1');
+        $this->assertCount(1, $row->getCells());
+
+        $cells = $row->getCells()['family1']['col1'];
+
+        $this->assertCount(2, $cells);
+
+        $this->assertEquals('val1', $cells[0]->getValue());
+        $this->assertEquals(1000, $cells[0]->getTimestampMicros());
+
+        $this->assertEquals('val2', $cells[1]->getValue());
+        $this->assertEquals(2000, $cells[1]->getTimestampMicros());
+    }
+
+    public function testResetRow()
+    {
+        $chunk1 = $this->setupCellChunk(
+            [
+            'value' => 'val1',
+            'row_key' => 'key1',
+            'family_name' => 'family1',
+            'col_name' => 'col1',
+            'timestamp' => 1000
+            ]
+        );
+
+        $chunk2 = $this->setupCellChunk(
+            [
+            'value' => 'val2',
+            'col_name' => 'col2',
+            'timestamp' => 1000
+            ]
+        );
+
+
+        $chunk3 = $this->setupCellChunk(['reset_row' => true]);
+
+        $chunk4 = $this->setupCellChunk(
+            [
+            'value' => 'val3',
+            'row_key' => 'key1',
+            'family_name' => 'family1',
+            'col_name' => 'col1',
+            'timestamp' => 1000
+            ]
+        );
+
+        $chunk5 = $this->setupCellChunk(
+            [
+            'value' => 'val4',
+            'col_name' => 'col2',
+            'timestamp' => 1000,
+            'commit_row' => true
+            ]
+        );
+
+        $row = $this->consumeSingleRow([$chunk1, $chunk2, $chunk3, $chunk4, $chunk5]);
+
+        $this->assertEquals($row->getRowKey(), 'key1');
+        $this->assertCount(1, $row->getCells());
+
+        $this->assertColumnSingleCellValue($row, 'family1', 'col1', 'val3', 1000);
+        $this->assertColumnSingleCellValue($row, 'family1', 'col2', 'val4', 1000);
+    }
+
+    /**
+     * @expectedException Google\Cloud\Bigtable\V2\Exception\InvalidChunkException
+     */
+    public function testRaisesOnNewRowKeyInRow()
+    {
+        $chunk1 = $this->setupCellChunk(
+            [
+            'value' => 'val1',
+            'row_key' => 'key1',
+            'family_name' => 'family1',
+            'col_name' => 'col1',
+            'timestamp' => 1000
+            ]
+        );
+
+        $chunk2 = $this->setupCellChunk(
+            [
+            'value' => 'val2',
+            'row_key' => 'key2',
+            'family_name' => 'family1',
+            'col_name' => 'col1',
+            'timestamp' => 1000,
+            'commit_row' => true
+            ]
+        );
+
+        $chunk2->setCommitRow(true);
+        $row = $this->consumeSingleRow([$chunk1, $chunk2]);
+    }
+
+    /**
+     * @expectedException Google\Cloud\Bigtable\V2\Exception\InvalidChunkException
+     */
+    public function testRaisesOnNewColumnInCell()
+    {
+        $chunk1 = $this->setupCellChunk(
+            [
+            'value' => 'val1',
+            'row_key' => 'key1',
+            'family_name' => 'family1',
+            'col_name' => 'col1',
+            'timestamp' => 1000,
+            'value_size' => 10
+            ]
+        );
+
+        $chunk2 = $this->setupCellChunk(
+            [
+            'value' => 'val2',
+            'col_name' => 'col2',
+            'timestamp' => 1000,
+            'commit_row' => true
+            ]
+        );
+
+        $row = $this->consumeSingleRow([$chunk1, $chunk2]);
+    }
+
+    /**
+     * @expectedException Google\Cloud\Bigtable\V2\Exception\InvalidChunkException
+     */
+    public function testRaisesOnResetRowWithValues()
+    {
+        $chunk1 = $this->setupCellChunk(
+            [
+            'value' => 'val1',
+            'reset_row' => true
+            ]
+        );
+
+        $buffer = new BigtableReadRowsBuffer();
+        $rows = $buffer->consumeCellChunks([$chunk1]);
+        iterator_to_array($rows);
+    }
+
+    /**
+     * @expectedException Google\Cloud\Bigtable\V2\Exception\InvalidChunkException
+     */
+    public function testRaisesOnCommitRowWithValueSize()
+    {
+        $chunk1 = $this->setupCellChunk(
+            [
+            'value' => 'val1',
+            'value_size' => 10,
+            'commit_row' => true
+            ]
+        );
+
+        $buffer = new BigtableReadRowsBuffer();
+        $rows = $buffer->consumeCellChunks([$chunk1]);
+        iterator_to_array($rows);
+    }
+}


### PR DESCRIPTION
This adds a higher-level wrapper around the Bigtable gRPC API for reading rows - the `BigtableReadRowsBuffer` consumes the streaming result of a Bigtable row read request and yields rows as they are consumed.

It wasn't clear to me if there was work currently in-flight for this. Please let me know if there's a more appropriate way to contribute. Thanks!