### PR TITLE
Fix tests for HHVM compat and pin HHVM version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
   - php: 7.2
   - php: 5.5.38
   - php: 5.6.25
-  - php: hhvm
+  - php: hhvm-3.24
     group: edge
   fast_finish: true
 

--- a/Core/tests/Unit/Report/MetadataProviderUtilsTest.php
+++ b/Core/tests/Unit/Report/MetadataProviderUtilsTest.php
@@ -33,7 +33,7 @@ class MetadataProviderUtilsTest extends TestCase
     {
         $metadataProvider = MetadataProviderUtils::autoSelect($this->envs);
         $this->assertInstanceOf(
-            GaeFlexMetadataProvider::class,
+            GAEFlexMetadataProvider::class,
             $metadataProvider
         );
         $metadataProvider = MetadataProviderUtils::autoSelect([]);

--- a/Datastore/tests/Unit/KeyTest.php
+++ b/Datastore/tests/Unit/KeyTest.php
@@ -196,7 +196,7 @@ class KeyTest extends TestCase
             ]
         ]);
 
-        $this->assertEquals($key->state(), key::STATE_NAMED);
+        $this->assertEquals($key->state(), Key::STATE_NAMED);
     }
 
     public function testStateIncomplete()
@@ -207,7 +207,7 @@ class KeyTest extends TestCase
             ]
         ]);
 
-        $this->assertEquals($key->state(), key::STATE_INCOMPLETE);
+        $this->assertEquals($key->state(), Key::STATE_INCOMPLETE);
     }
 
     public function testPath()

--- a/ErrorReporting/tests/Unit/BootstrapTest.php
+++ b/ErrorReporting/tests/Unit/BootstrapTest.php
@@ -193,7 +193,7 @@ class BootstrapTest extends TestCase
         )->shouldBeCalledTimes(1);
         Bootstrap::$psrLogger = $this->psrBatchLogger->reveal();
         MockValues::$errorReporting = $error['type']; // always match
-        BootStrap::errorHandler(
+        Bootstrap::errorHandler(
             $error['type'],
             $error['message'],
             $error['file'],
@@ -205,7 +205,7 @@ class BootstrapTest extends TestCase
     {
         Bootstrap::$psrLogger = null;
         MockValues::$errorReporting = 0;
-        $result = BootStrap::errorHandler(
+        $result = Bootstrap::errorHandler(
             E_ERROR,
             'message',
             'file',
@@ -217,7 +217,7 @@ class BootstrapTest extends TestCase
     public function testErrorHandlerWithoutLogger() {
         Bootstrap::$psrLogger = null;
         MockValues::$errorReporting = E_ERROR;
-        $result = BootStrap::errorHandler(
+        $result = Bootstrap::errorHandler(
             E_ERROR,
             'message',
             'file',
@@ -253,7 +253,7 @@ class BootstrapTest extends TestCase
             // The shutdownHandler should not do anything, so it should pass
             // with the empty psrBatchLogger mock.
             Bootstrap::$psrLogger = $this->psrBatchLogger->reveal();
-            $this->assertNull(BootStrap::shutdownHandler());
+            $this->assertNull(Bootstrap::shutdownHandler());
             return;
         }
         $this->psrBatchLogger->getMetadataProvider()
@@ -285,7 +285,7 @@ class BootstrapTest extends TestCase
             $expectedContext
         )->shouldBeCalledTimes(1);
         Bootstrap::$psrLogger = $this->psrBatchLogger->reveal();
-        BootStrap::shutdownHandler();
+        Bootstrap::shutdownHandler();
     }
 
     public function errorsAndMetadataProvider()

--- a/Firestore/tests/Unit/ValueMapperTest.php
+++ b/Firestore/tests/Unit/ValueMapperTest.php
@@ -194,7 +194,7 @@ class ValueMapperTest extends TestCase
         $blobValue = 'hello world';
         $blob = new Blob($blobValue);
 
-        $datetime = \DateTimeImmutable::createFromFormat('U.u', microtime(true));
+        $datetime = \DateTimeImmutable::createFromFormat('U.u', (string) microtime(true));
         $timestamp = new Timestamp($datetime);
         $now = (string) $datetime->format('U');
         $nanos = (int) $datetime->format('u') * 1000;

--- a/Logging/tests/Unit/PsrLoggerBatchTest.php
+++ b/Logging/tests/Unit/PsrLoggerBatchTest.php
@@ -120,7 +120,7 @@ class PsrLoggerBatchTest extends TestCase
             [
                 'batchEnabled' => true,
                 'batchRunner' => $this->runner->reveal(),
-                'metadataProvider' => new GaeFlexMetadataProvider($server)
+                'metadataProvider' => new GAEFlexMetadataProvider($server)
             ]
         );
         $psrBatchLogger->info(


### PR DESCRIPTION
We started seeing HHVM failures on Travis this morning, seemingly related to a new version (v3.26) of HHVM released today. This change addresses all but one of those errors, most of which were related to incorrect casing in classnames in unit tests.

The more complicated side is an error from the snippet parser, raising a fatal error and stopping the build.

> Fatal error: Uncaught Error: Cannot use 'Cast\Double' as class name as it is reserved in <path>/google-cloud-php/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinter/Standard.php:332

The installed version of `nikic/php-parser` is `v1.4.1`, but a brief look at the project seems to indicate that this issue will also exist in the latest iteration.

The temporary solution included in this PR is to pin the HHVM version to the last known working version. I'll open a tracking issue to follow this PR where I'll work on figuring out a way to remove the pin and get our builds working on the latest version of HHVM.