### PR TITLE
Update Minimum cloud-core Version

### DIFF
--- a/Firestore/composer.json
+++ b/Firestore/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "ext-grpc": "*",
-        "google/cloud-core": "^1.14",
+        "google/cloud-core": "^1.20",
         "google/gax": "^0.36",
         "ramsey/uuid": "~3"
     },


### PR DESCRIPTION
FireStore requires `Google\Cloud\Core\TimeTrait` which wasn't introduced into core until `1.20.0`,
increasing the minimum allowed version should address the issue.