### PR TITLE
Remove auth library restriction

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,8 +50,7 @@
         "monolog/monolog": "~1",
         "psr/http-message": "1.0.*",
         "ramsey/uuid": "~3",
-        "google/gax": "^0.36",
-        "google/auth": "1.2.0 - 1.3.0"
+        "google/gax": "^0.36"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",


### PR DESCRIPTION
The [latest patch to the auth library](https://github.com/google/google-auth-library-php/releases/tag/v1.3.2) includes fixes which allow us to loosen this requirement again.