### PR TITLE
Cleanup Firestore system test artifacts

### DIFF
--- a/Firestore/tests/System/DocumentAndCollectionTest.php
+++ b/Firestore/tests/System/DocumentAndCollectionTest.php
@@ -35,14 +35,11 @@ class DocumentAndCollectionTest extends FirestoreTestCase
             'firstName' => 'John',
             'country' => 'USA'
         ]);
-
-        self::$deletionQueue->add($this->document);
     }
 
     public function testCreate()
     {
         $document = self::$collection->newDocument();
-        self::$deletionQueue->add($document);
         $document->create(['firstName' => 'Kate']);
         $this->assertTrue($document->snapshot()->exists());
         $this->assertEquals(['firstName' => 'Kate'], $document->snapshot()->data());
@@ -108,12 +105,14 @@ class DocumentAndCollectionTest extends FirestoreTestCase
 
     public function testCollections()
     {
-        $doc = $this->document->collection('foo')->add(['name' => 'John']);
-        self::$deletionQueue->add($doc);
+        $childName = uniqid(self::COLLECTION_NAME);
+        $child = $this->document->collection($childName);
+        self::$localDeletionQueue->add($child);
+        $doc = $child->add(['name' => 'John']);
 
         $collection = $this->document->collections()->current();
 
-        $this->assertEquals('foo', $collection->id());
+        $this->assertEquals($childName, $collection->id());
     }
 
     public function testDeleteField()

--- a/Firestore/tests/System/GetAllDocumentsTest.php
+++ b/Firestore/tests/System/GetAllDocumentsTest.php
@@ -26,6 +26,8 @@ use Google\Cloud\Firestore\DocumentSnapshot;
  */
 class GetAllDocumentsTest extends FirestoreTestCase
 {
+    const COLLECTION_NAME = 'system-test-get-all-documents';
+
     private static $refsExist = [];
     private static $refsNonExist = [];
 
@@ -33,13 +35,14 @@ class GetAllDocumentsTest extends FirestoreTestCase
     {
         parent::setupBeforeClass();
 
-        $c = self::$client->collection('getAllDocumentsTest');
+        $c = self::$client->collection(uniqid(self::COLLECTION_NAME));
+        self::$localDeletionQueue->add($c);
+
         for ($i = 0; $i < 5; $i++) {
             $doc = $c->add([
                 'name' => 'foo'
             ]);
             self::$refsExist[$doc->name()] = $doc;
-            self::$deletionQueue->add($doc);
         }
 
         for ($i = 0; $i < 5; $i++) {

--- a/Firestore/tests/System/QueryTest.php
+++ b/Firestore/tests/System/QueryTest.php
@@ -23,13 +23,12 @@ namespace Google\Cloud\Firestore\Tests\System;
  */
 class QueryTest extends FirestoreTestCase
 {
-    const QUERY_COLLECTION = 'system-test-query';
-
     private $query;
 
     public function setUp()
     {
-        $this->query = self::$client->collection(self::QUERY_COLLECTION);
+        $this->query = self::$client->collection(uniqid(self::COLLECTION_NAME));
+        self::$localDeletionQueue->add($this->query);
     }
 
     public function testSelect()
@@ -94,7 +93,6 @@ class QueryTest extends FirestoreTestCase
     private function insertDoc(array $fields)
     {
         $doc = $this->query->add($fields);
-        self::$deletionQueue->add($doc);
 
         return $doc;
     }

--- a/Firestore/tests/System/README.md
+++ b/Firestore/tests/System/README.md
@@ -1,0 +1,10 @@
+# Firestore System Test Important Information
+
+Firestore does not use the global deletion queue for cleanup. Like datastore, it
+uses a local deletion queue, defined in `FirestoreTestCase` and available in all
+classes extending that class as `self::$localDeletionQueue`.
+
+Documents should not be added to the deletion queue. Instead, collections should
+be added to the deletion queue. Any collection created by the system test suite
+MUST be enqueued for deletion, and MUST use a unique name (i.e. `uniqid($testingPrefix)`).
+This applies to nested collections as well!

--- a/Firestore/tests/System/TransactionTest.php
+++ b/Firestore/tests/System/TransactionTest.php
@@ -28,7 +28,6 @@ class TransactionTest extends FirestoreTestCase
     public function setUp()
     {
         $doc = self::$collection->newDocument();
-        self::$deletionQueue->add($doc);
         $this->document = $doc;
     }
 

--- a/Firestore/tests/System/ValueMapperTest.php
+++ b/Firestore/tests/System/ValueMapperTest.php
@@ -36,7 +36,6 @@ class ValueMapperTest extends FirestoreTestCase
         parent::setupBeforeClass();
 
         self::$document = self::$collection->add([]);
-        self::$deletionQueue->add(self::$document);
     }
 
     /**

--- a/Firestore/tests/System/bootstrap.php
+++ b/Firestore/tests/System/bootstrap.php
@@ -1,6 +1,10 @@
 <?php
 
 use Google\Cloud\Core\Testing\TestHelpers;
+use Google\Cloud\Firestore\Tests\System\FirestoreTestCase;
 
 TestHelpers::requireKeyfile('GOOGLE_CLOUD_PHP_TESTS_KEY_PATH');
 TestHelpers::generatedSystemTestBootstrap();
+TestHelpers::systemTestShutdown(function () {
+    FirestoreTestCase::tearDownFixtures();
+});


### PR DESCRIPTION
This change fixes an issue where if system test artifacts remain, the next test run will fail.

All test collections are uniquely named and will not conflict with previous test executions. Additionally, the cleanup process has been improved to make it simpler to be sure all artifacts are removed upon test completion.