### PR TITLE
Add support for PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_script:
   - pecl install grpc || echo 'Failed to install grpc'
   - if [[ $TRAVIS_PHP_VERSION =~ ^7 ]]; then pecl install stackdriver_debugger-alpha || echo 'Failed to install stackdriver_debugger'; fi
   - composer install
+  - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then composer --no-interaction --dev remove phpunit/phpunit; composer require --dev phpunit/phpunit:^5.7; fi
   - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then composer --no-interaction --dev remove google/protobuf google/gax google/proto-client; fi
   - dev/google-cloud credentials
 

--- a/BigQuery/composer.json
+++ b/BigQuery/composer.json
@@ -8,7 +8,7 @@
         "ramsey/uuid": "~3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6",

--- a/BigQuery/phpunit-snippets.xml.dist
+++ b/BigQuery/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/BigQuery/phpunit-system.xml.dist
+++ b/BigQuery/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/BigQuery/phpunit.xml.dist
+++ b/BigQuery/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/BigQuery/tests/Snippet/JobTest.php
+++ b/BigQuery/tests/Snippet/JobTest.php
@@ -99,6 +99,9 @@ class JobTest extends SnippetTestCase
         $this->assertInstanceOf(QueryResults::class, $res->returnVal());
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testWaitUntilComplete()
     {
         $job = $this->getJob($this->connection, [
@@ -106,6 +109,7 @@ class JobTest extends SnippetTestCase
                 'state' => 'DONE'
             ]
         ]);
+
         $snippet = $this->snippetFromMethod(Job::class, 'waitUntilComplete');
         $snippet->addLocal('job', $job);
         $snippet->invoke();

--- a/BigQuery/tests/Snippet/QueryResultsTest.php
+++ b/BigQuery/tests/Snippet/QueryResultsTest.php
@@ -90,6 +90,9 @@ class QueryResultsTest extends SnippetTestCase
         $this->assertEquals('abcd', trim($res->output()));
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testWaitUntilComplete()
     {
         $snippet = $this->snippetFromMethod(QueryResults::class, 'waitUntilComplete');

--- a/BigQuery/tests/System/ManageJobsTest.php
+++ b/BigQuery/tests/System/ManageJobsTest.php
@@ -56,6 +56,9 @@ class ManageJobsTest extends BigQueryTestCase
         $this->assertFalse(self::$client->job('not_a_job')->exists());
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testCancelsJob()
     {
         $query = self::$client->query(sprintf(

--- a/BigQueryDataTransfer/composer.json
+++ b/BigQueryDataTransfer/composer.json
@@ -21,7 +21,7 @@
         "google/gax": "^0.31.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "google/cloud-core": "^1.14",
         "phpdocumentor/reflection": "^3.0"
     },

--- a/BigQueryDataTransfer/phpunit-snippets.xml.dist
+++ b/BigQueryDataTransfer/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/BigQueryDataTransfer/phpunit-system.xml.dist
+++ b/BigQueryDataTransfer/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/BigQueryDataTransfer/phpunit.xml.dist
+++ b/BigQueryDataTransfer/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Bigtable/composer.json
+++ b/Bigtable/composer.json
@@ -8,7 +8,7 @@
         "google/gax": "^0.31.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "google/cloud-core": "^1.14",
         "phpdocumentor/reflection": "^3.0"
     },

--- a/Bigtable/phpunit-snippets.xml.dist
+++ b/Bigtable/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Bigtable/phpunit-system.xml.dist
+++ b/Bigtable/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Bigtable/phpunit.xml.dist
+++ b/Bigtable/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Container/composer.json
+++ b/Container/composer.json
@@ -21,7 +21,7 @@
         "google/gax": "^0.31.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "google/cloud-core": "^1.14",
         "phpdocumentor/reflection": "^3.0"
     }

--- a/Container/phpunit-snippets.xml.dist
+++ b/Container/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Container/phpunit-system.xml.dist
+++ b/Container/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Container/phpunit.xml.dist
+++ b/Container/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Core/composer.json
+++ b/Core/composer.json
@@ -13,7 +13,7 @@
         "psr/http-message": "1.0.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6",

--- a/Core/phpunit-snippets.xml.dist
+++ b/Core/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Core/phpunit-system.xml.dist
+++ b/Core/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Core/phpunit.xml.dist
+++ b/Core/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Core/src/Batch/HandleFailureTrait.php
+++ b/Core/src/Batch/HandleFailureTrait.php
@@ -49,7 +49,7 @@ trait HandleFailureTrait
                 sys_get_temp_dir()
             );
         }
