### PR TITLE
Debugger: Fix loading source context as array from source-contexts.json

### DIFF
--- a/Debugger/src/Debuggee.php
+++ b/Debugger/src/Debuggee.php
@@ -380,7 +380,7 @@ class Debuggee
                 return is_array($esc) ? $esc['context'] : $esc->context()->info();
             }, $this->extSourceContexts),
             'extSourceContexts' => array_map(function ($esc) {
-                return is_array($esc) ? $exc : $esc->info();
+                return is_array($esc) ? $esc : $esc->info();
             }, $this->extSourceContexts)
         ];
         if ($this->status) {

--- a/Debugger/src/Debuggee.php
+++ b/Debugger/src/Debuggee.php
@@ -380,7 +380,7 @@ class Debuggee
                 return is_array($esc) ? $esc['context'] : $esc->context()->info();
             }, $this->extSourceContexts),
             'extSourceContexts' => array_map(function ($esc) {
-                return $esc->info();
+                return is_array($esc) ? $exc : $esc->info();
             }, $this->extSourceContexts)
         ];
         if ($this->status) {

--- a/Debugger/tests/Unit/DebuggeeTest.php
+++ b/Debugger/tests/Unit/DebuggeeTest.php
@@ -150,4 +150,21 @@ class DebuggeeTest extends TestCase
         $this->assertTrue($debuggee->register());
         $this->assertEquals('debuggee1', $debuggee->id());
     }
+
+    public function testDebuggeeExtendedSourceContextSerialization()
+    {
+        $debuggee = new Debuggee($this->connection->reveal(), [
+            'project' => 'project1',
+            'extSourceContexts' => [
+                [
+                    'context' => []
+                ]
+            ]
+        ]);
+        $info = $debuggee->info();
+        $this->assertArrayHasKey('extSourceContexts', $info);
+        $this->assertCount(1, $info['extSourceContexts']);
+        $this->assertArrayHasKey('sourceContexts', $info);
+        $this->assertCount(1, $info['sourceContexts']);
+    }
 }


### PR DESCRIPTION
This fixes a bug where the debuggee may not correctly register. This fixes the E2E Debugger test.