### PR TITLE
Add isRacy() to SafeSearch

### DIFF
--- a/Vision/src/Annotation/SafeSearch.php
+++ b/Vision/src/Annotation/SafeSearch.php
@@ -76,6 +76,16 @@ use Google\Cloud\Core\CallTrait;
  *
  *     @return string
  * }
+ * @method racy() {
+ *     Racy likelihood.
+ *
+ *     Example:
+ *     ```
+ *     echo $safeSearch->racy();
+ *     ```
+ *
+ *     @return string
+ * }
  * @method info() {
  *     Get the raw annotation result
  *
@@ -190,5 +200,26 @@ class SafeSearch extends AbstractFeature
     public function isViolent($strength = self::STRENGTH_LOW)
     {
         return $this->likelihood($this->info['violence'], $strength);
+    }
+
+    /**
+     * Check whether the image contains racy content
+     *
+     * Example:
+     * ```
+     * if ($safeSearch->isRacy()) {
+     *     echo "Image contains racy content.";
+     * }
+     * ```
+     *
+     * @param  string $strength [optional] Value should be one of "low",
+     *         "medium" or "high". Recommended usage is via `Face::STRENGTH_*`
+     *         constants. Higher strength will result in fewer `true` results,
+     *         but fewer false positives. **Defaults to** `"low"`.
+     * @return bool
+     */
+    public function isRacy($strength = self::STRENGTH_LOW)
+    {
+        return $this->likelihood($this->info['racy'], $strength);
     }
 }

--- a/Vision/src/Annotation/SafeSearch.php
+++ b/Vision/src/Annotation/SafeSearch.php
@@ -129,7 +129,7 @@ class SafeSearch extends AbstractFeature
      * ```
      *
      * @param  string $strength [optional] Value should be one of "low",
-     *         "medium" or "high". Recommended usage is via `Face::STRENGTH_*`
+     *         "medium" or "high". Recommended usage is via `SafeSearch::STRENGTH_*`
      *         constants. Higher strength will result in fewer `true` results,
      *         but fewer false positives. **Defaults to** `"low"`.
      * @return bool
@@ -150,7 +150,7 @@ class SafeSearch extends AbstractFeature
      * ```
      *
      * @param  string $strength [optional] Value should be one of "low",
-     *         "medium" or "high". Recommended usage is via `Face::STRENGTH_*`
+     *         "medium" or "high". Recommended usage is via `SafeSearch::STRENGTH_*`
      *         constants. Higher strength will result in fewer `true` results,
      *         but fewer false positives. **Defaults to** `"low"`.
      * @return bool
@@ -171,7 +171,7 @@ class SafeSearch extends AbstractFeature
      * ```
      *
      * @param  string $strength [optional] Value should be one of "low",
-     *         "medium" or "high". Recommended usage is via `Face::STRENGTH_*`
+     *         "medium" or "high". Recommended usage is via `SafeSearch::STRENGTH_*`
      *         constants. Higher strength will result in fewer `true` results,
      *         but fewer false positives. **Defaults to** `"low"`.
      * @return bool
@@ -192,7 +192,7 @@ class SafeSearch extends AbstractFeature
      * ```
      *
      * @param  string $strength [optional] Value should be one of "low",
-     *         "medium" or "high". Recommended usage is via `Face::STRENGTH_*`
+     *         "medium" or "high". Recommended usage is via `SafeSearch::STRENGTH_*`
      *         constants. Higher strength will result in fewer `true` results,
      *         but fewer false positives. **Defaults to** `"low"`.
      * @return bool