-        if (! is_dir($this->baseDir)) {
+        if (!is_dir($this->baseDir)) {
             if (@mkdir($this->baseDir, 0700, true) === false) {
                 throw new \RuntimeException(
                     sprintf(

--- a/Core/src/Testing/ExpectExceptionTrait.php
+++ b/Core/src/Testing/ExpectExceptionTrait.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Core\Testing;
+
+/**
+ * Provides methods for configuring exception expectations across multiple
+ * incompatible versions of PHPUnit.
+ */
+trait ExpectExceptionTrait
+{
+    /**
+     * Setup exception expectations for PHPUnit across major versions.
+     *
+     * @param $class string The exception class name. If the class does not
+     *        exist, and the name contains "PHPUnit", the method will predict
+     *        the counterpart method name. i.e. `\PHPUnit_Framework_Error_Warning`
+     *        will be converted to `\PHPUnit\Framework\Error\Warning`, and vice
+     *        versa. If neither exists, an error will be thrown.
+     * @param string|null $message [optional] The exception message. If given,
+     *        the message given must match the thrown exception message.
+     * @return void
+     * @throws \InvalidArgumentException If the class does not exist.
+     */
+    private function expectsException($class, $message = null)
+    {
+        if (!class_exists($class)) {
+            $alternative = null;
+
+            if (strpos($class, 'PHPUnit') !== false) {
+                $class = trim($class, '_\\');
+                if (strpos($class, '\\') !== false) {
+                    $alternative = str_replace('\\', '_', $class);
+                } else {
+                    $alternative = str_replace('_', '\\', $class);
+                }
+            }
+
+            if ($alternative === null || !class_exists($alternative)) {
+                $msg = 'Class `%s`';
+                if ($alternative) {
+                    $msg .= ' and predicted variant `%s`';
+                }
+                $msg .= ' do not exist.';
+
+                throw new \InvalidArgumentException(sprintf(
+                    $msg,
+                    $class,
+                    $alternative
+                ));
+            }
+
+            $class = $alternative;
+        }
+
+        if (method_exists($this, 'setExpectedException')) {
+            $this->setExpectedException($class, $message);
+        } else {
+            $this->expectException($class);
+            if ($message) {
+                $this->expectExceptionMessage($message);
+            }
+        }
+    }
+}

--- a/Core/src/Testing/Snippet/Coverage/ResultPrinter.php
+++ b/Core/src/Testing/Snippet/Coverage/ResultPrinter.php
@@ -18,6 +18,13 @@
 namespace Google\Cloud\Core\Testing\Snippet\Coverage;
 
 use Google\Cloud\Core\Testing\Snippet\Container;
+use PHPUnit\Framework\TestResult;
+use PHPUnit\TextUI\ResultPrinter as PHPUnitResultPrinter;
+
+if (!class_exists(PHPUnitResultPrinter::class)) {
+    class_alias(\PHPUnit_TextUI_ResultPrinter::class, PHPUnitResultPrinter::class);
+    class_alias(\PHPUnit_Framework_TestResult::class, TestResult::class);
+}
 
 /**
  * Augments the PHPUnit test run report with snippet info.
@@ -27,7 +34,7 @@ use Google\Cloud\Core\Testing\Snippet\Container;
  * @experimental
  * @internal
  */
-class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter
+class ResultPrinter extends PHPUnitResultPrinter
 {
     /**
      * Show snippet results.
@@ -37,10 +44,9 @@ class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter
      * @experimental
      * @internal
      */
-    public function printResult(\PHPUnit_Framework_TestResult $result)
+    public function printResult(TestResult $result)
     {
         parent::printResult($result);
-
         $uncovered = Container::$coverage->uncovered();
         Container::reset();
 

--- a/Core/tests/Unit/Batch/HandleFailureTraitTest.php
+++ b/Core/tests/Unit/Batch/HandleFailureTraitTest.php
@@ -58,16 +58,6 @@ class HandleFailureTraitTest extends TestCase
         putenv('GOOGLE_CLOUD_BATCH_DAEMON_FAILURE_DIR');
     }
 
-    /**
-     * @ExpectedException \RuntimeException
-     */
-    public function testInitFailureFileThrowsException()
-    {
-        putenv(
-            'GOOGLE_CLOUD_BATCH_DAEMON_FAILURE_DIR=/tmp/non-existent/subdir');
-        $this->impl->initFailureFile();
-    }
-
     public function testInitFailureFile()
     {
         $this->impl->initFailureFile();

--- a/Core/tests/Unit/CallTraitTest.php
+++ b/Core/tests/Unit/CallTraitTest.php
@@ -18,13 +18,18 @@
 namespace Google\Cloud\Core\Tests\Unit;
 
 use Google\Cloud\Core\CallTrait;
+use Google\Cloud\Core\Testing\ExpectExceptionTrait;
+use PHPUnit\Framework\Error\Error;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
+ * @group core-calltrait
  */
 class CallTraitTest extends TestCase
 {
+    use ExpectExceptionTrait;
+
     public function testCall()
     {
         $t = new CallTraitStub(['foo' => 'bar']);
@@ -32,11 +37,10 @@ class CallTraitTest extends TestCase
         $this->assertEquals('bar', $t->foo());
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error
-     */
     public function testErr()
     {
+        $this->expectsException(Error::class);
+
         $t = new CallTraitStub(['foo' => 'bar']);
 
         $t->bar();

--- a/Core/tests/Unit/ServicesNotFoundTest.php
+++ b/Core/tests/Unit/ServicesNotFoundTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
+ * @group core-services
  */
 class ServicesNotFoundTest extends TestCase
 {
@@ -104,10 +105,18 @@ class ServicesNotFoundTest extends TestCase
      */
     public function testServicesNotFound($method)
     {
-        $this->setExpectedException(\Exception::class, sprintf(
+        $exception = \Exception::class;
+        $message = sprintf(
             'The google/cloud-%s package is missing and must be installed.',
             strtolower($method)
-        ));
+        );
+
+        if (method_exists($this, 'setExpectedException')) {
+            $this->setExpectedException($exception, $message);
+        } else {
+            $this->expectException($exception);
+            $this->expectExceptionMessage($message);
+        }
 
         self::$cloud->$method();
     }

--- a/Core/tests/Unit/ValidateTraitTest.php
+++ b/Core/tests/Unit/ValidateTraitTest.php
@@ -32,6 +32,9 @@ class ValidateTraitTest extends TestCase
         $this->stub = new ValidateTraitStub;
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testValidateBatch()
     {
         $input = [

--- a/Dataproc/composer.json
+++ b/Dataproc/composer.json
@@ -21,7 +21,7 @@
         "google/gax": "^0.31.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "google/cloud-core": "^1.14",
         "phpdocumentor/reflection": "^3.0"
     },

--- a/Dataproc/phpunit-snippets.xml.dist
+++ b/Dataproc/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Dataproc/phpunit-system.xml.dist
+++ b/Dataproc/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Dataproc/phpunit.xml.dist
+++ b/Dataproc/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Datastore/composer.json
+++ b/Datastore/composer.json
@@ -7,7 +7,7 @@
         "google/cloud-core": "^1.14"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6"

--- a/Datastore/phpunit-snippets.xml.dist
+++ b/Datastore/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Datastore/phpunit-system.xml.dist
+++ b/Datastore/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Datastore/phpunit.xml.dist
+++ b/Datastore/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Datastore/tests/Unit/DatastoreSessionHandlerTest.php
+++ b/Datastore/tests/Unit/DatastoreSessionHandlerTest.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\Datastore\Tests\Unit;
 
 
 use Exception;
+use Google\Cloud\Core\Testing\ExpectExceptionTrait;
 use Google\Cloud\Datastore\DatastoreClient;
 use Google\Cloud\Datastore\DatastoreSessionHandler;
 use Google\Cloud\Datastore\Entity;
@@ -26,14 +27,17 @@ use Google\Cloud\Datastore\Key;
 use Google\Cloud\Datastore\Query\Query;
 use Google\Cloud\Datastore\Transaction;
 use InvalidArgumentException;
-use Prophecy\Argument;
+use PHPUnit\Framework\Error\Warning;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 
 /**
  * @group datastore
  */
 class DatastoreSessionHandlerTest extends TestCase
 {
+    use ExpectExceptionTrait;
+
     const KIND = 'PHPSESSID';
     const NAMESPACE_ID = 'sessions';
 
@@ -118,11 +122,10 @@ class DatastoreSessionHandlerTest extends TestCase
         $this->assertEquals('', $ret);
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Warning
-     */
     public function testReadWithException()
     {
+        $this->expectsException(Warning::class);
+
         $this->datastore->transaction()
             ->shouldBeCalledTimes(1)
             ->willReturn($this->transaction->reveal());
@@ -211,11 +214,10 @@ class DatastoreSessionHandlerTest extends TestCase
         $this->assertTrue($ret);
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Warning
-     */
     public function testWriteWithException()
     {
+        $this->expectsException(Warning::class);
+
         $data = 'sessiondata';
         $key = new Key('projectid');
         $key->pathElement(self::KIND, 'sessionid');
@@ -402,11 +404,10 @@ class DatastoreSessionHandlerTest extends TestCase
         $this->assertTrue($ret);
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Warning
-     */
     public function testDestroyWithException()
     {
+        $this->expectsException(Warning::class);
+
         $key = new Key('projectid');
         $key->pathElement(self::KIND, 'sessionid');
         $this->transaction->delete($key)
@@ -522,11 +523,10 @@ class DatastoreSessionHandlerTest extends TestCase
         $this->assertTrue($ret);
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Warning
-     */
     public function testGcWithException()
     {
+        $this->expectsException(Warning::class);
+
         $key1 = new Key('projectid');
         $key1->pathElement(self::KIND, 'sessionid1');
         $key2 = new Key('projectid');

--- a/Datastore/tests/Unit/OperationTest.php
+++ b/Datastore/tests/Unit/OperationTest.php
@@ -524,7 +524,9 @@ class OperationTest extends TestCase
 
     public function testRunQueryWithReadOptionsFromTransaction()
     {
-        $this->connection->runQuery(Argument::withKey('readOptions'))->willReturn([]);
+        $this->connection->runQuery(Argument::withKey('readOptions'))
+            ->shouldBeCalled()
+            ->willReturn([]);
 
         $this->operation->___setProperty('connection', $this->connection->reveal());
 
@@ -538,7 +540,9 @@ class OperationTest extends TestCase
 
     public function testRunQueryWithReadOptionsFromReadConsistency()
     {
-        $this->connection->runQuery(Argument::withKey('readOptions'))->willReturn([]);
+        $this->connection->runQuery(Argument::withKey('readOptions'))
+            ->shouldBeCalled()
+            ->willReturn([]);
 
         $this->operation->___setProperty('connection', $this->connection->reveal());
 
@@ -554,7 +558,7 @@ class OperationTest extends TestCase
     {
         $this->connection->runQuery(Argument::that(function ($args) {
             return !isset($args['readOptions']);
-        }))->willReturn([]);
+        }))->shouldBeCalled()->willReturn([]);
 
         $this->operation->___setProperty('connection', $this->connection->reveal());
 
@@ -687,7 +691,7 @@ class OperationTest extends TestCase
     {
         $this->connection->commit(Argument::that(function ($arg) {
             return $arg['mutations'][0]['baseVersion'] === 1;
-        }))->willReturn('foo');
+        }))->shouldBeCalled()->willReturn('foo');
 
         $this->operation->___setProperty('connection', $this->connection->reveal());
 
@@ -707,7 +711,7 @@ class OperationTest extends TestCase
             if (!isset($arg['mutations'][0]['delete']['path'])) return false;
 
             return true;
-        }))->willReturn('foo');
+        }))->shouldBeCalled()->willReturn('foo');
 
         $this->operation->___setProperty('connection', $this->connection->reveal());
 
@@ -730,7 +734,7 @@ class OperationTest extends TestCase
     public function testCheckOverwrite()
     {
         $e = $this->prophesize(Entity::class);
-        $e->populatedByService()->willReturn(true);
+        $e->populatedByService()->shouldBeCalled()->willReturn(true);
 
         $this->operation->checkOverwrite([$e->reveal()]);
     }
@@ -738,7 +742,7 @@ class OperationTest extends TestCase
     public function testCheckOverwriteWithFlagEnabled()
     {
         $e = $this->prophesize(Entity::class);
-        $e->populatedByService()->willReturn(false);
+        $e->populatedByService()->shouldBeCalled()->willReturn(false);
 
         $this->operation->checkOverwrite([$e->reveal()], true);
     }
@@ -845,8 +849,7 @@ class OperationTest extends TestCase
     {
         $this->connection->lookup(Argument::that(function ($arg) {
             return isset($arg['readOptions']['transaction']);
-        }))
-            ->willReturn([]);
+        }))->shouldBeCalled()->willReturn([]);
 
         $this->operation->___setProperty('connection', $this->connection->reveal());
 
@@ -860,8 +863,7 @@ class OperationTest extends TestCase
     {
         $this->connection->lookup(Argument::that(function ($arg) {
             return !isset($arg['readOptions']['transaction']);
-        }))
-            ->willReturn([]);
+        }))->shouldBeCalled()->willReturn([]);
 
         $this->operation->___setProperty('connection', $this->connection->reveal());
 
@@ -875,8 +877,7 @@ class OperationTest extends TestCase
             if ($arg['readOptions']['readConsistency'] !== 'test') return true;
 
             return true;
-        }))
-            ->willReturn([]);
+        }))->shouldBeCalled()->willReturn([]);
 
         $this->operation->___setProperty('connection', $this->connection->reveal());
 

