### PR TITLE
Fix return type for ItemIteratorTrait->current

### DIFF
--- a/Core/src/Iterator/ItemIteratorTrait.php
+++ b/Core/src/Iterator/ItemIteratorTrait.php
@@ -82,7 +82,7 @@ trait ItemIteratorTrait
     /**
      * Get the current item.
      *
-     * @return array|null
+     * @return mixed
      */
     public function current()
     {


### PR DESCRIPTION
The return type lists `array|null`, however it can actually return any type. E.g., in `EntityIterator`, it returns `Entity|null`.