### PR TITLE
Improve Signed URLs

### DIFF
--- a/Core/src/Upload/ResumableUploader.php
+++ b/Core/src/Upload/ResumableUploader.php
@@ -49,6 +49,15 @@ class ResumableUploader extends AbstractUploader
     protected $resumeUri;
 
     /**
+     * Classes extending ResumableUploader may provide request headers to be
+     * included in {@see Google\Cloud\Core\Upload\ResumableUploader::upload()}
+     * and {@see Google\Cloud\Core\Upload\ResumableUploader::createResumeUri{}}.
+     *
+     * @var array
+     */
+    protected $headers = [];
+
+    /**
      * @param RequestWrapper $requestWrapper
      * @param string|resource|StreamInterface $data
      * @param string $uri
@@ -151,7 +160,7 @@ class ResumableUploader extends AbstractUploader
 
             $rangeEnd = $rangeStart + ($currStreamLimitSize - 1);
 
-            $headers = [
+            $headers = $this->headers + [
                 'Content-Length' => $currStreamLimitSize,
                 'Content-Type' => $this->contentType,
                 'Content-Range' => "bytes $rangeStart-$rangeEnd/$size",
@@ -201,7 +210,7 @@ class ResumableUploader extends AbstractUploader
      */
     protected function createResumeUri()
     {
-        $headers = [
+        $headers = $this->headers + [
             'X-Upload-Content-Type' => $this->contentType,
             'X-Upload-Content-Length' => $this->data->getSize(),
             'Content-Type' => 'application/json'

--- a/Core/src/Upload/SignedUrlUploader.php
+++ b/Core/src/Upload/SignedUrlUploader.php
@@ -17,8 +17,10 @@
 
 namespace Google\Cloud\Core\Upload;
 
+use Google\Cloud\Core\RequestWrapper;
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Upload data to Cloud Storage using a Signed URL
@@ -26,13 +28,48 @@ use Psr\Http\Message\ResponseInterface;
 class SignedUrlUploader extends ResumableUploader
 {
     /**
+     * @param RequestWrapper $requestWrapper
+     * @param string|resource|StreamInterface $data
+     * @param string $uri
+     * @param array $options [optional] {
+     *     Optional configuration.
+     *
+     *     @type array $metadata Metadata on the resource.
+     *     @type int $chunkSize Size of the chunks to send incrementally during
+     *           a resumable upload. Must be in multiples of 262144 bytes.
+     *     @type array $restOptions HTTP client specific configuration options.
+     *     @type float $requestTimeout Seconds to wait before timing out the
+     *           request. **Defaults to** `0`.
+     *     @type int $retries Number of retries for a failed request.
+     *           **Defaults to** `3`.
+     *     @type string $contentType Content type of the resource.
+     *     @type string $origin If the target has Cross-Origin Resource Sharing
+     *           enabled, the value of the Origin header to be used in upload
+     *           requests.
+     * }
+     */
+    public function __construct(
+        RequestWrapper $requestWrapper,
+        $data,
+        $uri,
+        array $options = []
+    ) {
+        if (isset($options['origin'])) {
+            $this->headers['Origin'] = $options['origin'];
+            unset($options['origin']);
+        }
+
+        parent::__construct($requestWrapper, $data, $uri, $options);
+    }
+
+    /**
      * Creates the resume URI.
      *
      * @return string
      */
     protected function createResumeUri()
     {
-        $headers = [
+        $headers = $this->headers + [
             'Content-Type' => $this->contentType,
             'Content-Length' => 0,
             'x-goog-resumable' => 'start'
@@ -45,6 +82,7 @@ class SignedUrlUploader extends ResumableUploader
         );
 
         $response = $this->requestWrapper->send($request, $this->requestOptions);
+
         return $this->resumeUri = $response->getHeaderLine('Location');
     }
 

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -981,7 +981,7 @@ class StorageObject
      *     @type string $contentType If you provide this value, the client must
      *           provide this HTTP header set to the same value.
      *     @type string $origin Value of CORS header
-     *           "Access-Control-Allow-Origin". **Defaults to** "*".
+     *           "Access-Control-Allow-Origin". **Defaults to** `"*"`.
      *     @type string $contentMd5 The MD5 digest value in base64. If you
      *           provide this, the client must provide this HTTP header with
      *           this same value in its request. If provided, take care to

--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -644,6 +644,9 @@ class StorageObject
     /**
      * Create a Signed URL for this object.
      *
+     * Signed URLs can be complex, and it is strongly recommended you read and
+     * understand the [documentation](https://cloud.google.com/storage/docs/access-control/signed-urls).
+     *
      * Example:
      * ```
      * $url = $object->signedUrl(new Timestamp(new DateTime('tomorrow')));
@@ -655,6 +658,8 @@ class StorageObject
      *     'method' => 'PUT'
      * ]);
      * ```
+     *
+     * @see https://cloud.google.com/storage/docs/access-control/signed-urls Signed URLs
      *
      * @param Timestamp|\DateTimeInterface|int $expires Specifies when the URL
      *        will expire. May provide an instance of {@see Google\Cloud\Core\Timestamp},
@@ -672,20 +677,23 @@ class StorageObject
      *           provide this, the client must provide this HTTP header with
      *           this same value in its request. If provided, take care to
      *           always provide this value as a base64 encoded string.
-     *     @type string $contentType If you provide this value, the client must
-     *           provide this HTTP header set to the same value.
      *     @type array $headers If these headers are used, the server will check
      *           to make sure that the client provides matching values. Provide
      *           headers as a key/value array, where the key is the header name,
-     *           and the value is an array of header values.
+     *           and the value is an array of header values. Headers with multiple
+     *           values may provide values as a simple array, or a
+     *           comma-separated string. Headers names MUST begin with `x-goog-`.
      *     @type string $saveAsName The filename to prompt the user to save the
      *           file as when the signed url is accessed. This is ignored if
      *           `$options.responseDisposition` is set.
      *     @type string $responseDisposition The
      *           [`response-content-disposition`](http://www.iana.org/assignments/cont-disp/cont-disp.xhtml)
      *           parameter of the signed url.
+     *     @type string $contentType If you provide this value, the client must
+     *           provide this HTTP header set to the same value.
      *     @type string $responseType The `response-content-type` parameter of the
-     *           signed url.
+     *           signed url. When the server contentType is `null`, this option
+     *           may be used to control the content type of the response.
      *     @type array $keyFile Keyfile data to use in place of the keyfile with
      *           which the client was constructed. If `$options.keyFilePath` is
      *           set, this option is ignored.
@@ -695,10 +703,11 @@ class StorageObject
      *           whether phpseclib is available. **Defaults to** `false`.
      * }
      * @return string
-     * @throws \InvalidArgumentException If the given expiration is in the past.
+     * @throws \InvalidArgumentException If the given expiration is invalid or in the past.
      * @throws \InvalidArgumentException If the given `$options.method` is not valid.
      * @throws \InvalidArgumentException If the given `$options.keyFilePath` is not valid.
-     * @throws \InvalidArgumentException If the keyfile does not contain the required information.
+     * @throws \InvalidArgumentException If the given custom headers are invalid.
+     * @throws \RuntimeException If the keyfile does not contain the required information.
      */
     public function signedUrl($expires, array $options = [])
     {
@@ -772,11 +781,45 @@ class StorageObject
             );
         }
 
+        // Make sure disallowed headers are not included.
+        $illegalHeaders = [
+            'x-goog-encryption-key',
+            'x-goog-encryption-key-sha256'
+        ];
+
+        if ($illegal = array_intersect_key(array_flip($illegalHeaders), $options['headers'])) {
+            throw new \InvalidArgumentException(sprintf(
+                '%s %s not allowed in Signed URL headers.',
+                implode(' and ', array_keys($illegal)),
+                count($illegal) === 1 ? 'is' : 'are'
+            ));
+        }
+
+        // Sort headers by name.
+        ksort($options['headers']);
+
         $headers = [];
         foreach ($options['headers'] as $name => $value) {
-            $value = (is_array($value))
-                ? implode(',', $value)
-                : $value;
+            $name = strtolower(trim($name));
+
+            $value = is_array($value)
+                ? implode(',', array_map('trim', $value))
+                : trim($value);
+
+            // Linebreaks are not allowed in headers.
+            // Rather than strip, we throw because we don't want to change the expected value without the user knowing.
+            if (strpos($value, PHP_EOL) !== false) {
+                throw new \InvalidArgumentException(
+                    'Line endings are not allowed in header values. Replace line endings with a single space.'
+                );
+            }
+
+            // Invalid header names throw exception.
+            if (strpos($name, 'x-goog-') !== 0) {
+                throw new \InvalidArgumentException(
+                    'Header names must begin with `x-goog-`.'
+                );
+            }
 
             $headers[] = $name .':'. $value;
         }
@@ -815,10 +858,6 @@ class StorageObject
         $query[] = 'GoogleAccessId=' . $keyFile['client_email'];
         $query[] = 'Expires=' . $seconds;
         $query[] = 'Signature=' . $encodedSignature;
-
-        if ($options['contentType']) {
-            $query[] = 'response-content-type=' . urlencode($options['contentType']);
-        }
 
         if ($options['responseDisposition']) {
             $query[] = 'response-content-disposition=' . urlencode($options['responseDisposition']);
@@ -879,7 +918,9 @@ class StorageObject
      *     @type array $headers If these headers are used, the server will check
      *           to make sure that the client provides matching values. Provide
      *           headers as a key/value array, where the key is the header name,
-     *           and the value is an array of header values.
+     *           and the value is an array of header values. Headers with multiple
+     *           values may provide values as a simple array, or a
+     *           comma-separated string. Headers names MUST begin with `x-goog-`.
      *     @type array $keyFile Keyfile data to use in place of the keyfile with
      *           which the client was constructed. If `$options.keyFilePath` is
      *           set, this option is ignored.
@@ -893,10 +934,15 @@ class StorageObject
     public function signedUploadUrl($expires, array $options = [])
     {
         $options += [
-            'headers' => [],
             'contentType' => null,
             'contentMd5' => null,
         ];
+
+        if (!isset($options['headers'])) {
+            $options['headers'] = [];
+        }
+
+        $options['headers']['x-goog-resumable'] = ['start'];
 
         unset(
             $options['cname'],
@@ -904,8 +950,6 @@ class StorageObject
             $options['responseDisposition'],
             $options['responseType']
         );
-
-        $options['headers']['x-goog-resumable'] = ['start'];
 
         return $this->signedUrl($expires, [
             'method' => 'POST',
@@ -919,6 +963,7 @@ class StorageObject
      * The returned URL differs from the return value of
      * {@see Google\Cloud\Storage\StorageObject::signedUploadUrl()} in that it
      * is ready to accept upload data immediately via an HTTP PUT request.
+     *
      * Because an upload session is created by the client, the expiration date
      * is not configurable. The URL generated by this method is valid for one
      * week.
@@ -935,6 +980,8 @@ class StorageObject
      *
      *     @type string $contentType If you provide this value, the client must
      *           provide this HTTP header set to the same value.
+     *     @type string $origin Value of CORS header
+     *           "Access-Control-Allow-Origin". **Defaults to** "*".
      *     @type string $contentMd5 The MD5 digest value in base64. If you
      *           provide this, the client must provide this HTTP header with
      *           this same value in its request. If provided, take care to
@@ -942,7 +989,9 @@ class StorageObject
      *     @type array $headers If these headers are used, the server will check
      *           to make sure that the client provides matching values. Provide
      *           headers as a key/value array, where the key is the header name,
-     *           and the value is an array of header values.
+     *           and the value is an array of header values. Headers with multiple
+     *           values may provide values as a simple array, or a
+     *           comma-separated string. Headers names MUST begin with `x-goog-`.
      *     @type array $keyFile Keyfile data to use in place of the keyfile with
      *           which the client was constructed. If `$options.keyFilePath` is
      *           set, this option is ignored.
@@ -958,7 +1007,16 @@ class StorageObject
         $timestamp = new \DateTimeImmutable('+1 minute');
         $startUri = $this->signedUploadUrl($timestamp, $options);
 
-        $uploader = new SignedUrlUploader($this->connection->requestWrapper(), '', $startUri);
+        $uploaderOptions = $this->pluckArray([
+            'contentType',
+            'origin'
+        ], $options);
+
+        if (!isset($uploaderOptions['origin'])) {
+            $uploaderOptions['origin'] = '*';
+        }
+
+        $uploader = new SignedUrlUploader($this->connection->requestWrapper(), '', $startUri, $uploaderOptions);
 
         return $uploader->getResumeUri();
     }

--- a/Storage/tests/System/SignedUrlTest.php
+++ b/Storage/tests/System/SignedUrlTest.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Storage\Tests\System;
 
+use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Core\Timestamp;
 use GuzzleHttp\Client;
 
@@ -40,11 +41,19 @@ class SignedUrlTest extends StorageTestCase
     {
         return [
             [
-                self::RANDOM_NAME
+                uniqid(self::TESTING_PREFIX)
             ], [
                 uniqid(self::TESTING_PREFIX . ' ' . self::TESTING_PREFIX)
             ], [
                 uniqid(self::TESTING_PREFIX) .'/'. uniqid(self::TESTING_PREFIX) .' '. uniqid(self::TESTING_PREFIX)
+            ], [
+                uniqid(self::TESTING_PREFIX),
+                [
+                    'headers' => [
+                        'x-goog-foo' => 'bar',
+                        'x-goog-a' => 'b'
+                    ]
+                ]
             ]
         ];
     }
@@ -54,14 +63,11 @@ class SignedUrlTest extends StorageTestCase
      */
     public function testSignedUrl($objectName, array $urlOpts = [])
     {
-        if ($objectName === self::RANDOM_NAME) {
-            $objectName = null;
-        }
         $obj = $this->createFile($objectName);
         $ts = new Timestamp(new \DateTime('tomorrow'));
         return $obj->signedUrl($ts, $urlOpts);
 
-        $this->assertEquals(self::CONTENT, $this->getFile($url));
+        $this->assertEquals(self::CONTENT, $this->getFile($url, $urlOpts));
     }
 
     /**
@@ -69,13 +75,20 @@ class SignedUrlTest extends StorageTestCase
      */
     public function testSignedUrlDelete()
     {
-        $obj = $this->createFile();
+        $obj = $this->createFile(uniqid(self::TESTING_PREFIX));
 
         $ts = new Timestamp(new \DateTime('tomorrow'));
         $url = $obj->signedUrl($ts, [
             'method' => 'DELETE',
             'contentType' => 'text/plain'
         ]);
+
+        try {
+            $obj->reload();
+        } catch (NotFoundException $e) {
+            // If the file doesn't exist now, prevent the expected throw to get a failure.
+            return false;
+        }
 
         $this->deleteFile($url, [
             'Content-type' => 'text/plain'
@@ -84,11 +97,79 @@ class SignedUrlTest extends StorageTestCase
         $obj->reload();
     }
 
-    private function createFile($name = null)
+    public function testSignedUploadSession()
+    {
+        $obj = self::$bucket->object(uniqid(self::TESTING_PREFIX) .'.txt');
+        $url = $obj->beginSignedUploadSession();
+
+        $this->guzzle->request('PUT', $url, [
+            'body' => self::CONTENT
+        ]);
+
+        $this->assertTrue($obj->exists());
+        $this->assertEquals(self::CONTENT, $obj->downloadAsString());
+    }
+
+    public function testSignedUploadSessionOrigin()
+    {
+        $obj = self::$bucket->object(uniqid(self::TESTING_PREFIX) .'.txt');
+        self::$deletionQueue->add($obj);
+
+        $url = $obj->beginSignedUploadSession([
+            'origin' => 'https://google.com',
+            'headers' => [
+                'x-goog-test' => 'hi'
+            ]
+        ]);
+
+        $res = $this->guzzle->request('OPTIONS', $url, [
+            'headers' => [
+                'Origin' => 'https://google.com',
+                'x-goog-test' => 'hi'
+            ]
+        ]);
+
+        $this->guzzle->request('PUT', $url, [
+            'body' => self::CONTENT,
+            'headers' => [
+                'x-goog-test' => 'hi'
+            ]
+        ]);
+
+        $this->assertEquals('https://google.com', $res->getHeaderLine('Access-Control-Allow-Origin'));
+
+        $this->assertTrue($obj->exists());
+        $this->assertEquals(self::CONTENT, $obj->downloadAsString());
+    }
+
+    public function testSignedUrlContentType()
+    {
+        $obj = $this->createFile(uniqid(self::TESTING_PREFIX) .'.txt');
+
+        $obj->update([
+            'contentType' => null
+        ]);
+
+        $url = $obj->signedUrl(time()+2, [
+            'responseDisposition' => 'attachment;filename="image.jpg"',
+            'responseType' => 'image/jpg'
+        ]);
+
+        $res = $this->guzzle->request('GET', $url, [
+            'headers' => [
+                // 'Content-Type' => 'image/jpg'
+            ]
+        ]);
+
+        $this->assertEquals('image/jpg', $res->getHeaderLine('Content-Type'));
+        $this->assertEquals('attachment;filename="image.jpg"', $res->getHeaderLine('Content-Disposition'));
+    }
+
+    private function createFile($name)
     {
         $bucket = self::$bucket;
         $object = $bucket->upload(self::CONTENT, [
-            'name' => $name ?: uniqid(self::TESTING_PREFIX) .'.txt',
+            'name' => $name .'.txt',
         ]);
 
         self::$deletionQueue->add($object);
@@ -96,16 +177,15 @@ class SignedUrlTest extends StorageTestCase
         return $object;
     }
 
-    private function getFile($url)
+    private function getFile($url, array $options = [])
     {
-        $res = $this->guzzle->request('GET', $url);
+        $res = $this->guzzle->request('GET', $url, $options);
 
         return (string) $res->getBody();
     }
 
     private function deleteFile($url, array $headers = [])
     {
-
         $this->guzzle->request('DELETE', $url, [
             'headers' => $headers
         ]);

--- a/Storage/tests/System/SignedUrlTest.php
+++ b/Storage/tests/System/SignedUrlTest.php
@@ -65,7 +65,7 @@ class SignedUrlTest extends StorageTestCase
     {
         $obj = $this->createFile($objectName);
         $ts = new Timestamp(new \DateTime('tomorrow'));
-        return $obj->signedUrl($ts, $urlOpts);
+        $url = $obj->signedUrl($ts, $urlOpts);
 
         $this->assertEquals(self::CONTENT, $this->getFile($url, $urlOpts));
     }


### PR DESCRIPTION
Fixes #1108, #1056, #1055.

This change attempts to add missing feature support for Cloud Storage Signed URLs and to make the existing functionality simpler and less error-prone.

* Added support for CORS on object upload. Calls to `StorageObject::beginSignedUploadSession()` now support the `origin` option.
* `StorageObject::signedUrl()` catches more fatal mistakes related to headers earlier, throwing an exception with useful errors rather than the cryptic error returned when an invalid URL is requested by a user.
* Setting `contentType` on `StorageObject::signedUrl()` no longer sets the value of `response-content-type`.
* Custom headers are sorted by their name within the client. Previously the user needed to provide properly ordered headers.
* Added additional system test coverage.