--- a/Debugger/composer.json
+++ b/Debugger/composer.json
@@ -10,7 +10,7 @@
         "ext-stackdriver_debugger": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6",

--- a/Debugger/phpunit-snippets.xml.dist
+++ b/Debugger/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Debugger/phpunit-system.xml.dist
+++ b/Debugger/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Debugger/phpunit.xml.dist
+++ b/Debugger/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Debugger/tests/Snippet/BreakpointTest.php
+++ b/Debugger/tests/Snippet/BreakpointTest.php
@@ -172,6 +172,9 @@ class BreakpointTest extends SnippetTestCase
         $this->assertInstanceOf(Breakpoint::class, $res->returnVal());
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testValidate()
     {
         $breakpoint = new Breakpoint(['id' => 'breakpoint1']);

--- a/Debugger/tests/Snippet/DebuggeeTest.php
+++ b/Debugger/tests/Snippet/DebuggeeTest.php
@@ -111,7 +111,10 @@ class DebuggeeTest extends SnippetTestCase
 
     public function testUpdateBreakpoint()
     {
-        $this->connection->updateBreakpoint(Argument::any())->willReturn(true);
+        $this->connection->updateBreakpoint(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn(true);
+
         $debuggee = new Debuggee($this->connection->reveal(), ['project' => 'project']);
         $breakpoint = new Breakpoint(['id' => 'breakpoint1']);
         $snippet = $this->snippetFromMethod(Debuggee::class, 'updateBreakpoint');

--- a/Debugger/tests/Unit/CliDaemonTest.php
+++ b/Debugger/tests/Unit/CliDaemonTest.php
@@ -25,6 +25,9 @@ use PHPUnit\Framework\TestCase;
  */
 class CliDaemonTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testClientConfig()
     {
         new CliDaemon([
@@ -52,6 +55,9 @@ class CliDaemonTest extends TestCase
         ]);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testSourceRoot()
     {
         new CliDaemon([

--- a/Debugger/tests/Unit/DebuggeeTest.php
+++ b/Debugger/tests/Unit/DebuggeeTest.php
@@ -93,7 +93,7 @@ class DebuggeeTest extends TestCase
     {
         $this->connection->updateBreakpoint(Argument::that(function ($args) {
             return $args['id'] == 'breakpoint1';
-        }))->willReturn([]);
+        }))->shouldBeCalled()->willReturn([]);
         $debuggee = new Debuggee($this->connection->reveal(), ['id' => 'debuggee1', 'project' => 'project1']);
 
         $breakpoint = new Breakpoint([

--- a/Dialogflow/composer.json
+++ b/Dialogflow/composer.json
@@ -21,7 +21,7 @@
         "google/gax": "^0.31.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "google/cloud-core": "^1.14",
         "phpdocumentor/reflection": "^3.0"
     },

--- a/Dialogflow/phpunit-snippets.xml.dist
+++ b/Dialogflow/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Dialogflow/phpunit-system.xml.dist
+++ b/Dialogflow/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Dialogflow/phpunit.xml.dist
+++ b/Dialogflow/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Dlp/composer.json
+++ b/Dlp/composer.json
@@ -8,7 +8,7 @@
         "google/gax": "^0.31.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "google/cloud-core": "^1.14",
         "phpdocumentor/reflection": "^3.0"
     },

--- a/Dlp/phpunit-snippets.xml.dist
+++ b/Dlp/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Dlp/phpunit-system.xml.dist
+++ b/Dlp/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Dlp/phpunit.xml.dist
+++ b/Dlp/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/ErrorReporting/composer.json
+++ b/ErrorReporting/composer.json
@@ -9,7 +9,7 @@
         "google/gax": "^0.31.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "google/cloud-core": "^1.14",
         "phpdocumentor/reflection": "^3.0"
     },

--- a/ErrorReporting/phpunit-snippets.xml.dist
+++ b/ErrorReporting/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/ErrorReporting/phpunit-system.xml.dist
+++ b/ErrorReporting/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/ErrorReporting/phpunit.xml.dist
+++ b/ErrorReporting/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Firestore/composer.json
+++ b/Firestore/composer.json
@@ -11,7 +11,7 @@
         "ramsey/uuid": "~3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6"

--- a/Firestore/phpunit-conformance.xml.dist
+++ b/Firestore/phpunit-conformance.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Conformance</directory>

--- a/Firestore/phpunit-snippets.xml.dist
+++ b/Firestore/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Firestore/phpunit-system.xml.dist
+++ b/Firestore/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Firestore/phpunit.xml.dist
+++ b/Firestore/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Firestore/tests/Snippet/FieldValueTest.php
+++ b/Firestore/tests/Snippet/FieldValueTest.php
@@ -62,7 +62,7 @@ class FieldValueTest extends SnippetTestCase
                     ]
                 ]
             ]
-        ])->willReturn([[]]);
+        ])->shouldBeCalled()->willReturn([[]]);
 
         $this->firestore->___setProperty('connection', $this->connection->reveal());
 
