### PR TITLE
Add missing links and trailing slashes to README files

### DIFF
--- a/Bigtable/README.md
+++ b/Bigtable/README.md
@@ -1,6 +1,6 @@
 # Google Cloud Bigtable for PHP
 
-> Idiomatic PHP client for [Google Cloud Bigtable](https://cloud.google.com/bigtable/docs/).
+> Idiomatic PHP client for [Google Cloud Bigtable](https://cloud.google.com/bigtable/).
 
 [![Latest Stable Version](https://poser.pugx.org/google/cloud-bigtable/v/stable)](https://packagist.org/packages/google/cloud-bigtable) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-bigtable.svg)](https://packagist.org/packages/google/cloud-bigtable)
 

--- a/Dataproc/README.md
+++ b/Dataproc/README.md
@@ -1,6 +1,6 @@
 # Google Cloud Dataproc for PHP
 
-> Idiomatic PHP client for [Google Cloud Dataproc](https://cloud.google.com/dataproc).
+> Idiomatic PHP client for [Google Cloud Dataproc](https://cloud.google.com/dataproc/).
 
 [![Latest Stable Version](https://poser.pugx.org/google/cloud-bigtable/v/stable)](https://packagist.org/packages/google/cloud-bigtable) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-bigtable.svg)](https://packagist.org/packages/google/cloud-bigtable)
 

--- a/Dlp/README.md
+++ b/Dlp/README.md
@@ -1,6 +1,6 @@
 # Data Loss Prevention for PHP
 
-> Idiomatic PHP client for [Google DLP](https://cloud.google.com/dlp).
+> Idiomatic PHP client for [Google DLP](https://cloud.google.com/dlp/).
 
 [![Latest Stable Version](https://poser.pugx.org/google/cloud-dlp/v/stable)](https://packagist.org/packages/google/cloud-dlp) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-dlp.svg)](https://packagist.org/packages/google/cloud-dlp)
 

--- a/Kms/README.md
+++ b/Kms/README.md
@@ -1,6 +1,6 @@
 # Cloud KMS for PHP
 
-> Idiomatic PHP client for [Cloud KMS](https://cloud.google.com/kms).
+> Idiomatic PHP client for [Cloud KMS](https://cloud.google.com/kms/).
 
 [![Latest Stable Version](https://poser.pugx.org/google/cloud-kms/v/stable)](https://packagist.org/packages/google/cloud-kms) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-kms.svg)](https://packagist.org/packages/google/cloud-kms)
 

--- a/Redis/README.md
+++ b/Redis/README.md
@@ -1,6 +1,6 @@
 # Google Cloud Redis for PHP
 
-> Idiomatic PHP client for [Google Cloud Redis](https://cloud.google.com/memorystore).
+> Idiomatic PHP client for [Google Cloud Redis](https://cloud.google.com/memorystore/).
 
 [![Latest Stable Version](https://poser.pugx.org/google/cloud-redis/v/stable)](https://packagist.org/packages/google/cloud-redis) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-redis.svg)](https://packagist.org/packages/google/cloud-redis)
 

--- a/TextToSpeech/README.md
+++ b/TextToSpeech/README.md
@@ -1,6 +1,6 @@
 # Cloud Text-to-Speech for PHP
 
-> Idiomatic PHP client for [Cloud Text-to-Speech](https://cloud.google.com/text-to-speech).
+> Idiomatic PHP client for [Cloud Text-to-Speech](https://cloud.google.com/text-to-speech/).
 
 [![Latest Stable Version](https://poser.pugx.org/google/cloud-text-to-speech/v/stable)](https://packagist.org/packages/google/cloud-text-to-speech) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-text-to-speech.svg)](https://packagist.org/packages/google/cloud-text-to-speech)
 

--- a/VideoIntelligence/README.md
+++ b/VideoIntelligence/README.md
@@ -1,5 +1,7 @@
 # Google Cloud Video Intelligence for PHP
 
+> Idiomatic PHP client for [Cloud Video Intelligence](https://cloud.google.com/video-intelligence/)
+
 [![Latest Stable Version](https://poser.pugx.org/google/cloud-videointelligence/v/stable)](https://packagist.org/packages/google/cloud-videointelligence) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-videointelligence.svg)](https://packagist.org/packages/google/cloud-videointelligence)
 
 * [API documentation](http://googlecloudplatform.github.io/google-cloud-php/#/docs/cloud-videointelligence/latest)


### PR DESCRIPTION
Replaces https://github.com/GoogleCloudPlatform/google-cloud-php-redis/pull/1.

The [Redis page 404's](https://cloud.google.com/memorystore) if the trailing slash is not present. This seems to be somewhat inconsistent across cloud.google.com, so I added them where missing to be safe.