### PR TITLE
[Breaking Change] Add support for Document Snapshots in Firestore Query Cursors

### DIFF
--- a/Firestore/src/CollectionReference.php
+++ b/Firestore/src/CollectionReference.php
@@ -73,14 +73,16 @@ class CollectionReference extends Query
         $this->valueMapper = $valueMapper;
         $this->name = $name;
 
+        $parent = $this->parentPath($this->name);
+
         parent::__construct(
             $connection,
             $valueMapper,
-            $this->parentPath($this->name),
+            $parent,
             [
                 'from' => [
                     [
-                        'collectionId' => $this->pathId($this->name)
+                        'collectionId' => $this->pathId($this->name),
                     ]
                 ]
             ]

--- a/Firestore/src/CollectionReference.php
+++ b/Firestore/src/CollectionReference.php
@@ -73,16 +73,14 @@ class CollectionReference extends Query
         $this->valueMapper = $valueMapper;
         $this->name = $name;
 
-        $parent = $this->parentPath($this->name);
-
         parent::__construct(
             $connection,
             $valueMapper,
-            $parent,
+            $this->parentPath($this->name),
             [
                 'from' => [
                     [
-                        'collectionId' => $this->pathId($this->name),
+                        'collectionId' => $this->pathId($this->name)
                     ]
                 ]
             ]

--- a/Firestore/src/DocumentSnapshot.php
+++ b/Firestore/src/DocumentSnapshot.php
@@ -294,7 +294,10 @@ class DocumentSnapshot implements \ArrayAccess
                 break;
             } else {
                 if (!isset($fields[$part])) {
-                    throw new \InvalidArgumentException('field path does not exist.');
+                    throw new \InvalidArgumentException(sprintf(
+                        'Field path `%s` does not exist.',
+                        $fieldPath
+                    ));
                 }
 
                 $fields = $fields[$part];

--- a/Firestore/src/FieldValue.php
+++ b/Firestore/src/FieldValue.php
@@ -84,4 +84,19 @@ class FieldValue
     {
         return '___google-cloud-php__serverTimestamp___';
     }
+
+    /**
+     * Check if the given value is a sentinel.
+     *
+     * @param string $value
+     * @return bool
+     * @access private
+     */
+    public static function isSentinelValue($value)
+    {
+        return in_array($value, [
+            self::deleteField(),
+            self::serverTimestamp()
+        ]);
+    }
 }

--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -580,7 +580,7 @@ class Query
     {
         $orderBy = $this->queryKey('orderBy') ?: [];
         if ($fieldValues instanceof DocumentSnapshot) {
-            list ($fieldValues, $orderBy) = $this->snapshotPosition($fieldValues, $orderBy);
+            list($fieldValues, $orderBy) = $this->snapshotPosition($fieldValues, $orderBy);
         } else {
             if (!is_array($fieldValues)) {
                 throw new \InvalidArgumentException(sprintf(
@@ -675,18 +675,18 @@ class Query
      * Build cursors for document snapshots.
      *
      * @param DocumentSnapshot $snapshot The document snapshot
-     * @return array[] A list, where position 0 is fieldValues and position 1 is orderBy.
+     * @param array $orderBy A list of orderBy clauses.
+     * @return array A list, where position 0 is fieldValues and position 1 is orderBy.
      */
     private function snapshotPosition(DocumentSnapshot $snapshot, array $orderBy)
     {
         $appendName = true;
-        $direction = self::DIR_ASCENDING;
-        $fieldValues = [];
-
-        // If the list of orderBy clauses already contains __name__, use it unchanged.
-        $appendName = !(bool) array_filter($orderBy, function ($order) {
-            return $order['field']['fieldPath'] === self::DOCUMENT_ID;
-        });
+        foreach ($orderBy as $order) {
+            if ($order['field']['fieldPath'] === self::DOCUMENT_ID) {
+                $appendName = false;
+                break;
+            }
+        }
 
         if ($appendName) {
             // If there is inequality filter (anything other than equals),
@@ -799,15 +799,15 @@ class Query
      * at execution.
      *
      * @param array $query The incoming query
-     * @return array The final query data,
+     * @return array The final query data
      */
     private function finalQueryPrepare(array $query)
     {
         if (isset($query['where']['compositeFilter']) && count($query['where']['compositeFilter']['filters']) === 1) {
             $filter = $query['where']['compositeFilter']['filters'][0];
-            unset($query['where']);
             $query['where'] = $filter;
         }
+
         return $query;
     }
 }

--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -276,9 +276,10 @@ class Query
     public function where($fieldPath, $operator, $value)
     {
         if (FieldValue::isSentinelValue($value)) {
-            throw new \InvalidArgumentException(
-                'Value cannot be a `Google\Cloud\Firestore\FieldType` value.'
-            );
+            throw new \InvalidArgumentException(sprintf(
+                'Value cannot be a `%s` value.',
+                FieldValue::class
+            ));
         }
 
         $escapedFieldPath = $this->valueMapper->escapeFieldPath($fieldPath);
@@ -582,20 +583,25 @@ class Query
             list ($fieldValues, $orderBy) = $this->snapshotPosition($fieldValues, $orderBy);
         } else {
             if (!is_array($fieldValues)) {
-                throw new \InvalidArgumentException('Field values must be an array or DocumentSnapshot.');
+                throw new \InvalidArgumentException(sprintf(
+                    'Field values must be an array or an instance of `%s`.',
+                    DocumentSnapshot::class
+                ));
             }
 
             foreach ($fieldValues as $value) {
                 if ($value instanceof DocumentSnapshot) {
-                    throw new \InvalidArgumentException(
-                        'DocumentSnapshots are not allowed in an array of field values. ' .
-                        'Provide it as the method argument instead.'
-                    );
+                    throw new \InvalidArgumentException(sprintf(
+                        'Instances of `%` are not allowed in an array of field values. ' .
+                        'Provide it as the method argument instead.',
+                        DocumentSnapshot::class
+                    ));
                 }
                 if (FieldValue::isSentinelValue($value)) {
-                    throw new \InvalidArgumentException(
-                        'Value cannot be a `Google\Cloud\Firestore\FieldType` value.'
-                    );
+                    throw new \InvalidArgumentException(sprintf(
+                        'Value cannot be a `%s` value.',
+                        FieldValue::class
+                    ));
                 }
             }
         }

--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -21,6 +21,7 @@ use Google\Cloud\Core\DebugInfoTrait;
 use Google\Cloud\Core\ExponentialBackoff;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\DocumentSnapshot;
+use Google\Cloud\Firestore\FieldValue;
 use Google\Cloud\Firestore\SnapshotTrait;
 use Google\Cloud\Firestore\V1beta1\StructuredQuery_CompositeFilter_Operator;
 use Google\Cloud\Firestore\V1beta1\StructuredQuery_Direction;
@@ -126,7 +127,10 @@ class Query
         $this->connection = $connection;
         $this->valueMapper = $valueMapper;
         $this->parent = $parent;
-        $this->query = $query;
+        $this->query = $query + [
+            'orderBy' => [],
+            'offset' => 0
+        ];
 
         if (!isset($this->query['from'])) {
             throw new \InvalidArgumentException(
@@ -162,11 +166,12 @@ class Query
             : $maxRetries;
 
         $rows = (new ExponentialBackoff($maxRetries))->execute(function () use ($options) {
-            $generator = $this->connection->runQuery([
+            $query = $this->finalQueryPrepare($this->query);
+            $generator = $this->connection->runQuery($this->arrayFilterRemoveNull([
                 'parent' => $this->parent,
-                'structuredQuery' => $this->query,
+                'structuredQuery' => $query,
                 'retries' => 0
-            ] + $options);
+            ]) + $options);
 
             // cache collection references
             $collections = [];
@@ -270,6 +275,12 @@ class Query
      */
     public function where($fieldPath, $operator, $value)
     {
+        if (FieldValue::isSentinelValue($value)) {
+            throw new \InvalidArgumentException(
+                'Value cannot be a `Google\Cloud\Firestore\FieldType` value.'
+            );
+        }
+
         $escapedFieldPath = $this->valueMapper->escapeFieldPath($fieldPath);
 
         $operator = array_key_exists($operator, $this->shortOperators)
@@ -338,7 +349,7 @@ class Query
      * @param string $direction The direction to order in. **Defaults to** `ASC`.
      * @return Query A new instance of Query with the given changes applied.
      * @throws \InvalidArgumentException If an invalid direction is given.
-     * @throws \BadMethodCallException If orderBy is called after `startAt()`,
+     * @throws \InvalidArgumentException If orderBy is called after `startAt()`,
      *         `startAfter()`, `endBefore()` or `endAt`().
      */
     public function orderBy($fieldPath, $direction = self::DIR_ASCENDING)
@@ -355,7 +366,7 @@ class Query
         }
 
         if ($this->queryHas('startAt') || $this->queryHas('endAt')) {
-            throw new \BadMethodCallException(
+            throw new \InvalidArgumentException(
                 'Cannot specify an orderBy constraint after calling any of ' .
                 '`startAt()`, `startAfter()`, `endBefore()` or `endAt`().'
             );
@@ -433,14 +444,14 @@ class Query
      * $users18YearsOrOlder = $query->documents();
      * ```
      *
-     * @param array $fieldValues A list of values defining the query starting point.
+     * @param mixed[]|DocumentSnapshot $fieldValues A list of values, or an
+     *        instance of {@see Google\Cloud\Firestore\DocumentSnapshot}
+     *        defining the query starting point.
      * @return Query A new instance of Query with the given changes applied.
      */
-    public function startAt(array $fieldValues)
+    public function startAt($fieldValues)
     {
-        return $this->newQuery([
-            'startAt' => $this->buildPosition($fieldValues, true)
-        ], true);
+        return $this->buildPosition('startAt', $fieldValues, true);
     }
 
     /**
@@ -461,14 +472,14 @@ class Query
      * $users18YearsOrOlder = $query->documents();
      * ```
      *
-     * @param array $fieldValues A list of values defining the query starting point.
+     * @param mixed[]|DocumentSnapshot $fieldValues A list of values, or an
+     *        instance of {@see Google\Cloud\Firestore\DocumentSnapshot}
+     *        defining the query starting point.
      * @return Query A new instance of Query with the given changes applied.
      */
-    public function startAfter(array $fieldValues)
+    public function startAfter($fieldValues)
     {
-        return $this->newQuery([
-            'startAt' => $this->buildPosition($fieldValues, false)
-        ], true);
+        return $this->buildPosition('startAt', $fieldValues, false);
     }
 
     /**
@@ -489,14 +500,14 @@ class Query
      * $usersYoungerThan18 = $query->documents();
      * ```
      *
-     * @param array $fieldValues A list of values defining the query end point.
+     * @param mixed[]|DocumentSnapshot $fieldValues A list of values, or an
+     *        instance of {@see Google\Cloud\Firestore\DocumentSnapshot}
+     *        defining the query end point.
      * @return Query A new instance of Query with the given changes applied.
      */
-    public function endBefore(array $fieldValues)
+    public function endBefore($fieldValues)
     {
-        return $this->newQuery([
-            'endAt' => $this->buildPosition($fieldValues, true)
-        ], true);
+        return $this->buildPosition('endAt', $fieldValues, true);
     }
 
     /**
@@ -517,82 +528,14 @@ class Query
      * $usersYoungerThan18 = $query->documents();
      * ```
      *
-     * @param array $fieldValues A list of values defining the query end point.
+     * @param mixed[]|DocumentSnapshot $fieldValues A list of values, or an
+     *        instance of {@see Google\Cloud\Firestore\DocumentSnapshot}
+     *        defining the query end point.
      * @return Query A new instance of Query with the given changes applied.
      */
-    public function endAt(array $fieldValues)
+    public function endAt($fieldValues)
     {
-        return $this->newQuery([
-            'endAt' => $this->buildPosition($fieldValues, false)
-        ], true);
-    }
-
-    /**
-     * Builds a Firestore query position.
-     *
-     * @param array $fieldValues The set of field values to use as the query boundary.
-     * @param bool $before Whether the query boundary lies just before or after
-     *        the provided data.
-     * @return array
-     */
-    private function buildPosition(array $fieldValues, $before)
-    {
-        if (!$this->queryHas('orderBy') || count($fieldValues) > count($this->query['orderBy'])) {
-            throw new \BadMethodCallException(
-                'Too many cursor values specified. The specified values must ' .
-                'match the `orderBy` constraints of the query.'
-            );
-        }
-
-        $order = $this->query['orderBy'];
-        foreach ($fieldValues as $i => &$value) {
-            if ($order[$i]['field']['fieldPath'] === self::DOCUMENT_ID) {
-                $collection = $this->childPath(
-                    $this->parent,
-                    $this->query['from'][0]['collectionId']
-                );
-
-                if (is_string($value)) {
-                    $c = new CollectionReference(
-                        $this->connection,
-                        $this->valueMapper,
-                        $collection
-                    );
-
-                    $value = new DocumentReference(
-                        $this->connection,
-                        $this->valueMapper,
-                        $c,
-                        $this->childPath($collection, $value)
-                    );
-                } elseif ($value instanceof DocumentReference) {
-                    $name = $value->name();
-                    if (!$this->isPrefixOf($collection, $name)) {
-                        throw new \BadMethodCallException(sprintf(
-                            '%s is not a part of the query result set and ' .
-                            'cannot be used as a query boundary',
-                            $name
-                        ));
-                    }
-                } else {
-                    throw new \BadMethodCallException(
-                        'The corresponding value for DOCUMENT_ID must be a ' .
-                        'string or a DocumentReference.'
-                    );
-                }
-
-                if ($value->parent()->name() !== $collection) {
-                    throw new \BadMethodCallException(
-                        'Only direct children may be used as query boundaries.'
-                    );
-                }
-            }
-        }
-
-        return [
-            'before' => $before,
-            'values' => $this->valueMapper->encodeValues($fieldValues)
-        ];
+        return $this->buildPosition('endAt', $fieldValues, false);
     }
 
     /**
@@ -600,10 +543,218 @@ class Query
      *
      * @param string $key The constraint name.
      * @return bool
+     * @access private
      */
-    private function queryHas($key)
+    public function queryHas($key)
     {
         return isset($this->query[$key]);
+    }
+
+    /**
+     * Get the constraint data from the current query.
+     *
+     * @param string $key The constraint name
+     * @return mixed
+     * @access private
+     */
+    public function queryKey($key)
+    {
+        return $this->queryHas($key)
+            ? $this->query[$key]
+            : null;
+    }
+
+    /**
+     * Builds a Firestore query position.
+     *
+     * @param string $key The query key.
+     * @param mixed[]|DocumentSnapshot $fieldValues An array of values, or an
+     *        instance of {@see Google\Cloud\Firestore\DocumentSnapshot}
+     *        to use as the query boundary.
+     * @param bool $before Whether the query boundary lies just before or after
+     *        the provided data.
+     * @return array
+     */
+    private function buildPosition($key, $fieldValues, $before)
+    {
+        $orderBy = $this->queryKey('orderBy') ?: [];
+        if ($fieldValues instanceof DocumentSnapshot) {
+            list ($fieldValues, $orderBy) = $this->snapshotPosition($fieldValues, $orderBy);
+        } else {
+            if (!is_array($fieldValues)) {
+                throw new \InvalidArgumentException('Field values must be an array or DocumentSnapshot.');
+            }
+
+            foreach ($fieldValues as $value) {
+                if ($value instanceof DocumentSnapshot) {
+                    throw new \InvalidArgumentException(
+                        'DocumentSnapshots are not allowed in an array of field values. ' .
+                        'Provide it as the method argument instead.'
+                    );
+                }
+                if (FieldValue::isSentinelValue($value)) {
+                    throw new \InvalidArgumentException(
+                        'Value cannot be a `Google\Cloud\Firestore\FieldType` value.'
+                    );
+                }
+            }
+        }
+
+        if (count($fieldValues) > count($orderBy)) {
+            throw new \InvalidArgumentException(
+                'Too many cursor values specified. The specified values must ' .
+                'match the `orderBy` constraints of the query.'
+            );
+        }
+
+        foreach ($fieldValues as $i => &$value) {
+            if ($orderBy[$i]['field']['fieldPath'] === self::DOCUMENT_ID) {
+                $collection = $this->childPath(
+                    $this->parent,
+                    $this->query['from'][0]['collectionId']
+                );
+
+                if (is_string($value)) {
+                    $parent = new CollectionReference(
+                        $this->connection,
+                        $this->valueMapper,
+                        $collection
+                    );
+
+                    $name = $this->childPath($collection, $value);
+                    $value = new DocumentReference(
+                        $this->connection,
+                        $this->valueMapper,
+                        $parent,
+                        $name
+                    );
+                } else {
+                    if ($value instanceof DocumentReference) {
+                        $name = $value->name();
+                        $parent = $value->parent()->name();
+                    } else {
+                        throw new \InvalidArgumentException(
+                            'The corresponding value for DOCUMENT_ID must be a ' .
+                            'string or a DocumentReference.'
+                        );
+                    }
+
+                    if (!$this->isPrefixOf($collection, $name)) {
+                        throw new \InvalidArgumentException(sprintf(
+                            '%s is not a part of the query result set and ' .
+                            'cannot be used as a query boundary',
+                            $name
+                        ));
+                    }
+
+                    if ($parent !== $collection) {
+                        throw new \InvalidArgumentException(
+                            'Only direct children may be used as query boundaries.'
+                        );
+                    }
+                }
+            }
+        }
+
+        return $this->newQuery([
+            $key => [
+                'before' => $before,
+                'values' => $this->valueMapper->encodeValues($fieldValues)
+            ],
+            'orderBy' => $orderBy
+        ], true);
+    }
+
+    /**
+     * Build cursors for document snapshots.
+     *
+     * @param DocumentSnapshot $snapshot The document snapshot
+     * @return array[] A list, where position 0 is fieldValues and position 1 is orderBy.
+     */
+    private function snapshotPosition(DocumentSnapshot $snapshot, array $orderBy)
+    {
+        $appendName = true;
+        $direction = self::DIR_ASCENDING;
+        $fieldValues = [];
+
+        // If the list of orderBy clauses already contains __name__, use it unchanged.
+        $appendName = !(bool) array_filter($orderBy, function ($order) {
+            return $order['field']['fieldPath'] === self::DOCUMENT_ID;
+        });
+
+        if ($appendName) {
+            // If there is inequality filter (anything other than equals),
+            // append orderBy(the last inequality filter’s path, ascending).
+            if (!$orderBy && $this->queryHas('where')) {
+                $filters = $this->query['where']['compositeFilter']['filters'];
+                $inequality = array_filter($filters, function ($filter) {
+                    $type = array_keys($filter)[0];
+                    return $filter[$type]['op'] !== self::OP_EQUAL;
+                });
+
+                if ($inequality) {
+                    $filter = end($inequality);
+                    $type = array_keys($filter)[0];
+                    $orderBy[] = [
+                        'field' => [
+                            'fieldPath' => $filter[$type]['field']['fieldPath'],
+                        ],
+                        'direction' => self::DIR_ASCENDING
+                    ];
+                }
+            }
+
+            // If the query has existing orderBy constraints
+            if ($orderBy) {
+                // Append orderBy(__name__, direction of last orderBy clause)
+                $lastOrderDirection = end($orderBy)['direction'];
+                $orderBy[] = [
+                    'field' => [
+                        'fieldPath' => self::DOCUMENT_ID
+                    ],
+                    'direction' => $lastOrderDirection
+                ];
+            } else {
+                // no existing orderBy constraints
+                // Otherwise append orderBy(__name__, ‘asc’)
+                $orderBy[] = [
+                    'field' => [
+                        'fieldPath' => self::DOCUMENT_ID
+                    ],
+                    'direction' => self::DIR_ASCENDING
+                ];
+            }
+        }
+
+        $fieldValues = $this->snapshotCursorValues($snapshot, $orderBy);
+
+        return [
+            $fieldValues,
+            $orderBy
+        ];
+    }
+
+    /**
+     * Determine field values for Document Snapshot cursors.
+     *
+     * @param DocumentSnapshot $snapshot
+     * @param array $orderBy
+     * @return $fieldValues
+     */
+    private function snapshotCursorValues(DocumentSnapshot $snapshot, array $orderBy)
+    {
+        $fieldValues = [];
+        foreach ($orderBy as $order) {
+            $path = $order['field']['fieldPath'];
+            if ($path === self::DOCUMENT_ID) {
+                continue;
+            }
+
+            $fieldValues[] = $snapshot->get($path);
+        }
+
+        $fieldValues[] = $snapshot->reference();
+        return $fieldValues;
     }
 
     /**
@@ -633,5 +784,24 @@ class Query
             $this->parent,
             $query
         );
+    }
+
+    /**
+     * Clean up the query array before sending.
+     *
+     * Some optimizations cannot be performed ahead of time and must be done
+     * at execution.
+     *
+     * @param array $query The incoming query
+     * @return array The final query data,
+     */
+    private function finalQueryPrepare(array $query)
+    {
+        if (isset($query['where']['compositeFilter']) && count($query['where']['compositeFilter']['filters']) === 1) {
+            $filter = $query['where']['compositeFilter']['filters'][0];
+            unset($query['where']);
+            $query['where'] = $filter;
+        }
+        return $query;
     }
 }

--- a/Firestore/src/ValueMapper.php
+++ b/Firestore/src/ValueMapper.php
@@ -429,7 +429,7 @@ class ValueMapper
             return ['geoPointValue' => $value->point()];
         }
 
-        if ($value instanceof DocumentReference) {
+        if ($value instanceof DocumentReference || $value instanceof DocumentSnapshot) {
             return ['referenceValue' => $value->name()];
         }
 

--- a/Firestore/tests/Snippet/QueryTest.php
+++ b/Firestore/tests/Snippet/QueryTest.php
@@ -17,15 +17,16 @@
 
 namespace Google\Cloud\Firestore\Tests\Snippet;
 
-use Prophecy\Argument;
-use Google\Cloud\Firestore\Query;
+use Google\Cloud\Core\Testing\ArrayHasSameValuesToken;
 use Google\Cloud\Core\Testing\GrpcTestTrait;
-use Google\Cloud\Firestore\ValueMapper;
-use Google\Cloud\Firestore\QuerySnapshot;
 use Google\Cloud\Core\Testing\Snippet\Parser\Snippet;
 use Google\Cloud\Core\Testing\Snippet\SnippetTestCase;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
+use Google\Cloud\Firestore\Query;
+use Google\Cloud\Firestore\QuerySnapshot;
 use Google\Cloud\Firestore\V1beta1\StructuredQuery_CompositeFilter_Operator;
+use Google\Cloud\Firestore\ValueMapper;
+use Prophecy\Argument;
 
 /**
  * @group firestore
@@ -86,20 +87,13 @@ class QueryTest extends SnippetTestCase
     {
         $snippet = $this->snippetFromMethod(Query::class, 'where');
         $this->runAndAssert($snippet, 'where', [
-            'compositeFilter' => [
-                'op' => StructuredQuery_CompositeFilter_Operator::PBAND,
-                'filters' => [
-                    [
-                        'fieldFilter' => [
-                            'field' => [
-                                'fieldPath' => 'firstName'
-                            ],
-                            'op' => Query::OP_EQUAL,
-                            'value' => [
-                                'stringValue' => 'John'
-                            ]
-                        ]
-                    ]
+            'fieldFilter' => [
+                'field' => [
+                    'fieldPath' => 'firstName'
+                ],
+                'op' => Query::OP_EQUAL,
+                'value' => [
+                    'stringValue' => 'John'
                 ]
             ]
         ]);
@@ -109,18 +103,11 @@ class QueryTest extends SnippetTestCase
     {
         $snippet = $this->snippetFromMethod(Query::class, 'where', 1);
         $this->runAndAssert($snippet, 'where', [
-            'compositeFilter' => [
-                'op' => StructuredQuery_CompositeFilter_Operator::PBAND,
-                'filters' => [
-                    [
-                        'unaryFilter' => [
-                            'field' => [
-                                'fieldPath' => 'coolnessPercentage'
-                            ],
-                            'op' => Query::OP_NAN,
-                        ]
-                    ]
-                ]
+            'unaryFilter' => [
+                'field' => [
+                    'fieldPath' => 'coolnessPercentage'
+                ],
+                'op' => Query::OP_NAN,
             ]
         ]);
     }
@@ -196,18 +183,22 @@ class QueryTest extends SnippetTestCase
 
     private function runAndAssertArray(Snippet $snippet, array $query)
     {
-        $this->connection->runQuery([
+        $this->connection->runQuery(new ArrayHasSameValuesToken([
             'parent' => self::NAME,
             'retries' => 0,
             'structuredQuery' => array_filter([
                 'from' => self::NAME,
-            ]) + $query
-        ])->shouldBeCalled()->willReturn(new \ArrayIterator([[]]));
+            ]) + $query + [
+                'offset' => 0,
+                'orderBy' => []
+            ]
+        ]))->shouldBeCalled()->willReturn(new \ArrayIterator([[]]));
 
         $this->query->___setProperty('connection', $this->connection->reveal());
         $snippet->addLocal('query', $this->query);
+
         $res = $snippet->invoke('query');
-        $res->returnVal()->documents(['retries' => 0]);
+        $res->returnVal()->documents(['maxRetries' => 0]);
         $this->assertInstanceOf(Query::class, $res->returnVal());
     }
 }

--- a/Firestore/tests/Unit/QueryTest.php
+++ b/Firestore/tests/Unit/QueryTest.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Firestore\Tests\Unit;
 
+use Google\Cloud\Core\Testing\ArrayHasSameValuesToken;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\CollectionReference;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
@@ -344,7 +345,7 @@ class QueryTest extends TestCase
     }
 
     /**
-     * @expectedException BadMethodCallException
+     * @expectedException InvalidArgumentException
      * @dataProvider cursors
      */
     public function testOrderByAfterCursor($cursor)
@@ -612,8 +613,163 @@ class QueryTest extends TestCase
         ]);
     }
 
+        public function testPositionWithDocumentSnapshot()
+    {
+        $c = $this->prophesize(CollectionReference::class);
+        $c->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId']);
+        $ref = $this->prophesize(DocumentReference::class);
+        $ref->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
+        $ref->parent()->willReturn($c->reveal());
+        $snapshot = $this->prophesize(DocumentSnapshot::class);
+        $snapshot->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
+        $snapshot->reference()->willReturn($ref->reveal());
+        $this->runAndAssert(function (Query $q) use ($snapshot) {
+            return $this->query->startAt($snapshot->reveal());
+        }, [
+            'parent' => self::PARENT,
+            'structuredQuery' => [
+                'from' => $this->queryFrom(),
+                'orderBy' => [
+                    [
+                        'field' => [
+                            'fieldPath' => Query::DOCUMENT_ID
+                        ],
+                        'direction' => Query::DIR_ASCENDING
+                    ]
+                ],
+                'startAt' => [
+                    'before' => true,
+                    'values' => [
+                        [
+                            'referenceValue' => self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john'
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+    }
     /**
-     * @expectedException BadMethodCallException
+     * @expectedException InvalidArgumentException
+     */
+    public function testSnapshotInFieldValue()
+    {
+        $snapshot = $this->prophesize(DocumentSnapshot::class);
+        $this->query->startAt([$snapshot->reveal()]);
+    }
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testInvalidFieldValues()
+    {
+        $this->query->startAt('foo');
+    }
+    public function testPositionSnapshotOrderBy()
+    {
+        $c = $this->prophesize(CollectionReference::class);
+        $c->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId']);
+        $ref = $this->prophesize(DocumentReference::class);
+        $ref->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
+        $ref->parent()->willReturn($c->reveal());
+        $snapshot = $this->prophesize(DocumentSnapshot::class);
+        $snapshot->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
+        $snapshot->reference()->willReturn($ref->reveal());
+        $snapshot->get('a')->willReturn('b');
+        $snapshot->get('c')->willReturn('d');
+        $this->runAndAssert(function (Query $q) use ($snapshot) {
+            $query = $this->query->orderBy('a')->orderBy('c');
+            return $query->startAt($snapshot->reveal());
+        }, [
+            'parent' => self::PARENT,
+            'structuredQuery' => [
+                'from' => $this->queryFrom(),
+                'orderBy' => [
+                    [
+                        'field' => [
+                            'fieldPath' => 'a'
+                        ],
+                        'direction' => Query::DIR_ASCENDING
+                    ], [
+                        'field' => [
+                            'fieldPath' => 'c'
+                        ],
+                        'direction' => Query::DIR_ASCENDING
+                    ], [
+                        'field' => [
+                            'fieldPath' => Query::DOCUMENT_ID
+                        ],
+                        'direction' => Query::DIR_ASCENDING
+                    ]
+                ],
+                'startAt' => [
+                    'before' => true,
+                    'values' => [
+                        ['stringValue' => 'b'],
+                        ['stringValue' => 'd'],
+                        [
+                            'referenceValue' => self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john'
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+    }
+    public function testPositionInequalityFilter()
+    {
+        $c = $this->prophesize(CollectionReference::class);
+        $c->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId']);
+        $ref = $this->prophesize(DocumentReference::class);
+        $ref->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
+        $ref->parent()->willReturn($c->reveal());
+        $snapshot = $this->prophesize(DocumentSnapshot::class);
+        $snapshot->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
+        $snapshot->reference()->willReturn($ref->reveal());
+        $snapshot->get('foo')->willReturn('bar');
+        $this->runAndAssert(function (Query $q) use ($snapshot) {
+            $query = $this->query->where('foo', '>', 'bar');
+            return $query->startAt($snapshot->reveal());
+        }, [
+            'parent' => self::PARENT,
+            'structuredQuery' => [
+                'from' => $this->queryFrom(),
+                'orderBy' => [
+                    [
+                        'field' => [
+                            'fieldPath' => 'foo'
+                        ],
+                        'direction' => Query::DIR_ASCENDING
+                    ], [
+                        'field' => [
+                            'fieldPath' => Query::DOCUMENT_ID
+                        ],
+                        'direction' => Query::DIR_ASCENDING
+                    ]
+                ],
+                'startAt' => [
+                    'before' => true,
+                    'values' => [
+                        [
+                            'stringValue' => 'bar'
+                        ], [
+                            'referenceValue' => self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john'
+                        ]
+                    ]
+                ],
+                "where" => [
+                "fieldFilter" => [
+                    "field" => [
+                        "fieldPath" => "foo"
+                    ],
+                    "op" => 3,
+                    "value" => [
+                        "stringValue" => "bar"
+                    ]
+                ]
+            ]
+        ]]);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
      */
     public function testBuildPositionTooManyCursorValues()
     {
@@ -621,17 +777,22 @@ class QueryTest extends TestCase
     }
 
     /**
-     * @expectedException BadMethodCallException
+     * @expectedException InvalidArgumentException
      */
     public function testBuildPositionOutOfBounds()
     {
         $ref = $this->prophesize(DocumentReference::class);
         $ref->name()->willReturn(self::PARENT .'/whatev/john');
+
+        $col = $this->prophesize(CollectionReference::class);
+        $col->name()->willReturn(self::PARENT .'/whatev/john');
+        $ref->parent()->willReturn($col->reveal());
+
         $this->query->orderBy(Query::DOCUMENT_ID)->startAt([$ref->reveal()]);
     }
 
     /**
-     * @expectedException BadMethodCallException
+     * @expectedException InvalidArgumentException
      */
     public function testBuildPositionInvalidCursorType()
     {
@@ -639,7 +800,7 @@ class QueryTest extends TestCase
     }
 
     /**
-     * @expectedException BadMethodCallException
+     * @expectedException InvalidArgumentException
      */
     public function testBuildPositionNestedChild()
     {
@@ -656,8 +817,16 @@ class QueryTest extends TestCase
     private function runAndAssert(callable $filters, $assertion)
     {
         if (is_array($assertion)) {
-            $this->connection->runQuery($assertion + ['retries' => 0])
-            ->shouldBeCalledTimes(1)->willReturn(new \ArrayIterator([
+            if (isset($assertion['structuredQuery'])) {
+                $assertion['structuredQuery'] = array_merge([
+                    'orderBy' => [],
+                    'offset' => 0
+                ], $assertion['structuredQuery']);
+            }
+
+            $this->connection->runQuery(
+                new ArrayHasSameValuesToken($assertion + ['retries' => 0])
+            )->shouldBeCalledTimes(1)->willReturn(new \ArrayIterator([
                 []
             ]));
         } elseif (is_callable($assertion)) {
@@ -672,7 +841,7 @@ class QueryTest extends TestCase
         $this->assertInstanceOf(Query::class, $query);
         $this->assertNotEquals($immutable, $query);
 
-        $query->documents(['maxRetries' => 0]);
+        iterator_to_array($query->documents(['maxRetries' => 0]));
     }
 
     private function queryFrom()

--- a/Firestore/tests/Unit/QueryTest.php
+++ b/Firestore/tests/Unit/QueryTest.php
@@ -613,16 +613,19 @@ class QueryTest extends TestCase
         ]);
     }
 
-        public function testPositionWithDocumentSnapshot()
+    public function testPositionWithDocumentSnapshot()
     {
         $c = $this->prophesize(CollectionReference::class);
         $c->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId']);
+
         $ref = $this->prophesize(DocumentReference::class);
         $ref->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
         $ref->parent()->willReturn($c->reveal());
+
         $snapshot = $this->prophesize(DocumentSnapshot::class);
         $snapshot->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
         $snapshot->reference()->willReturn($ref->reveal());
+
         $this->runAndAssert(function (Query $q) use ($snapshot) {
             return $this->query->startAt($snapshot->reveal());
         }, [
@@ -648,6 +651,7 @@ class QueryTest extends TestCase
             ]
         ]);
     }
+
     /**
      * @expectedException InvalidArgumentException
      */
@@ -656,6 +660,7 @@ class QueryTest extends TestCase
         $snapshot = $this->prophesize(DocumentSnapshot::class);
         $this->query->startAt([$snapshot->reveal()]);
     }
+
     /**
      * @expectedException InvalidArgumentException
      */
@@ -663,18 +668,22 @@ class QueryTest extends TestCase
     {
         $this->query->startAt('foo');
     }
+
     public function testPositionSnapshotOrderBy()
     {
         $c = $this->prophesize(CollectionReference::class);
         $c->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId']);
+
         $ref = $this->prophesize(DocumentReference::class);
         $ref->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
         $ref->parent()->willReturn($c->reveal());
+
         $snapshot = $this->prophesize(DocumentSnapshot::class);
         $snapshot->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
         $snapshot->reference()->willReturn($ref->reveal());
         $snapshot->get('a')->willReturn('b');
         $snapshot->get('c')->willReturn('d');
+
         $this->runAndAssert(function (Query $q) use ($snapshot) {
             $query = $this->query->orderBy('a')->orderBy('c');
             return $query->startAt($snapshot->reveal());
@@ -713,17 +722,21 @@ class QueryTest extends TestCase
             ]
         ]);
     }
+
     public function testPositionInequalityFilter()
     {
         $c = $this->prophesize(CollectionReference::class);
         $c->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId']);
+
         $ref = $this->prophesize(DocumentReference::class);
         $ref->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
         $ref->parent()->willReturn($c->reveal());
+
         $snapshot = $this->prophesize(DocumentSnapshot::class);
         $snapshot->name()->willReturn(self::PARENT .'/'. $this->queryFrom()[0]['collectionId'] .'/john');
         $snapshot->reference()->willReturn($ref->reveal());
         $snapshot->get('foo')->willReturn('bar');
+
         $this->runAndAssert(function (Query $q) use ($snapshot) {
             $query = $this->query->where('foo', '>', 'bar');
             return $query->startAt($snapshot->reveal());


### PR DESCRIPTION
cc @schmidt-sebastian

Extracted from #923 and updated to address pull request comments.

Breaking change is the standardization in Query of using `InvalidArgumentException`, replacing various throws of `BadMethodCallException`.

Closes #851.