### PR TITLE
adds context to exception handler

### DIFF
--- a/ErrorReporting/src/Bootstrap.php
+++ b/ErrorReporting/src/Bootstrap.php
@@ -134,9 +134,8 @@ class Bootstrap
                     'reportLocation' => [
                         'filePath' => $ex->getFile(),
                         'lineNumber' => $ex->getLine(),
-                        'functionName' => isset($ex->getTrace()[0]['function'])
-                            ? $ex->getTrace()[0]['function']
-                            : 'none'
+                        'functionName' =>
+                            self::getFunctionNameForReport($ex->getTrace()),
                     ]
                 ],
                 'serviceContext' => [
@@ -177,7 +176,8 @@ class Bootstrap
                 'reportLocation' => [
                     'filePath' => $file,
                     'lineNumber' => $line,
-                    'functionName' => 'unknown'
+                    'functionName' =>
+                        self::getFunctionNameForReport(null),
                 ]
             ],
             'serviceContext' => [
@@ -222,7 +222,8 @@ class Bootstrap
                             'reportLocation' => [
                                 'filePath' => $err['file'],
                                 'lineNumber' => $err['line'],
-                                'functionName' => 'unknown'
+                                'functionName' =>
+                                    self::getFunctionNameForReport(null),
                             ]
                         ],
                         'serviceContext' => [
@@ -240,5 +241,23 @@ class Bootstrap
                     break;
             }
         }
+    }
+
+    public static function getFunctionNameForReport($trace = [])
+    {
+        if (null === $trace) {
+            return '<unknown function>';
+        }
+        if (empty($trace[0]['function'])) {
+            return '<none>';
+        }
+        $functionName = [$trace[0]['function']];
+        if (isset($trace[0]['type'])) {
+            $functionName[] = $trace[0]['type'];
+        }
+        if (isset($trace[0]['class'])) {
+            $functionName[] = $trace[0]['class'];
+        }
+        return implode('', array_reverse($functionName));
     }
 }

--- a/ErrorReporting/src/Bootstrap.php
+++ b/ErrorReporting/src/Bootstrap.php
@@ -177,7 +177,7 @@ class Bootstrap
                     'filePath' => $file,
                     'lineNumber' => $line,
                     'functionName' =>
-                        self::getFunctionNameForReport(null),
+                        self::getFunctionNameForReport(),
                 ]
             ],
             'serviceContext' => [
@@ -223,7 +223,7 @@ class Bootstrap
                                 'filePath' => $err['file'],
                                 'lineNumber' => $err['line'],
                                 'functionName' =>
-                                    self::getFunctionNameForReport(null),
+                                    self::getFunctionNameForReport(),
                             ]
                         ],
                         'serviceContext' => [
@@ -243,7 +243,14 @@ class Bootstrap
         }
     }
 
-    public static function getFunctionNameForReport($trace = [])
+    /**
+     * Format the function name from a stack trace. This could be a global
+     * function (function_name), a class function (Class->function), or a static
+     * function (Class::function).
+     *
+     * @param array $trace The stack trace returned from Exception::getTrace()
+     */
+    private static function getFunctionNameForReport(array $trace = null)
     {
         if (null === $trace) {
             return '<unknown function>';

--- a/ErrorReporting/src/Bootstrap.php
+++ b/ErrorReporting/src/Bootstrap.php
@@ -130,6 +130,15 @@ class Bootstrap
             $service = self::$psrLogger->getMetadataProvider()->serviceId();
             $version = self::$psrLogger->getMetadataProvider()->versionId();
             self::$psrLogger->error($message, [
+                'context' => [
+                    'reportLocation' => [
+                        'filePath' => $ex->getFile(),
+                        'lineNumber' => $ex->getLine(),
+                        'functionName' => isset($ex->getTrace()[0]['function'])
+                            ? $ex->getTrace()[0]['function']
+                            : 'none'
+                    ]
+                ],
                 'serviceContext' => [
                     'service' => $service,
                     'version' => $version,

--- a/ErrorReporting/tests/Unit/BootstrapTest.php
+++ b/ErrorReporting/tests/Unit/BootstrapTest.php
@@ -118,9 +118,7 @@ class BootstrapTest extends TestCase
                 'reportLocation' => [
                     'filePath' => $exception->getFile(),
                     'lineNumber' => $exception->getLine(),
-                    'functionName' => Bootstrap::getFunctionNameForReport(
-                        $exception->getTrace()
-                    )
+                    'functionName' => 'Google\Cloud\ErrorReporting\Tests\Unit\BootstrapTest->exceptionProvider',
                 ]
             ],
             'serviceContext' => [

--- a/ErrorReporting/tests/Unit/BootstrapTest.php
+++ b/ErrorReporting/tests/Unit/BootstrapTest.php
@@ -114,6 +114,13 @@ class BootstrapTest extends TestCase
     ) {
         $expectedMessage = sprintf('PHP Notice: %s', (string)$exception);
         $expectedContext = [
+            'context' => [
+                'reportLocation' => [
+                    'filePath' => $exception->getFile(),
+                    'lineNumber' => $exception->getLine(),
+                    'functionName' => $exception->getTrace()[0]['function']
+                ]
+            ],
             'serviceContext' => [
                 'service' => '',
                 'version' => ''

--- a/ErrorReporting/tests/Unit/BootstrapTest.php
+++ b/ErrorReporting/tests/Unit/BootstrapTest.php
@@ -118,7 +118,9 @@ class BootstrapTest extends TestCase
                 'reportLocation' => [
                     'filePath' => $exception->getFile(),
                     'lineNumber' => $exception->getLine(),
-                    'functionName' => $exception->getTrace()[0]['function']
+                    'functionName' => Bootstrap::getFunctionNameForReport(
+                        $exception->getTrace()
+                    )
                 ]
             ],
             'serviceContext' => [
@@ -185,7 +187,7 @@ class BootstrapTest extends TestCase
                 'reportLocation' => [
                     'filePath' => $error['file'],
                     'lineNumber' => $error['line'],
-                    'functionName' => 'unknown'
+                    'functionName' => '<unknown function>'
                 ]
             ],
             'serviceContext' => [
@@ -278,7 +280,7 @@ class BootstrapTest extends TestCase
                 'reportLocation' => [
                     'filePath' => $error['file'],
                     'lineNumber' => $error['line'],
-                    'functionName' => 'unknown'
+                    'functionName' => '<unknown function>'
                 ]
             ],
             'serviceContext' => [


### PR DESCRIPTION
Without the `reportLocation` property, the `exceptionHandler` function does not actually populate the serviceContext data. Also, we have the reportLocation data via the exception so we can plug it in.

I believe the intention here was the stack trace would be parsed, but this is not working as expected so we should just plug the actual data in.