### PR TITLE
Revert "Revert "Spanner grpc config" (#1240)"

### DIFF
--- a/BigQueryDataTransfer/composer.json
+++ b/BigQueryDataTransfer/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Bigtable/composer.json
+++ b/Bigtable/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Container/composer.json
+++ b/Container/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Core/composer.json
+++ b/Core/composer.json
@@ -17,7 +17,7 @@
         "squizlabs/php_codesniffer": "2.*",
         "phpdocumentor/reflection": "^3.0",
         "erusev/parsedown": "^1.6",
-        "google/gax": "^0.36",
+        "google/gax": "^0.37",
         "opis/closure": "^3"
     },
     "suggest": {

--- a/Dataproc/composer.json
+++ b/Dataproc/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Debugger/composer.json
+++ b/Debugger/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "google/cloud-core": "^1.23",
         "google/cloud-logging": "^1.4",
-        "google/gax": "^0.36",
+        "google/gax": "^0.37",
         "psr/log": "^1.0"
     },
     "require-dev": {

--- a/Dialogflow/composer.json
+++ b/Dialogflow/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Dlp/composer.json
+++ b/Dlp/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/ErrorReporting/composer.json
+++ b/ErrorReporting/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "google/cloud-logging": "^1.5.0",
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Firestore/composer.json
+++ b/Firestore/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "ext-grpc": "*",
         "google/cloud-core": "^1.23",
-        "google/gax": "^0.36",
+        "google/gax": "^0.37",
         "ramsey/uuid": "~3"
     },
     "require-dev": {

--- a/Iot/composer.json
+++ b/Iot/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Kms/composer.json
+++ b/Kms/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Language/composer.json
+++ b/Language/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "google/cloud-core": "^1.23",
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Logging/composer.json
+++ b/Logging/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "google/cloud-core": "^1.23",
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Monitoring/composer.json
+++ b/Monitoring/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/OsLogin/composer.json
+++ b/OsLogin/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/PubSub/composer.json
+++ b/PubSub/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "google/cloud-core": "^1.23",
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Redis/composer.json
+++ b/Redis/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "ext-grpc": "*",
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Spanner/composer.json
+++ b/Spanner/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "ext-grpc": "*",
         "google/cloud-core": "^1.23",
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Spanner/src/V1/Gapic/SpannerGapicClient.php
+++ b/Spanner/src/V1/Gapic/SpannerGapicClient.php
@@ -129,6 +129,7 @@ class SpannerGapicClient
             'serviceAddress' => self::SERVICE_ADDRESS.':'.self::DEFAULT_SERVICE_PORT,
             'clientConfig' => __DIR__.'/../resources/spanner_client_config.json',
             'descriptorsConfigPath' => __DIR__.'/../resources/spanner_descriptor_config.php',
+            'gcpApiConfigPath' => __DIR__.'/../resources/spanner_grpc_config.json',
             'credentialsConfig' => [
                 'scopes' => self::$serviceScopes,
             ],

--- a/Spanner/src/V1/resources/spanner_grpc_config.json
+++ b/Spanner/src/V1/resources/spanner_grpc_config.json
@@ -1,0 +1,116 @@
+{
+    "channelPool": {
+        "maxSize": 10,
+        "maxConcurrentStreamsLowWatermark": 100
+    },
+    "method": [
+        {
+            "name": [
+                "/google.spanner.v1.Spanner/CreateSession"
+            ],
+            "affinity": {
+                "command": "BIND",
+                "affinityKey": "name"
+            }
+        },
+        {
+            "name": [
+                "/google.spanner.v1.Spanner/GetSession"
+            ],
+            "affinity": {
+                "command": "BOUND",
+                "affinityKey": "name"
+            }
+        },
+        {
+            "name": [
+                "/google.spanner.v1.Spanner/DeleteSession"
+            ],
+            "affinity": {
+                "command": "UNBIND",
+                "affinityKey": "name"
+            }
+        },
+        {
+            "name": [
+                "/google.spanner.v1.Spanner/ExecuteSql"
+            ],
+            "affinity": {
+                "command": "BOUND",
+                "affinityKey": "session"
+            }
+        },
+        {
+            "name": [
+                "/google.spanner.v1.Spanner/ExecuteStreamingSql"
+            ],
+            "affinity": {
+                "command": "BOUND",
+                "affinityKey": "session"
+            }
+        },
+        {
+            "name": [
+                "/google.spanner.v1.Spanner/Read"
+            ],
+            "affinity": {
+                "command": "BOUND",
+                "affinityKey": "session"
+            }
+        },
+        {
+            "name": [
+                "/google.spanner.v1.Spanner/StreamingRead"
+            ],
+            "affinity": {
+                "command": "BOUND",
+                "affinityKey": "session"
+            }
+        },
+        {
+            "name": [
+                "/google.spanner.v1.Spanner/BeginTransaction"
+            ],
+            "affinity": {
+                "command": "BOUND",
+                "affinityKey": "session"
+            }
+        },
+        {
+            "name": [
+                "/google.spanner.v1.Spanner/Commit"
+            ],
+            "affinity": {
+                "command": "BOUND",
+                "affinityKey": "session"
+            }
+        },
+        {
+            "name": [
+                "/google.spanner.v1.Spanner/Rollback"
+            ],
+            "affinity": {
+                "command": "BOUND",
+                "affinityKey": "session"
+            }
+        },
+        {
+            "name": [
+                "/google.spanner.v1.Spanner/PartitionQuery"
+            ],
+            "affinity": {
+                "command": "BOUND",
+                "affinityKey": "session"
+            }
+        },
+        {
+            "name": [
+                "/google.spanner.v1.Spanner/PartitionRead"
+            ],
+            "affinity": {
+                "command": "BOUND",
+                "affinityKey": "session"
+            }
+        }
+    ]
+}

--- a/Speech/composer.json
+++ b/Speech/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "google/cloud-core": "^1.23",
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Tasks/composer.json
+++ b/Tasks/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/TextToSpeech/composer.json
+++ b/TextToSpeech/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Trace/composer.json
+++ b/Trace/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "google/cloud-core": "^1.23",
         "ramsey/uuid": "~3",
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
      "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/VideoIntelligence/composer.json
+++ b/VideoIntelligence/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/Vision/composer.json
+++ b/Vision/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "google/cloud-core": "^1.23",
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "monolog/monolog": "~1",
         "psr/http-message": "1.0.*",
         "ramsey/uuid": "~3",
-        "google/gax": "^0.36"
+        "google/gax": "^0.37"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0",


### PR DESCRIPTION
This reverts commit e646b9cf9784a9eda14d08ff8e76aa39c0de5795.

This brings back the reverted changes on spanner grpc config, which was previously causing file descriptors leak on macOS.

Related fix: https://github.com/GoogleCloudPlatform/grpc-gcp-php/pull/25 