@@ -213,7 +213,7 @@ class SafeSearch extends AbstractFeature
      * ```
      *
      * @param  string $strength [optional] Value should be one of "low",
-     *         "medium" or "high". Recommended usage is via `Face::STRENGTH_*`
+     *         "medium" or "high". Recommended usage is via `SafeSearch::STRENGTH_*`
      *         constants. Higher strength will result in fewer `true` results,
      *         but fewer false positives. **Defaults to** `"low"`.
      * @return bool

--- a/Vision/tests/Snippet/Annotation/SafeSearchTest.php
+++ b/Vision/tests/Snippet/Annotation/SafeSearchTest.php
@@ -110,6 +110,15 @@ class SafeSearchTest extends SnippetTestCase
         $this->assertEquals($this->ssData['violence'], $res->output());
     }
 
+    public function testRacy()
+    {
+        $snippet = $this->snippetFromMagicMethod(SafeSearch::class, 'racy');
+        $snippet->addLocal('safeSearch', $this->ss);
+
+        $res = $snippet->invoke();
+        $this->assertEquals($this->ssData['racy'], $res->output());
+    }
+
     public function testIsAdult()
     {
         $snippet = $this->snippetFromMethod(SafeSearch::class, 'isAdult');

--- a/Vision/tests/Snippet/Annotation/SafeSearchTest.php
+++ b/Vision/tests/Snippet/Annotation/SafeSearchTest.php
@@ -37,6 +37,7 @@ class SafeSearchTest extends SnippetTestCase
             'spoof' => 'VERY_LIKELY',
             'medical' => 'VERY_LIKELY',
             'violence' => 'VERY_LIKELY',
+            'racy' => 'VERY_LIKELY',
         ];
         $this->ss = new SafeSearch($this->ssData);
     }

--- a/Vision/tests/Snippet/Annotation/SafeSearchTest.php
+++ b/Vision/tests/Snippet/Annotation/SafeSearchTest.php
@@ -145,6 +145,15 @@ class SafeSearchTest extends SnippetTestCase
         $this->assertEquals(sprintf('Image contains %s content.', 'violent'), $res->output());
     }
 
+    public function testIsRacy()
+    {
+        $snippet = $this->snippetFromMethod(SafeSearch::class, 'isRacy');
+        $snippet->addLocal('safeSearch', $this->ss);
+
+        $res = $snippet->invoke();
+        $this->assertEquals(sprintf('Image contains %s content.', 'racy'), $res->output());
+    }
+
     public function testInfo()
     {
         $snippet = $this->snippetFromMagicMethod(SafeSearch::class, 'info');

--- a/Vision/tests/System/AnnotationsTest.php
+++ b/Vision/tests/System/AnnotationsTest.php
@@ -67,10 +67,12 @@ class AnnotationsTest extends VisionTestCase
         $this->assertEquals('VERY_UNLIKELY', $res->safeSearch()->spoof());
         $this->assertEquals('VERY_UNLIKELY', $res->safeSearch()->medical());
         $this->assertEquals('VERY_UNLIKELY', $res->safeSearch()->violence());
+        $this->assertEquals('VERY_UNLIKELY', $res->safeSearch()->racy());
         $this->assertFalse($res->safeSearch()->isAdult());
         $this->assertFalse($res->safeSearch()->isSpoof());
         $this->assertFalse($res->safeSearch()->isMedical());
         $this->assertFalse($res->safeSearch()->isViolent());
+        $this->assertFalse($res->safeSearch()->isRacy());
 
         // Image Properties
         $this->assertInstanceOf(ImageProperties::class, $res->imageProperties());

--- a/Vision/tests/Unit/Annotation/SafeSearchTest.php
+++ b/Vision/tests/Unit/Annotation/SafeSearchTest.php
@@ -33,7 +33,8 @@ class SafeSearchTest extends TestCase
             'adult' => 'VERY_LIKELY',
             'spoof' => 'VERY_LIKELY',
             'medical' => 'VERY_LIKELY',
-            'violence' => 'VERY_LIKELY'
+            'violence' => 'VERY_LIKELY',
+            'racy' => 'VERY_LIKELY'
         ]);
     }
 
@@ -55,6 +56,11 @@ class SafeSearchTest extends TestCase
     public function testIsViolent()
     {
         $this->assertTrue($this->safeSearch->isViolent());
+    }
+
+    public function testIsRacy()
+    {
+        $this->assertTrue($this->safeSearch->isRacy());
     }
 
     public function testCall()


### PR DESCRIPTION
The SafeSearch class included `is` functions for each SafeSearch feature (adult, spoof, medical, violence), but was missing Racy. This Pull Request adds `isRacy()` to the SafeSearch class.