@@ -93,7 +93,7 @@ class FieldValueTest extends SnippetTestCase
                     ]
                 ]
             ]
-        ])->willReturn([[]]);
+        ])->shouldBeCalled()->willReturn([[]]);
 
         $this->firestore->___setProperty('connection', $this->connection->reveal());
 

--- a/Firestore/tests/System/DocumentAndCollectionTest.php
+++ b/Firestore/tests/System/DocumentAndCollectionTest.php
@@ -20,6 +20,7 @@ namespace Google\Cloud\Firestore\Tests\System;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\FieldValue;
 use Google\Cloud\Firestore\FirestoreClient;
+use PHPUnit\Framework\Error\Notice;
 
 /**
  * @group firestore
@@ -79,6 +80,8 @@ class DocumentAndCollectionTest extends FirestoreTestCase
             $snapshot['country'];
             $this->assertTrue(false);
         } catch (\PHPUnit_Framework_Error_Notice $e) {
+            $this->assertTrue(true);
+        } catch (Notice $e) {
             $this->assertTrue(true);
         }
     }

--- a/Firestore/tests/Unit/DocumentSnapshotTest.php
+++ b/Firestore/tests/Unit/DocumentSnapshotTest.php
@@ -17,12 +17,14 @@
 
 namespace Google\Cloud\Firestore\Tests\Unit;
 
+use Google\Cloud\Core\Testing\ExpectExceptionTrait;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\DocumentReference;
 use Google\Cloud\Firestore\DocumentSnapshot;
 use Google\Cloud\Firestore\FieldPath;
 use Google\Cloud\Firestore\ValueMapper;
+use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,6 +33,8 @@ use PHPUnit\Framework\TestCase;
  */
 class DocumentSnapshotTest extends TestCase
 {
+    use ExpectExceptionTrait;
+
     const NAME = 'projects/example_project/databases/(default)/documents/a/b';
     const ID = 'b';
 
@@ -201,11 +205,10 @@ class DocumentSnapshotTest extends TestCase
         unset($this->snapshot['name']);
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Notice
-     */
     public function testArrayAccessNonExistentIndex()
     {
+        $this->expectsException(Notice::class);
+
         $this->snapshot['name'];
     }
 }

--- a/Firestore/tests/Unit/QueryTest.php
+++ b/Firestore/tests/Unit/QueryTest.php
@@ -267,6 +267,7 @@ class QueryTest extends TestCase
 
     /**
      * @dataProvider whereOperators
+     * @doesNotPerformAssertions
      */
     public function testWhereOperators($operator)
     {
@@ -339,8 +340,9 @@ class QueryTest extends TestCase
 
     /**
      * @dataProvider orderOperators
+     * @doesNotPerformAssertions
      */
-    public function testorderOperators($operator)
+    public function testOrderOperators($operator)
     {
         $this->query->orderBy('foo', $operator);
     }

--- a/Firestore/tests/Unit/ValueMapperTest.php
+++ b/Firestore/tests/Unit/ValueMapperTest.php
@@ -194,7 +194,7 @@ class ValueMapperTest extends TestCase
         $blobValue = 'hello world';
         $blob = new Blob($blobValue);
 
-        $datetime = \DateTimeImmutable::createFromFormat('U.u', microtime(true));
+        $datetime = \DateTimeImmutable::createFromFormat('U.u', (string) microtime(true));
         $timestamp = new Timestamp($datetime);
         $now = (string) $datetime->format('U');
         $nanos = (int) $datetime->format('u') * 1000;

--- a/Firestore/tests/Unit/WriteBatchTest.php
+++ b/Firestore/tests/Unit/WriteBatchTest.php
@@ -379,7 +379,7 @@ class WriteBatchTest extends TestCase
         $this->connection->rollback([
             'database' => sprintf('projects/%s/databases/%s', self::PROJECT, self::DATABASE),
             'transaction' => self::TRANSACTION
-        ]);
+        ])->shouldBeCalled();
 
         $this->batch->___setProperty('connection', $this->connection->reveal());
         $this->batch->___setProperty('transaction', self::TRANSACTION);

--- a/Iot/composer.json
+++ b/Iot/composer.json
@@ -21,7 +21,7 @@
         "google/gax": "^0.31.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "google/cloud-core": "^1.14",
         "phpdocumentor/reflection": "^3.0"
     },

--- a/Iot/phpunit-snippets.xml.dist
+++ b/Iot/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Iot/phpunit-system.xml.dist
+++ b/Iot/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Iot/phpunit.xml.dist
+++ b/Iot/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Language/composer.json
+++ b/Language/composer.json
@@ -9,7 +9,7 @@
         "google/gax": "^0.31.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6",

--- a/Language/phpunit-snippets.xml.dist
+++ b/Language/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Language/phpunit-system.xml.dist
+++ b/Language/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Language/phpunit.xml.dist
+++ b/Language/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Logging/composer.json
+++ b/Logging/composer.json
@@ -9,7 +9,7 @@
         "google/gax": "^0.31.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6",

--- a/Logging/phpunit-snippets.xml.dist
+++ b/Logging/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Logging/phpunit-system.xml.dist
+++ b/Logging/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Logging/phpunit.xml.dist
+++ b/Logging/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Logging/tests/Unit/PsrLoggerCompatibilityTest.php
+++ b/Logging/tests/Unit/PsrLoggerCompatibilityTest.php
@@ -20,13 +20,17 @@ namespace Google\Cloud\Logging\Tests\Unit;
 use Google\Cloud\Logging\Connection\ConnectionInterface;
 use Google\Cloud\Logging\Logger;
 use Google\Cloud\Logging\PsrLogger;
-use Psr\Log\Test\LoggerInterfaceTest;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Psr\Log\LogLevel;
 
 /**
+ * This class includes the body of {@see Psr\Log\Test\LoggerInterfaceTest} due
+ * to the lack of compatibility of that test with PHPUnit 6+.
+ *
  * @group logging
  */
