### PR TITLE
[Breaking Change] Fix firestore queries

### DIFF
--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -156,7 +156,10 @@ class Query
      */
     public function documents(array $options = [])
     {
-        $maxRetries = $this->pluck('maxRetries', $options, false) ?: FirestoreClient::MAX_RETRIES;
+        $maxRetries = $this->pluck('maxRetries', $options, false);
+        $maxRetries = $maxRetries === null
+            ? FirestoreClient::MAX_RETRIES
+            : $maxRetries;
 
         $rows = (new ExponentialBackoff($maxRetries))->execute(function () use ($options) {
             $generator = $this->connection->runQuery([
@@ -212,6 +215,8 @@ class Query
      * list of field paths to return, or use an empty list to only return the
      * references of matching documents.
      *
+     * Subsequent calls to this method will override previous values.
+     *
      * Example:
      * ```
      * $query = $query->select(['firstName']);
@@ -241,7 +246,7 @@ class Query
             'select' => [
                 'fields' => $fields
             ]
-        ]);
+        ], true);
     }
 
     /**

--- a/Firestore/tests/Unit/QueryTest.php
+++ b/Firestore/tests/Unit/QueryTest.php
@@ -95,7 +95,7 @@ class QueryTest extends TestCase
 
         $this->query->___setProperty('connection', $this->connection->reveal());
 
-        $res = $this->query->documents();
+        $res = $this->query->documents(['maxRetries' => 0]);
         $this->assertContainsOnlyInstancesOf(DocumentSnapshot::class, $res);
         $this->assertCount(1, $res->rows());
 
@@ -145,7 +145,6 @@ class QueryTest extends TestCase
 
         $this->runAndAssert(function (Query $q) use ($paths) {
             $res = $q->select($paths);
-            $res = $res->select(['users.dan']);
 
             return $res;
         }, [
@@ -156,6 +155,29 @@ class QueryTest extends TestCase
                     'fields' => [
                         [ 'fieldPath' => 'users.john' ],
                         [ 'fieldPath' => 'users.dave' ],
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    public function testSelectOverride()
+    {
+        $paths = [
+            'users.john',
+            'users.dave'
+        ];
+
+        $this->runAndAssert(function (Query $q) use ($paths) {
+            $res = $q->select($paths);
+            $res = $res->select(['users.dan']);
+            return $res;
+        }, [
+            'parent' => self::PARENT,
+            'structuredQuery' => [
+                'from' => $this->queryFrom(),
+                'select' => [
+                    'fields' => [
                         [ 'fieldPath' => 'users.dan' ],
                     ]
                 ]


### PR DESCRIPTION
* [Breaking] `Query::select()` now overwrites previous selects rather than merging/appending.
* [Bugfix] `Query::documents()` now correctly handles setting `maxRetries` to zero.
