### PR TITLE
Add getServiceAccount method to StorageClient

### DIFF
--- a/Storage/src/Connection/ConnectionInterface.php
+++ b/Storage/src/Connection/ConnectionInterface.php
@@ -152,4 +152,9 @@ interface ConnectionInterface
      * @param array $args
      */
     public function listNotifications(array $args = []);
+
+    /**
+     * @param array $args
+     */
+    public function getServiceAccount(array $args = []);
 }

--- a/Storage/src/Connection/Rest.php
+++ b/Storage/src/Connection/Rest.php
@@ -386,4 +386,12 @@ class Rest implements ConnectionInterface
     {
         return $this->send('notifications', 'list', $args);
     }
+
+    /**
+     * @param array $args
+     */
+    public function getServiceAccount(array $args = [])
+    {
+        return $this->send('projects.resources.serviceAccount', 'get', $args);
+    }
 }

--- a/Storage/src/StorageClient.php
+++ b/Storage/src/StorageClient.php
@@ -379,4 +379,26 @@ class StorageClient
     {
         return new Timestamp($timestamp, $nanoSeconds);
     }
+
+    /**
+     * Get a service account email for the KMS integration.
+     *
+     * Example:
+     * ```
+     * $serviceAccount = $storage->getServiceAccount();
+     * ```
+     *
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type string $userProject If set, this is the ID of the project which
+     *           will be billed for the request.
+     * }
+     * @return string
+     */
+    public function getServiceAccount(array $options = [])
+    {
+        $resp = $this->connection->getServiceAccount($options + ['projectId' => $this->projectId]);
+        return $resp['email_address'];
+    }
 }

--- a/Storage/tests/System/KmsTest.php
+++ b/Storage/tests/System/KmsTest.php
@@ -178,7 +178,7 @@ class KmsTest extends StorageTestCase
             'scopes' => ['https://www.googleapis.com/auth/cloud-platform']
         ]);
         $projectId = self::getProjectId($keyFilePath);
-        $serviceAccount = self::getServiceAccount($wrapper, $projectId);
+        $serviceAccount = self::$client->getServiceAccount();
         self::buildKeyRing($wrapper, $projectId, $keyRingId);
         $keyNames[] = self::getCryptoKeyName(
             $wrapper,
@@ -294,28 +294,5 @@ class KmsTest extends StorageTestCase
         );
 
         return $name;
-    }
-
-    /**
-     * @param RequestWrapper $wrapper
-     * @param string $projectId
-     * @return string
-     */
-    private static function getServiceAccount(RequestWrapper $wrapper, $projectId)
-    {
-        $response = $wrapper->send(
-            new Request(
-                'GET',
-                sprintf(
-                    'https://www.googleapis.com/storage/v1/projects/%s/serviceAccount',
-                    $projectId
-                )
-            )
-        );
-
-        return json_decode(
-            (string) $response->getBody(),
-            true
-        )['email_address'];
     }
 }

--- a/Storage/tests/Unit/Connection/RestTest.php
+++ b/Storage/tests/Unit/Connection/RestTest.php
@@ -106,6 +106,7 @@ class RestTest extends TestCase
             ['deleteNotification'],
             ['insertNotification'],
             ['listNotifications'],
+            ['getServiceAccount']
         ];
     }
 

--- a/Storage/tests/Unit/StorageClientTest.php
+++ b/Storage/tests/Unit/StorageClientTest.php
@@ -156,6 +156,24 @@ class StorageClientTest extends TestCase
         $this->assertInstanceOf(Timestamp::class, $ts);
         $this->assertEquals($ts->get(), $dt);
     }
+
+    public function testGetServiceAccount()
+    {
+        $expectedServiceAccount = self::PROJECT . '@gs-project-accounts.iam.gserviceaccount.com';
+        $this->connection->getServiceAccount([
+            'projectId' => self::PROJECT,
+            'userProject' => self::PROJECT
+        ])->willReturn([
+            'kind' => 'storage#serviceAccount',
+            'email_address' => $expectedServiceAccount
+        ])->shouldBeCalledTimes(1);
+        $this->client->___setProperty('connection', $this->connection->reveal());
+
+        $this->assertEquals(
+            $this->client->getServiceAccount(['userProject' => self::PROJECT]),
+            $expectedServiceAccount
+        );
+    }
 }
 
 class StorageClientStub extends StorageClient


### PR DESCRIPTION
This adds a way to programmatically fetch the service account, similarly to https://github.com/GoogleCloudPlatform/google-cloud-php/pull/1167 for BigQuery.

Addresses https://github.com/GoogleCloudPlatform/google-cloud-php/issues/1079#issuecomment-404871481