-class PsrLoggerCompatibilityTest extends LoggerInterfaceTest
+class PsrLoggerCompatibilityTest extends TestCase
 {
     public static $logs = [];
 
@@ -59,5 +63,114 @@ class PsrLoggerCompatibilityTest extends LoggerInterfaceTest
     public function getLogs()
     {
         return self::$logs;
+    }
+
+    public function testImplements()
+    {
+        $this->assertInstanceOf('Psr\Log\LoggerInterface', $this->getLogger());
+    }
+
+    /**
+     * @dataProvider provideLevelsAndMessages
+     */
+    public function testLogsAtAllLevels($level, $message)
+    {
+        $logger = $this->getLogger();
+        $logger->{$level}($message, array('user' => 'Bob'));
+        $logger->log($level, $message, array('user' => 'Bob'));
+
+        $expected = array(
+            $level.' message of level '.$level.' with context: Bob',
+            $level.' message of level '.$level.' with context: Bob',
+        );
+        $this->assertEquals($expected, $this->getLogs());
+    }
+
+    public function provideLevelsAndMessages()
+    {
+        return array(
+            LogLevel::EMERGENCY => array(LogLevel::EMERGENCY, 'message of level emergency with context: {user}'),
+            LogLevel::ALERT => array(LogLevel::ALERT, 'message of level alert with context: {user}'),
+            LogLevel::CRITICAL => array(LogLevel::CRITICAL, 'message of level critical with context: {user}'),
+            LogLevel::ERROR => array(LogLevel::ERROR, 'message of level error with context: {user}'),
+            LogLevel::WARNING => array(LogLevel::WARNING, 'message of level warning with context: {user}'),
+            LogLevel::NOTICE => array(LogLevel::NOTICE, 'message of level notice with context: {user}'),
+            LogLevel::INFO => array(LogLevel::INFO, 'message of level info with context: {user}'),
+            LogLevel::DEBUG => array(LogLevel::DEBUG, 'message of level debug with context: {user}'),
+        );
+    }
+
+    /**
+     * @expectedException \Psr\Log\InvalidArgumentException
+     */
+    public function testThrowsOnInvalidLevel()
+    {
+        $logger = $this->getLogger();
+        $logger->log('invalid level', 'Foo');
+    }
+
+    public function testContextReplacement()
+    {
+        $logger = $this->getLogger();
+        $logger->info('{Message {nothing} {user} {foo.bar} a}', array('user' => 'Bob', 'foo.bar' => 'Bar'));
+
+        $expected = array('info {Message {nothing} Bob Bar a}');
+        $this->assertEquals($expected, $this->getLogs());
+    }
+
+    public function testObjectCastToString()
+    {
+        if (method_exists($this, 'createPartialMock')) {
+            $dummy = $this->createPartialMock(DummyTest::class, array('__toString'));
+        } else {
+            $dummy = $this->getMock(DummyTest::class, array('__toString'));
+        }
+        $dummy->expects($this->once())
+            ->method('__toString')
+            ->will($this->returnValue('DUMMY'));
+
+        $this->getLogger()->warning($dummy);
+
+        $expected = array('warning DUMMY');
+        $this->assertEquals($expected, $this->getLogs());
+    }
+
+    public function testContextCanContainAnything()
+    {
+        $context = array(
+            'bool' => true,
+            'null' => null,
+            'string' => 'Foo',
+            'int' => 0,
+            'float' => 0.5,
+            'nested' => array('with object' => new DummyTest),
+            'object' => new \DateTime,
+            'resource' => fopen('php://memory', 'r'),
+        );
+
+        $this->getLogger()->warning('Crazy context data', $context);
+
+        $expected = array('warning Crazy context data');
+        $this->assertEquals($expected, $this->getLogs());
+    }
+
+    public function testContextExceptionKeyCanBeExceptionOrOtherValues()
+    {
+        $logger = $this->getLogger();
+        $logger->warning('Random message', array('exception' => 'oops'));
+        $logger->critical('Uncaught Exception!', array('exception' => new \LogicException('Fail')));
+
+        $expected = array(
+            'warning Random message',
+            'critical Uncaught Exception!'
+        );
+        $this->assertEquals($expected, $this->getLogs());
+    }
+}
+
+class DummyTest
+{
+    public function __toString()
+    {
     }
 }

--- a/Monitoring/composer.json
+++ b/Monitoring/composer.json
@@ -8,7 +8,7 @@
         "google/gax": "^0.31.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "google/cloud-core": "^1.14",
         "phpdocumentor/reflection": "^3.0"
     },

--- a/Monitoring/phpunit-snippets.xml.dist
+++ b/Monitoring/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Monitoring/phpunit-system.xml.dist
+++ b/Monitoring/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Monitoring/phpunit.xml.dist
+++ b/Monitoring/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/OsLogin/composer.json
+++ b/OsLogin/composer.json
@@ -21,7 +21,7 @@
         "google/gax": "^0.31.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "google/cloud-core": "^1.14",
         "phpdocumentor/reflection": "^3.0"
     },

--- a/OsLogin/phpunit-snippets.xml.dist
+++ b/OsLogin/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/OsLogin/phpunit-system.xml.dist
+++ b/OsLogin/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/OsLogin/phpunit.xml.dist
+++ b/OsLogin/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/PubSub/composer.json
+++ b/PubSub/composer.json
@@ -9,7 +9,7 @@
         "google/gax": "^0.31.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6"

