### PR TITLE
Prevents unneeded files from being installed through composer.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/dev export-ignore
+/docs export-ignore
+/tests export-ignore
+/*.md export-ignore
+/*.xml export-ignore
+/*.xml.dist


### PR DESCRIPTION
Currently the install size for the library is 9.4MB, of which 6.6MB is tests. 

Using a gitattributes file means that when Composer downloads the 'distribution' version from github, those files will be excluded, resulting in quicker deployments and smaller containers for everyone who uses this library

https://blog.madewithlove.be/post/gitattributes/