### PR TITLE
Removing $optind variable

### DIFF
--- a/Debugger/bin/google-cloud-debugger
+++ b/Debugger/bin/google-cloud-debugger
@@ -58,7 +58,7 @@ if (count($argv) < 2) {
     showUsageAndDie();
 }
 
-$options = getopt('c:s:', ['config:', 'source-root:'], $optind) + [
+$options = getopt('c:s:', ['config:', 'source-root:']) + [
     'c' => null,
     'config' => null,
     's' => null,


### PR DESCRIPTION
On our documentation we say PHP 7.0 is necessary to use Stackdriver, however this debugger library uses the `$optind` parameter for `getopt`, said parameter was only added on 7.1 and it throws a Fatal error when using with PHP 7.0.

* Changelog: [http://php.net/manual/en/function.getopt.php#refsect1-function.getopt-changelog](http://php.net/manual/en/function.getopt.php#refsect1-function.getopt-changelog)
* [Documentation Stackdriver](https://cloud.google.com/debugger/docs/setup/php)

This PR removes it since it's not being used to keep the library compatible with 7.0