--- a/PubSub/phpunit-snippets.xml.dist
+++ b/PubSub/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/PubSub/phpunit-system.xml.dist
+++ b/PubSub/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/PubSub/phpunit.xml.dist
+++ b/PubSub/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/PubSub/src/Topic.php
+++ b/PubSub/src/Topic.php
@@ -348,8 +348,8 @@ class Topic
      *
      * Example:
      * ```
-     * $topic->batchPublisher()
-     *     ->publish([
+     * $publisher = $topic->batchPublisher();
+     * $publisher->publish([
      *         'data' => 'New User Registered',
      *         'attributes' => [
      *             'id' => '2',

--- a/PubSub/tests/Snippet/BatchPublisherTest.php
+++ b/PubSub/tests/Snippet/BatchPublisherTest.php
@@ -39,6 +39,9 @@ class BatchPublisherTest extends SnippetTestCase
             ->willReturn(true);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testClass()
     {
         $snippet = $this->snippetFromClass(BatchPublisher::class);
@@ -54,6 +57,9 @@ class BatchPublisherTest extends SnippetTestCase
         $snippet->invoke();
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testPublish()
     {
         $snippet = $this->snippetFromMethod(BatchPublisher::class, 'publish');

--- a/PubSub/tests/Snippet/TopicTest.php
+++ b/PubSub/tests/Snippet/TopicTest.php
@@ -188,13 +188,17 @@ class TopicTest extends SnippetTestCase
         $snippet = $this->snippetFromMethod(Topic::class, 'batchPublisher');
         $batchPublisher = $this->prophesize(BatchPublisher::class);
         $batchPublisher->publish(Argument::type('array'))
+            ->shouldBeCalled()
             ->willReturn(true);
         $topic = $this->prophesize(Topic::class);
         $topic->batchPublisher()
+            ->shouldBeCalled()
             ->willReturn($batchPublisher->reveal());
         $snippet->addLocal('topic', $topic->reveal());
 
-        $snippet->invoke();
+        $res = $snippet->invoke('publisher');
+
+        $this->assertInstanceOf(BatchPublisher::class, $res->returnVal());
     }
 
     public function testSubscribe()

--- a/PubSub/tests/Unit/SnapshotTest.php
+++ b/PubSub/tests/Unit/SnapshotTest.php
@@ -114,7 +114,7 @@ class SnapshotTest extends TestCase
     {
         $this->connection->deleteSnapshot([
             'snapshot' => 'projects/'. self::PROJECT .'/snapshots/'. self::NAME
-        ]);
+        ])->shouldBeCalled();
 
         $this->snapshot->setConnection($this->connection->reveal());
 

--- a/PubSub/tests/Unit/TopicTest.php
+++ b/PubSub/tests/Unit/TopicTest.php
@@ -197,31 +197,6 @@ class TopicTest extends TestCase
         $this->assertEquals($res, $ids);
     }
 
-    public function testPublishBatchUnencoded()
-    {
-        $message = [
-            'data' => 'hello world',
-            'attributes' => [
-                'key' => 'value'
-            ]
-        ];
-
-        $this->connection->publishMessage(Argument::that(function ($options) use ($message) {
-            if ($options['foo'] !== 'bar') return false;
-
-            if ($options['messages'] !== [$message]) return false;
-
-            // If the message was encoded, this will fail the test.
-            if ($options['messages'][0]['data'] !== $message['data']) return false;
-
-            return true;
-        }));
-
-        $this->topic->setConnection($this->connection->reveal());
-
-        $res = $this->topic->publishBatch([$message], ['foo' => 'bar', 'encode' => false]);
-    }
-
     /**
      * @expectedException InvalidArgumentException
      */

--- a/Spanner/composer.json
+++ b/Spanner/composer.json
@@ -10,7 +10,7 @@
         "google/proto-client": "^0.37"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6",

--- a/Spanner/phpunit-snippets.xml.dist
+++ b/Spanner/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Spanner/phpunit-system.xml.dist
+++ b/Spanner/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Spanner/phpunit.xml.dist
+++ b/Spanner/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Spanner/tests/Snippet/DatabaseTest.php
+++ b/Spanner/tests/Snippet/DatabaseTest.php
@@ -829,6 +829,9 @@ class DatabaseTest extends SnippetTestCase
         $this->assertInstanceOf(SessionPoolInterface::class, $res->returnVal());
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testClose()
     {
         $snippet = $this->snippetFromMethod(Database::class, 'close');

--- a/Spanner/tests/Snippet/ResultTest.php
+++ b/Spanner/tests/Snippet/ResultTest.php
@@ -117,7 +117,7 @@ class ResultTest extends SnippetTestCase
     public function testQueryWithStats()
     {
         $db = $this->prophesize(Database::class);
-        $db->execute(Argument::any(), ['queryMode' => 'PROFILE']);
+        $db->execute(Argument::any(), ['queryMode' => 'PROFILE'])->shouldBeCalled();
 
         $snippet = $this->snippetFromMethod(Result::class, 'stats', 1);
         $snippet->addLocal('database', $db->reveal());

--- a/Spanner/tests/System/TransactionTest.php
+++ b/Spanner/tests/System/TransactionTest.php
@@ -56,6 +56,9 @@ class TransactionTest extends SpannerTestCase
         )->pollUntilComplete();
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testRunTransaction()
     {
         $db = self::$database;

--- a/Spanner/tests/Unit/DatabaseTest.php
+++ b/Spanner/tests/Unit/DatabaseTest.php
@@ -184,7 +184,7 @@ class DatabaseTest extends TestCase
         $this->connection->updateDatabaseDdl([
             'name' => DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE),
             'statements' => [$statement]
-        ])->willReturn([
+        ])->shouldBeCalled()->willReturn([
             'name' => 'my-operation'
         ]);
 
@@ -202,7 +202,7 @@ class DatabaseTest extends TestCase
         $this->connection->updateDatabaseDdl([
             'name' => DatabaseAdminClient::databaseName(self::PROJECT, self::INSTANCE, self::DATABASE),
             'statements' => $statements
-        ])->willReturn([
+        ])->shouldBeCalled()->willReturn([
             'name' => 'my-operation'
         ]);
 

--- a/Spanner/tests/Unit/ResultTest.php
+++ b/Spanner/tests/Unit/ResultTest.php
@@ -199,6 +199,9 @@ class ResultTest extends TestCase
         $this->assertInstanceOf(Snapshot::class, $result->snapshot());
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testUsesCorrectDefaultFormatOption()
     {
         $mapper = $this->prophesize(ValueMapper::class);
@@ -215,8 +218,9 @@ class ResultTest extends TestCase
 
     /**
      * @dataProvider formatProvider
+     * @doesNotPerformAssertions
      */
-    public function testRecievesCorrectFormatOption($format)
+    public function testReceivesCorrectFormatOption($format)
     {
         $mapper = $this->prophesize(ValueMapper::class);
         $mapper->decodeValues(

--- a/Speech/composer.json
+++ b/Speech/composer.json
@@ -9,7 +9,7 @@
         "google/gax": "^0.31.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6",

--- a/Speech/phpunit-snippets.xml.dist
+++ b/Speech/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Speech/phpunit-system.xml.dist
+++ b/Speech/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Speech/phpunit.xml.dist
+++ b/Speech/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Speech/tests/Snippet/OperationTest.php
+++ b/Speech/tests/Snippet/OperationTest.php
@@ -57,20 +57,16 @@ class OperationTest extends SnippetTestCase
 
     public function testClass()
     {
-        $snippet = $this->snippetFromClass(Operation::class);
-
-        $connectionStub = $this->prophesize(ConnectionInterface::class);
-
-        $connectionStub->longRunningRecognize(Argument::any())
+        $this->connection->longRunningRecognize(Argument::any())
+            ->shouldBeCalled()
             ->willReturn(['name' => 'foo']);
 
-        $snippet->addLocal('connectionStub', $connectionStub->reveal());
-        $snippet->insertAfterLine(4, '$reflection = new \ReflectionClass($speech);
-            $property = $reflection->getProperty(\'connection\');
-            $property->setAccessible(true);
-            $property->setValue($speech, $connectionStub);
-            $property->setAccessible(false);'
-        );
+        $speech = \Google\Cloud\Core\Testing\TestHelpers::stub(SpeechClient::class, [['languageCode' => 'en-US']]);
+        $speech->___setProperty('connection', $this->connection->reveal());
+
+        $snippet = $this->snippetFromClass(Operation::class);
+        $snippet->replace('$speech = new SpeechClient([' . PHP_EOL . '    \'languageCode\' => \'en-US\'' . PHP_EOL .']);', '');
+        $snippet->addLocal('speech', $speech);
 
         $snippet->replace("__DIR__  . '/audio.flac'", '"php://temp"');
 

--- a/Storage/composer.json
+++ b/Storage/composer.json
@@ -7,7 +7,7 @@
         "google/cloud-core": "^1.14"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6",

--- a/Storage/phpunit-snippets.xml.dist
+++ b/Storage/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Storage/phpunit-system.xml.dist
+++ b/Storage/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Storage/phpunit.xml.dist
+++ b/Storage/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Storage/tests/System/RequesterPaysTest.php
+++ b/Storage/tests/System/RequesterPaysTest.php
@@ -71,6 +71,10 @@ class RequesterPaysTest extends StorageTestCase
 
     public function setUp()
     {
+        if (!self::$hasSetUp) {
+            self::setupBeforeClass();
+        }
+
         $this->keyFilePath = getenv('GOOGLE_CLOUD_PHP_TESTS_WHITELIST_KEY_PATH');
 
         $keyfile = json_decode(file_get_contents(getenv('GOOGLE_CLOUD_PHP_TESTS_WHITELIST_KEY_PATH')), true);

--- a/Storage/tests/System/SignedUrlTest.php
+++ b/Storage/tests/System/SignedUrlTest.php
@@ -57,9 +57,10 @@ class SignedUrlTest extends StorageTestCase
         if ($objectName === self::RANDOM_NAME) {
             $objectName = null;
         }
+
         $obj = $this->createFile($objectName);
         $ts = new Timestamp(new \DateTime('tomorrow'));
-        return $obj->signedUrl($ts, $urlOpts);
+        $url = $obj->signedUrl($ts, $urlOpts);
 
         $this->assertEquals(self::CONTENT, $this->getFile($url));
     }

--- a/Storage/tests/System/StorageTestCase.php
+++ b/Storage/tests/System/StorageTestCase.php
@@ -38,7 +38,7 @@ class StorageTestCase extends SystemTestCase
     protected static $pubsubClient;
     protected static $object;
     protected static $mainBucketName;
-    private static $hasSetUp = false;
+    protected static $hasSetUp = false;
 
     public static function setUpBeforeClass()
     {

--- a/Storage/tests/Unit/BucketTest.php
+++ b/Storage/tests/Unit/BucketTest.php
@@ -391,7 +391,7 @@ class BucketTest extends TestCase
     public function testRequesterPays()
     {
         $this->connection->getBucket(Argument::withEntry('userProject', 'foo'))
-            ->willReturn([]);
+            ->shouldBeCalled()->willReturn([]);
 
         $bucket = $this->getBucket(['requesterProjectId' => 'foo']);
 

--- a/Storage/tests/Unit/StorageClientTest.php
+++ b/Storage/tests/Unit/StorageClientTest.php
@@ -49,7 +49,11 @@ class StorageClientTest extends TestCase
 
     public function testGetBucketRequesterPaysDefaultProjectId()
     {
-        $this->connection->getBucket(Argument::withEntry('userProject', self::PROJECT));
+        $this->connection->getBucket(Argument::withEntry('userProject', self::PROJECT))
+            ->shouldBeCalled();
+
+        $this->connection->projectId()->willReturn(self::PROJECT);
+
         $this->client->___setProperty('connection', $this->connection->reveal());
         $bucket = $this->client->bucket('myBucket', true);
 

--- a/Storage/tests/Unit/StorageObjectTest.php
+++ b/Storage/tests/Unit/StorageObjectTest.php
@@ -115,7 +115,7 @@ class StorageObjectTest extends TestCase
             'bucket' => $bucket,
             'object' => $object,
             'acl' => null
-        ])->willReturn([]);
+        ])->shouldBeCalled()->willReturn([]);
         $object = new StorageObject(
             $this->connection->reveal(),
             $object,
@@ -900,7 +900,7 @@ class StorageObjectTest extends TestCase
     public function testRequesterPays()
     {
         $this->connection->getObject(Argument::withEntry('userProject', 'foo'))
-            ->willReturn([]);
+            ->shouldBeCalled()->willReturn([]);
 
         $object = new StorageObject($this->connection->reveal(), 'object', 'bucket', null, ['requesterProjectId' => 'foo']);
 

--- a/Storage/tests/Unit/StreamWrapperTest.php
+++ b/Storage/tests/Unit/StreamWrapperTest.php
@@ -18,22 +18,26 @@
 namespace Google\Cloud\Tests\Storage;
 
 use Google\Cloud\Core\Exception\NotFoundException;
+use Google\Cloud\Core\Testing\ExpectExceptionTrait;
 use Google\Cloud\Core\Upload\StreamableUploader;
 use Google\Cloud\Storage\Bucket;
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Storage\StorageObject;
 use Google\Cloud\Storage\StreamWrapper;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\Error\Warning;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Promise\CallbackPromise;
 use Prophecy\Prophecy\ObjectProphecy;
-use PHPUnit\Framework\TestCase;
 
 /**
  * @group storage
  */
 class StreamWrapperTest extends TestCase
 {
+    use ExpectExceptionTrait;
+
     private $originalDefaultContext;
 
     private $connection;
@@ -197,10 +201,11 @@ class StreamWrapperTest extends TestCase
 
     /**
      * @group storageInfo
-     * @expectedException PHPUnit_Framework_Error_Warning
      */
     public function testStatOnNonExistentFile()
     {
+        $this->expectsException(Warning::class);
+
         $object = $this->prophesize(StorageObject::class);
         $object->info()->willThrow(NotFoundException::class);
         $this->bucket->object('non-existent/file.txt')->willReturn($object->reveal());

--- a/Trace/composer.json
+++ b/Trace/composer.json
@@ -10,7 +10,7 @@
         "google/proto-client": "^0.37"
     },
      "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6"

--- a/Trace/phpunit-snippets.xml.dist
+++ b/Trace/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Trace/phpunit-system.xml.dist
+++ b/Trace/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Trace/phpunit.xml.dist
+++ b/Trace/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Trace/tests/Snippet/SpanTest.php
+++ b/Trace/tests/Snippet/SpanTest.php
@@ -145,6 +145,9 @@ class SpanTest extends SnippetTestCase
         $this->assertEquals('span name', $res->output());
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testAddTimeEvents()
     {
         $snippet = $this->snippetFromMethod(Span::class, 'addTimeEvents');
@@ -154,6 +157,9 @@ class SpanTest extends SnippetTestCase
         $res = $snippet->invoke('span');
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testAddTimeEvent()
     {
         $snippet = $this->snippetFromMethod(Span::class, 'addTimeEvent');
@@ -162,6 +168,9 @@ class SpanTest extends SnippetTestCase
         $res = $snippet->invoke('span');
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testAddLinks()
     {
         $snippet = $this->snippetFromMethod(Span::class, 'addLinks');
@@ -170,6 +179,9 @@ class SpanTest extends SnippetTestCase
         $res = $snippet->invoke('span');
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testAddLink()
     {
         $snippet = $this->snippetFromMethod(Span::class, 'addLink');

--- a/Translate/composer.json
+++ b/Translate/composer.json
@@ -7,7 +7,7 @@
         "google/cloud-core": "^1.14"
     },
      "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6"

--- a/Translate/phpunit-snippets.xml.dist
+++ b/Translate/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Translate/phpunit-system.xml.dist
+++ b/Translate/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Translate/phpunit.xml.dist
+++ b/Translate/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Translate/tests/System/TranslateTest.php
+++ b/Translate/tests/System/TranslateTest.php
@@ -147,7 +147,7 @@ class TranslateTest extends TranslateTestCase
         $res = $client->detectLanguage(self::INPUT_STRING);
         $this->assertEquals(self::INPUT_LANGUAGE, $res['languageCode']);
         $this->assertEquals(self::INPUT_STRING, $res['input']);
-        $this->assertInternalType('double', $res['confidence']);
+        $this->assertContains(gettype($res['confidence']), ['double', 'integer']);
     }
 
     public function testDetectLanguageUndefined()
@@ -166,7 +166,7 @@ class TranslateTest extends TranslateTestCase
         $res = $client->detectLanguageBatch([self::INPUT_STRING]);
         $this->assertEquals(self::INPUT_LANGUAGE, $res[0]['languageCode']);
         $this->assertEquals(self::INPUT_STRING, $res[0]['input']);
-        $this->assertInternalType('double', $res[0]['confidence']);
+        $this->assertContains(gettype($res['confidence']), ['double', 'integer']);
     }
 
     public function testDetectLanguageBatchUndefined()

--- a/Translate/tests/Unit/TranslateClientTest.php
+++ b/Translate/tests/Unit/TranslateClientTest.php
@@ -53,16 +53,15 @@ class TranslateClientTest extends TestCase
     public function testTranslateModel()
     {
         $this->connection->listTranslations(Argument::that(function ($args) {
-            if (isset($args['model'])) return false;
-        }));
+            return !isset($args['model']);
+        }))->shouldBeCalled();
 
         $this->client->setConnection($this->connection->reveal());
 
         $this->client->translate('foo bar');
 
-        $this->connection->listTranslations(Argument::that(function ($args) {
-            if ($args['model'] !== 'base') return false;
-        }));
+        $this->connection->listTranslations(Argument::withEntry('model', 'base'))
+            ->shouldBeCalled();
 
         $this->client->setConnection($this->connection->reveal());
         $this->client->translate('foo bar', ['model' => 'base']);

--- a/VideoIntelligence/composer.json
+++ b/VideoIntelligence/composer.json
@@ -8,7 +8,7 @@
         "google/gax": "^0.31.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "google/cloud-core": "^1.14",
         "phpdocumentor/reflection": "^3.0"
     },

--- a/VideoIntelligence/phpunit-snippets.xml.dist
+++ b/VideoIntelligence/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/VideoIntelligence/phpunit-system.xml.dist
+++ b/VideoIntelligence/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/VideoIntelligence/phpunit.xml.dist
+++ b/VideoIntelligence/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Vision/composer.json
+++ b/Vision/composer.json
@@ -9,7 +9,7 @@
         "google/gax": "^0.31.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6",

--- a/Vision/phpunit-snippets.xml.dist
+++ b/Vision/phpunit-snippets.xml.dist
@@ -2,7 +2,8 @@
 <phpunit
   bootstrap="./vendor/google/cloud-core/snippet-bootstrap.php"
   colors="true"
-  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter">
+  printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Snippet</directory>

--- a/Vision/phpunit-system.xml.dist
+++ b/Vision/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./vendor/google-cloud/cloud-core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/System</directory>

--- a/Vision/phpunit.xml.dist
+++ b/Vision/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>tests/Unit</directory>

--- a/Vision/tests/System/AnnotationsTest.php
+++ b/Vision/tests/System/AnnotationsTest.php
@@ -86,11 +86,6 @@ class AnnotationsTest extends VisionTestCase
         $this->assertInstanceOf(Web::class, $res->web());
         $this->assertInstanceOf(WebEntity::class, $res->web()->entities()[0]);
 
-        $desc = array_filter($res->web()->entities(), function ($e) {
-            return ($e->description() === 'Eiffel Tower');
-        });
-        $this->assertGreaterThan(0, $desc);
-
         $this->assertInstanceOf(WebImage::class, $res->web()->matchingImages()[0]);
         $this->assertInstanceOf(WebImage::class, $res->web()->partialMatchingImages()[0]);
         $this->assertInstanceOf(WebPage::class, $res->web()->pages()[0]);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ environment:
 install:
   - cinst -y OpenSSL.Light
   - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:PHP_VERSION | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
-  - ps: . .\dev\appveyor-grpc.ps1
+  - ps: . .\dev\appveyor-php.ps1
   - cd c:\projects\google-cloud
   - curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -o composer-setup.php https://getcomposer.org/installer
   - curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -o composer-signature.sig https://composer.github.io/installer.sig

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "google/proto-client": "^0.37"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0|^6.0",
+        "phpunit/phpunit": "^6.0|^5.0|^4.8",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "symfony/console": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "google/proto-client": "^0.37"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
+        "phpunit/phpunit": "^4.8|^5.0|^6.0",
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "symfony/console": "^3.0",

--- a/dev/appveyor-php.ps1
+++ b/dev/appveyor-php.ps1
@@ -3,6 +3,7 @@ cd c:\tools\php
 
 Add-Content php.ini "`nextension_dir=ext"
 Add-Content php.ini "`nextension=php_openssl.dll"
