### PR TITLE
Update AliasContext constants

### DIFF
--- a/Debugger/src/AliasContext.php
+++ b/Debugger/src/AliasContext.php
@@ -17,7 +17,7 @@
 
 namespace Google\Cloud\Debugger;
 
-use Google\Cloud\DevTools\Source\V1\AliasContext_Kind;
+use Google\Cloud\DevTools\Source\V1\AliasContext\Kind;
 
 /**
  * An alias to a repo revision.
@@ -35,10 +35,10 @@ use Google\Cloud\DevTools\Source\V1\AliasContext_Kind;
  */
 class AliasContext
 {
-    const KIND_ANY = AliasContext_Kind::ANY;
-    const KIND_FIXED = AliasContext_Kind::FIXED;
-    const KIND_MOVABLE = AliasContext_Kind::MOVABLE;
-    const KIND_OTHER = AliasContext_Kind::OTHER;
+    const KIND_ANY = Kind::ANY;
+    const KIND_FIXED = Kind::FIXED;
+    const KIND_MOVABLE = Kind::MOVABLE;
+    const KIND_OTHER = Kind::OTHER;
 
     /**
      * @var string The alias kind.


### PR DESCRIPTION
[GAX v0.37.0](https://github.com/googleapis/gax-php/releases/tag/0.37.0) updated some shared protobuf classes to our new namespace format, this brings `Google\Cloud\Debugger\AliasContext`  into line with these changes.