+Add-Content php.ini "`nextension=php_mbstring.dll"
 
 if (Test-Path 'env:GRPC_SRC') {
     "Downloading $env:GRPC_SRC as grpc.zip"

--- a/phpunit-conformance.xml.dist
+++ b/phpunit-conformance.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>*/tests/Conformance</directory>

--- a/phpunit-perf.xml.dist
+++ b/phpunit-perf.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./Core/perf-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./Core/perf-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>*/tests/Perf</directory>

--- a/phpunit-snippets.xml.dist
+++ b/phpunit-snippets.xml.dist
@@ -3,7 +3,7 @@
   bootstrap="./Core/snippet-bootstrap.php"
   colors="true"
   printerClass="Google\Cloud\Core\Testing\Snippet\Coverage\ResultPrinter"
-  >
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>*/tests/Snippet</directory>

--- a/phpunit-system.xml.dist
+++ b/phpunit-system.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./Core/system-bootstrap.php" colors="true">
+<phpunit
+  bootstrap="./Core/system-bootstrap.php"
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>*/tests/System</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+  colors="true"
+  failOnRisky="true">
   <testsuites>
     <testsuite>
       <directory>*/tests/Unit</directory>

--- a/tests/Unit/JsonFileTest.php
+++ b/tests/Unit/JsonFileTest.php
@@ -49,27 +49,37 @@ class JsonFileTest extends TestCase
         $this->assertFalse($validator->fails());
     }
 
-    public function testComponentComposer()
+    /**
+     * @dataProvider componentComposer
+     */
+    public function testComponentComposer($file)
     {
-        $files = glob(__DIR__ .'/../../src/*/composer.json');
-        foreach ($files as $file) {
-            $json = json_decode(file_get_contents($file));
-            $this->assertEquals(JSON_ERROR_NONE, json_last_error());
+        $json = json_decode(file_get_contents($file));
+        $this->assertEquals(JSON_ERROR_NONE, json_last_error());
 
-            $deref  = new Dereferencer();
-            $schema = $deref->dereference(json_decode(file_get_contents(sprintf(
-                self::SCHEMA_PATH,
-                __DIR__, 'composer.json.schema'
-            ))));
+        $deref  = new Dereferencer();
+        $schema = $deref->dereference(json_decode(file_get_contents(sprintf(
+            self::SCHEMA_PATH,
+            __DIR__, 'composer.json.schema'
+        ))));
 
-            $validator = new Validator($json, $schema);
+        $validator = new Validator($json, $schema);
 
-            if ($validator->fails()) {
-                print_r($validator->errors());
-            }
-
-            $this->assertFalse($validator->fails());
+        if ($validator->fails()) {
+            print_r($validator->errors());
         }
+
+        $this->assertFalse($validator->fails());
+    }
+
+    public function componentComposer()
+    {
+        $files = glob(__DIR__ .'/../../*/composer.json');
+        array_walk($files, function (&$file) {
+            $file = [$file];
+        });
+
+        return $files;
     }
 
     public function testManifest()


### PR DESCRIPTION
This isn't as big a change as it looks. Most of the changed files are adding a switch to PHPUnit configs and updating composer.json files. The vast majority of test case changes are adding assertions to tests which previously did not make assertions, or annotating tests as not performing assertions where applicable. In the diff, I'll call out important things to note.