### PR TITLE
[Breaking Change] Firestore array operations

### DIFF
--- a/Firestore/src/FieldValue.php
+++ b/Firestore/src/FieldValue.php
@@ -17,8 +17,13 @@
 
 namespace Google\Cloud\Firestore;
 
+use Google\Cloud\Firestore\FieldValue\ArrayRemoveValue;
+use Google\Cloud\Firestore\FieldValue\ArrayUnionValue;
+use Google\Cloud\Firestore\FieldValue\DeleteFieldValue;
+use Google\Cloud\Firestore\FieldValue\ServerTimestampValue;
+
 /**
- * Contains special field values for Cloud Firestore.
+ * Provides special field values for Cloud Firestore.
  *
  * This class cannot be instantiated, and methods contained within it should be
  * accessed statically.
@@ -48,7 +53,10 @@ class FieldValue
      * $firestore = new FirestoreClient;
      * $document = $firestore->document('users/dave');
      * $document->update([
-     *     ['path' => 'hometown', 'value' => FieldValue::deleteField()]
+     *     [
+     *         'path' => 'hometown',
+     *         'value' => FieldValue::deleteField()
+     *     ]
      * ]);
      * ```
      *
@@ -56,7 +64,7 @@ class FieldValue
      */
     public static function deleteField()
     {
-        return '___google-cloud-php__deleteField___';
+        return new DeleteFieldValue();
     }
 
     /**
@@ -74,40 +82,80 @@ class FieldValue
      * $firestore = new FirestoreClient;
      * $document = $firestore->document('users/dave');
      * $document->update([
-     *     ['path' => 'lastLogin', 'value' => FieldValue::serverTimestamp()]
+     *     [
+     *         'path' => 'lastLogin',
+     *         'value' => FieldValue::serverTimestamp()
+     *     ]
      * ]);
      * ```
      *
-     * @return string
+     * @return ServerTimestampValue
      */
     public static function serverTimestamp()
     {
-        return '___google-cloud-php__serverTimestamp___';
+        return new ServerTimestampValue();
     }
 
     /**
-     * Check if the given value is a sentinel.
+     * Returns a special value that can be used with set(), create() or update()
+     * that tells the server to union the given elements with any array value
+     * that already exists on the server. Each specified element that doesn't
+     * already exist in the array will be added to the end. If the field being
+     * modified is not already an array it will be overwritten with an array
+     * containing exactly the specified elements.
      *
-     * @param string $value
-     * @return bool
-     * @access private
+     * Example:
+     * ```
+     * use Google\Cloud\Firestore\FieldValue;
+     * use Google\Cloud\Firestore\FirestoreClient;
+     *
+     * $firestore = new FirestoreClient;
+     * $document = $firestore->document('users/dave');
+     *
+     * $document->update([
+     *     [
+     *         'path' => 'favoriteColors',
+     *         'value' => FieldValue::arrayUnion(['red', 'blue'])
+     *     ]
+     * ]);
+     * ```
+     *
+     * @param array $elements The elements to union into the array.
+     * @return ArrayUnionValue
      */
-    public static function isSentinelValue($value)
+    public static function arrayUnion(array $elements)
     {
-        return in_array($value, self::sentinelValues(), true);
+        return new ArrayUnionValue($elements);
     }
 
     /**
-     * Get a list of sentinel values.
+     * Returns a special value that can be used with set(), create() or update()
+     * that tells the server to remove the given elements from any array value
+     * that already exists on the server. All instances of each element
+     * specified will be removed from the array. If the field being modified is
+     * not already an array it will be overwritten with an empty array.
      *
-     * @return array
-     * @access private
+     * Example:
+     * ```
+     * use Google\Cloud\Firestore\FieldValue;
+     * use Google\Cloud\Firestore\FirestoreClient;
+     *
+     * $firestore = new FirestoreClient;
+     * $document = $firestore->document('users/dave');
+     *
+     * $document->update([
+     *     [
+     *         'path' => 'favoriteColors',
+     *         'value' => FieldValue::arrayRemove(['green'])
+     *     ]
+     * ]);
+     * ```
+     *
+     * @param array $elements The elements to remove from the array.
+     * @return ArrayRemoveValue
      */
-    public static function sentinelValues()
+    public static function arrayRemove(array $elements)
     {
-        return [
-            self::deleteField(),
-            self::serverTimestamp()
-        ];
+        return new ArrayRemoveValue($elements);
     }
 }

--- a/Firestore/src/FieldValue.php
+++ b/Firestore/src/FieldValue.php
@@ -60,7 +60,7 @@ class FieldValue
      * ]);
      * ```
      *
-     * @return string
+     * @return DeleteFieldValue
      */
     public static function deleteField()
     {

--- a/Firestore/src/FieldValue/ArrayRemoveValue.php
+++ b/Firestore/src/FieldValue/ArrayRemoveValue.php
@@ -19,11 +19,16 @@ namespace Google\Cloud\Firestore\FieldValue;
 
 /**
  * Represents an ArrayRemove DocumentTransform.
+ *
+ * See {@see Google\Cloud\Firestore\FieldValue::arrayRemove()} for usage.
  */
 class ArrayRemoveValue implements DocumentTransformInterface
 {
     use DocumentTransformTrait;
 
+    /**
+     * @access private
+     */
     public function key()
     {
         return 'removeAllFromArray';

--- a/Firestore/src/FieldValue/ArrayRemoveValue.php
+++ b/Firestore/src/FieldValue/ArrayRemoveValue.php
@@ -29,6 +29,7 @@ class ArrayRemoveValue implements DocumentTransformInterface
 
     /**
      * @access private
+     * @return string
      */
     public function key()
     {
@@ -37,6 +38,7 @@ class ArrayRemoveValue implements DocumentTransformInterface
 
     /**
      * @access private
+     * @return bool
      */
     public function includeInUpdateMask()
     {

--- a/Firestore/src/FieldValue/ArrayRemoveValue.php
+++ b/Firestore/src/FieldValue/ArrayRemoveValue.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Firestore\FieldValue;
+
+/**
+ * Represents an ArrayRemove DocumentTransform.
+ */
+class ArrayRemoveValue implements DocumentTransformInterface
+{
+    use DocumentTransformTrait;
+
+    public function key()
+    {
+        return 'removeAllFromArray';
+    }
+
+    /**
+     * @access private
+     */
+    public function includeInUpdateMask()
+    {
+        return false;
+    }
+}

--- a/Firestore/src/FieldValue/ArrayRemoveValue.php
+++ b/Firestore/src/FieldValue/ArrayRemoveValue.php
@@ -20,7 +20,8 @@ namespace Google\Cloud\Firestore\FieldValue;
 /**
  * Represents an ArrayRemove DocumentTransform.
  *
- * See {@see Google\Cloud\Firestore\FieldValue::arrayRemove()} for usage.
+ * This class is not intended to be used directly. See
+ * {@see Google\Cloud\Firestore\FieldValue::arrayRemove()} for usage.
  */
 class ArrayRemoveValue implements DocumentTransformInterface
 {

--- a/Firestore/src/FieldValue/ArrayUnionValue.php
+++ b/Firestore/src/FieldValue/ArrayUnionValue.php
@@ -19,11 +19,16 @@ namespace Google\Cloud\Firestore\FieldValue;
 
 /**
  * Represents an ArrayUnion DocumentTransform.
+ *
+ * See {@see Google\Cloud\Firestore\FieldValue::arrayUnion()} for usage.
  */
 class ArrayUnionValue implements DocumentTransformInterface
 {
     use DocumentTransformTrait;
 
+    /**
+     * @access private
+     */
     public function key()
     {
         return 'appendMissingElements';

--- a/Firestore/src/FieldValue/ArrayUnionValue.php
+++ b/Firestore/src/FieldValue/ArrayUnionValue.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Firestore\FieldValue;
+
+/**
+ * Represents an ArrayUnion DocumentTransform.
+ */
+class ArrayUnionValue implements DocumentTransformInterface
+{
+    use DocumentTransformTrait;
+
+    public function key()
+    {
+        return 'appendMissingElements';
+    }
+
+    /**
+     * @access private
+     */
+    public function includeInUpdateMask()
+    {
+        return false;
+    }
+}

--- a/Firestore/src/FieldValue/ArrayUnionValue.php
+++ b/Firestore/src/FieldValue/ArrayUnionValue.php
@@ -29,6 +29,7 @@ class ArrayUnionValue implements DocumentTransformInterface
 
     /**
      * @access private
+     * @return string
      */
     public function key()
     {
@@ -37,6 +38,7 @@ class ArrayUnionValue implements DocumentTransformInterface
 
     /**
      * @access private
+     * @return bool
      */
     public function includeInUpdateMask()
     {

--- a/Firestore/src/FieldValue/DeleteFieldValue.php
+++ b/Firestore/src/FieldValue/DeleteFieldValue.php
@@ -22,34 +22,12 @@ use Google\Cloud\Firestore\FieldPath;
 /**
  * Represents a field to be deleted.
  *
- * See {@see Google\Cloud\Firestore\FieldValue::deleteField()} for usage.
+ * This class is not intended to be used directly. See
+ * {@see Google\Cloud\Firestore\FieldValue::deleteField()} for usage.
  */
 class DeleteFieldValue implements FieldValueInterface
 {
-    private $fieldPath;
-
-    /**
-     * Set the field path for the transform value.
-     *
-     * @param FieldPath $fieldPath The field path object.
-     * @return void
-     * @access private
-     */
-    public function setFieldPath(FieldPath $fieldPath)
-    {
-        $this->fieldPath = $fieldPath;
-    }
-
-    /**
-     * Get the field path.
-     *
-     * @return FieldPath|null
-     * @access private
-     */
-    public function fieldPath()
-    {
-        return $this->fieldPath;
-    }
+    use FieldValueTrait;
 
     /**
      * @access private

--- a/Firestore/src/FieldValue/DeleteFieldValue.php
+++ b/Firestore/src/FieldValue/DeleteFieldValue.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Firestore\FieldValue;
+
+use Google\Cloud\Firestore\FieldPath;
+
+/**
+ * Represents a field to be deleted.
+ *
+ * See {@see Google\Cloud\Firestore\FieldValue::deleteField()} for usage.
+ */
+class DeleteFieldValue implements FieldValueInterface
+{
+    private $fieldPath;
+
+    /**
+     * Set the field path for the transform value.
+     *
+     * @param FieldPath $fieldPath The field path object.
+     * @return void
+     * @access private
+     */
+    public function setFieldPath(FieldPath $fieldPath)
+    {
+        $this->fieldPath = $fieldPath;
+    }
+
+    /**
+     * Get the field path.
+     *
+     * @return FieldPath|null
+     * @access private
+     */
+    public function fieldPath()
+    {
+        return $this->fieldPath;
+    }
+
+    /**
+     * @access private
+     */
+    public function includeInUpdateMask()
+    {
+        return true;
+    }
+}

--- a/Firestore/src/FieldValue/DocumentTransformInterface.php
+++ b/Firestore/src/FieldValue/DocumentTransformInterface.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Firestore\FieldValue;
+
+/**
+ * Represents a DocumentTransform value.
+ *
+ * A DocumentTransformInterface instance defines the structure of a
+ * {@see Google\Cloud\Firestore\V1beta1\DocumentTransform\FieldTransform}
+ * message. `$key` defines the `oneof transformType` key, and `$args` defines
+ * the transformType message data.
+ */
+interface DocumentTransformInterface extends FieldValueInterface
+{
+    /**
+     * Get the transform key.
+     *
+     * @return string
+     */
+    public function key();
+
+    /**
+     * Get the transform arguments.
+     *
+     * @return mixed
+     */
+    public function args();
+}

--- a/Firestore/src/FieldValue/DocumentTransformTrait.php
+++ b/Firestore/src/FieldValue/DocumentTransformTrait.php
@@ -24,15 +24,12 @@ use Google\Cloud\Firestore\FieldPath;
  */
 trait DocumentTransformTrait
 {
+    use FieldValueTrait;
+
     /**
      * @var array
      */
     private $args;
-
-    /**
-     * @var FieldPath|null
-     */
-    private $fieldPath;
 
     /**
      * @param array $args
@@ -51,28 +48,5 @@ trait DocumentTransformTrait
     public function args()
     {
         return $this->args;
-    }
-
-    /**
-     * Set the field path for the transform value.
-     *
-     * @param FieldPath $fieldPath The field path object.
-     * @return void
-     * @access private
-     */
-    public function setFieldPath(FieldPath $fieldPath)
-    {
-        $this->fieldPath = $fieldPath;
-    }
-
-    /**
-     * Get the field path.
-     *
-     * @return FieldPath|null
-     * @access private
-     */
-    public function fieldPath()
-    {
-        return $this->fieldPath;
     }
 }

--- a/Firestore/src/FieldValue/DocumentTransformTrait.php
+++ b/Firestore/src/FieldValue/DocumentTransformTrait.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Firestore\FieldValue;
+
+use Google\Cloud\Firestore\FieldPath;
+
+/**
+ * Common methods for DocumentTransforms.
+ */
+trait DocumentTransformTrait
+{
+    /**
+     * @var array
+     */
+    private $args;
+
+    /**
+     * @var FieldPath|null
+     */
+    private $fieldPath;
+
+    /**
+     * @param array $args
+     */
+    public function __construct(array $args = [])
+    {
+        $this->args = $args;
+    }
+
+    /**
+     * Get the field value arguments.
+     *
+     * @access private
+     * @return array
+     */
+    public function args()
+    {
+        return $this->args;
+    }
+
+    /**
+     * Set the field path for the transform value.
+     *
+     * @param FieldPath $fieldPath The field path object.
+     * @return void
+     * @access private
+     */
+    public function setFieldPath(FieldPath $fieldPath)
+    {
+        $this->fieldPath = $fieldPath;
+    }
+
+    /**
+     * Get the field path.
+     *
+     * @return FieldPath|null
+     * @access private
+     */
+    public function fieldPath()
+    {
+        return $this->fieldPath;
+    }
+}

--- a/Firestore/src/FieldValue/FieldValueInterface.php
+++ b/Firestore/src/FieldValue/FieldValueInterface.php
@@ -25,7 +25,7 @@ use Google\Cloud\Firestore\FieldPath;
  * A special field value which is handled by the client to accomplish a specific
  * task, such as field deletion. Instances of `FieldValueInterface` do not
  * enqueue a DocumentTransform mutation. to enqueue a transform, use
- * {@see Google\Cloud\Firestore\DocumentTransformInterface}.
+ * {@see Google\Cloud\Firestore\FieldValue\DocumentTransformInterface}.
  */
 interface FieldValueInterface
 {

--- a/Firestore/src/FieldValue/FieldValueInterface.php
+++ b/Firestore/src/FieldValue/FieldValueInterface.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Firestore\FieldValue;
+
+use Google\Cloud\Firestore\FieldPath;
+
+/**
+ * Represents a special Field Value.
+ *
+ * A special field value which is handled by the client to accomplish a specific
+ * task, such as field deletion. Instances of `FieldValueInterface` do not
+ * enqueue a DocumentTransform mutation. to enqueue a transform, use
+ * {@see Google\Cloud\Firestore\DocumentTransformInterface}.
+ */
+interface FieldValueInterface
+{
+    /**
+     * Whether the value should be included in the update mask.
+     *
+     * @return bool
+     */
+    public function includeInUpdateMask();
+
+    /**
+     * Set the transform field path.
+     *
+     * @param FieldPath $fieldPath
+     * @return void
+     */
+    public function setFieldPath(FieldPath $fieldPath);
+
+    /**
+     * Get the transform field path.
+     *
+     * @return FieldPath|null
+     */
+    public function fieldPath();
+}

--- a/Firestore/src/FieldValue/FieldValueTrait.php
+++ b/Firestore/src/FieldValue/FieldValueTrait.php
@@ -17,29 +17,38 @@
 
 namespace Google\Cloud\Firestore\FieldValue;
 
+use Google\Cloud\Firestore\FieldPath;
+
 /**
- * Represents an ArrayUnion DocumentTransform.
- *
- * This class is not intended to be used directly. See
- * {@see Google\Cloud\Firestore\FieldValue::arrayUnion()} for usage.
+ * Common methods for special field values.
  */
-class ArrayUnionValue implements DocumentTransformInterface
+trait FieldValueTrait
 {
-    use DocumentTransformTrait;
+    /**
+     * @var FieldPath|null
+     */
+    private $fieldPath;
 
     /**
+     * Set the field path for the transform value.
+     *
+     * @param FieldPath $fieldPath The field path object.
+     * @return void
      * @access private
      */
-    public function key()
+    public function setFieldPath(FieldPath $fieldPath)
     {
-        return 'appendMissingElements';
+        $this->fieldPath = $fieldPath;
     }
 
     /**
+     * Get the field path.
+     *
+     * @return FieldPath|null
      * @access private
      */
-    public function includeInUpdateMask()
+    public function fieldPath()
     {
-        return false;
+        return $this->fieldPath;
     }
 }

--- a/Firestore/src/FieldValue/ServerTimestampValue.php
+++ b/Firestore/src/FieldValue/ServerTimestampValue.php
@@ -33,6 +33,7 @@ class ServerTimestampValue implements DocumentTransformInterface
 
     /**
      * @access private
+     * @return string
      */
     public function key()
     {
@@ -41,6 +42,7 @@ class ServerTimestampValue implements DocumentTransformInterface
 
     /**
      * @access private
+     * @return int
      */
     public function args()
     {
@@ -49,6 +51,7 @@ class ServerTimestampValue implements DocumentTransformInterface
 
     /**
      * @access private
+     * @return bool
      */
     public function includeInUpdateMask()
     {

--- a/Firestore/src/FieldValue/ServerTimestampValue.php
+++ b/Firestore/src/FieldValue/ServerTimestampValue.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Firestore\FieldValue;
+
+use Google\Cloud\Firestore\V1beta1\DocumentTransform\FieldTransform\ServerValue;
+
+/**
+ * Represents a ServerTimestamp DocumentTransform.
+ */
+class ServerTimestampValue implements DocumentTransformInterface
+{
+    use DocumentTransformTrait;
+
+    const REQUEST_TIME = ServerValue::REQUEST_TIME;
+
+    public function key()
+    {
+        return 'setToServerValue';
+    }
+
+    public function args()
+    {
+        return self::REQUEST_TIME;
+    }
+
+    /**
+     * @access private
+     */
+    public function includeInUpdateMask()
+    {
+        return false;
+    }
+}

--- a/Firestore/src/FieldValue/ServerTimestampValue.php
+++ b/Firestore/src/FieldValue/ServerTimestampValue.php
@@ -22,7 +22,8 @@ use Google\Cloud\Firestore\V1beta1\DocumentTransform\FieldTransform\ServerValue;
 /**
  * Represents a ServerTimestamp DocumentTransform.
  *
- * See {@see Google\Cloud\Firestore\FieldValue::serverTimestamp()} for usage.
+ * This class is not intended to be used directly. See
+ * {@see Google\Cloud\Firestore\FieldValue::serverTimestamp()} for usage.
  */
 class ServerTimestampValue implements DocumentTransformInterface
 {

--- a/Firestore/src/FieldValue/ServerTimestampValue.php
+++ b/Firestore/src/FieldValue/ServerTimestampValue.php
@@ -21,6 +21,8 @@ use Google\Cloud\Firestore\V1beta1\DocumentTransform\FieldTransform\ServerValue;
 
 /**
  * Represents a ServerTimestamp DocumentTransform.
+ *
+ * See {@see Google\Cloud\Firestore\FieldValue::serverTimestamp()} for usage.
  */
 class ServerTimestampValue implements DocumentTransformInterface
 {
@@ -28,11 +30,17 @@ class ServerTimestampValue implements DocumentTransformInterface
 
     const REQUEST_TIME = ServerValue::REQUEST_TIME;
 
+    /**
+     * @access private
+     */
     public function key()
     {
         return 'setToServerValue';
     }
 
+    /**
+     * @access private
+     */
     public function args()
     {
         return self::REQUEST_TIME;

--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -54,6 +54,7 @@ class Query
     const OP_GREATER_THAN = FieldFilterOperator::GREATER_THAN;
     const OP_GREATER_THAN_OR_EQUAL = FieldFilterOperator::GREATER_THAN_OR_EQUAL;
     const OP_EQUAL = FieldFilterOperator::EQUAL;
+    const OP_ARRAY_CONTAINS = FieldFilterOperator::ARRAY_CONTAINS;
 
     const OP_NAN = UnaryFilterOperator::IS_NAN;
     const OP_NULL = UnaryFilterOperator::IS_NULL;
@@ -69,6 +70,7 @@ class Query
         self::OP_EQUAL,
         self::OP_GREATER_THAN,
         self::OP_GREATER_THAN_OR_EQUAL,
+        self::OP_ARRAY_CONTAINS,
     ];
 
     private $shortOperators = [
@@ -79,6 +81,7 @@ class Query
         '='  => self::OP_EQUAL,
         '=='  => self::OP_EQUAL,
         '==='  => self::OP_EQUAL,
+        'array-contains' => self::OP_ARRAY_CONTAINS,
     ];
 
     private $allowedDirections = [

--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -276,6 +276,11 @@ class Query
      * $query = $query->where('coolnessPercentage', '=', NAN);
      * ```
      *
+     * ```
+     * // Use `array-contains` to select documents where the array contains given elements.
+     * $query = $query->where('friends', 'array-contains', ['Steve', 'Sarah']);
+     * ```
+     *
      * @param string|FieldPath $fieldPath The field to filter by.
      * @param string $operator The operator to filter by.
      * @param mixed $value The value to compare to.

--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -21,7 +21,7 @@ use Google\Cloud\Core\DebugInfoTrait;
 use Google\Cloud\Core\ExponentialBackoff;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\DocumentSnapshot;
-use Google\Cloud\Firestore\FieldValue;
+use Google\Cloud\Firestore\FieldValue\FieldValueInterface;
 use Google\Cloud\Firestore\SnapshotTrait;
 use Google\Cloud\Firestore\V1beta1\StructuredQuery\CompositeFilter\Operator;
 use Google\Cloud\Firestore\V1beta1\StructuredQuery\Direction;
@@ -281,7 +281,7 @@ class Query
      */
     public function where($fieldPath, $operator, $value)
     {
-        if (FieldValue::isSentinelValue($value)) {
+        if ($value instanceof FieldValueInterface) {
             throw new \InvalidArgumentException(sprintf(
                 'Value cannot be a `%s` value.',
                 FieldValue::class
@@ -611,7 +611,7 @@ class Query
                         DocumentSnapshot::class
                     ));
                 }
-                if (FieldValue::isSentinelValue($value)) {
+                if ($value instanceof FieldValueInterface) {
                     throw new \InvalidArgumentException(sprintf(
                         'Value cannot be a `%s` value.',
                         FieldValue::class

--- a/Firestore/src/Query.php
+++ b/Firestore/src/Query.php
@@ -717,7 +717,10 @@ class Query
                 $filters = $this->query['where']['compositeFilter']['filters'];
                 $inequality = array_filter($filters, function ($filter) {
                     $type = array_keys($filter)[0];
-                    return $filter[$type]['op'] !== self::OP_EQUAL;
+                    return !in_array($filter[$type]['op'], [
+                        self::OP_EQUAL,
+                        self::OP_ARRAY_CONTAINS
+                    ]);
                 });
 
                 if ($inequality) {

--- a/Firestore/src/ValueMapper.php
+++ b/Firestore/src/ValueMapper.php
@@ -224,7 +224,7 @@ class ValueMapper
                     return $this->encodeAssociativeArrayValue($value);
                 }
 
-                return $this->encodeArrayValue($value);
+                return ['arrayValue' => $this->encodeArrayValue($value)];
                 break;
 
             case 'NULL':
@@ -241,6 +241,29 @@ class ValueMapper
                 break;
             // @codeCoverageIgnoreEnd
         }
+    }
+
+    /**
+     * Encode a simple array as a Firestore array value.
+     *
+     * @codingStandardsIgnoreStart
+     * @param array $value
+     * @return array [ArrayValue](https://firebase.google.com/docs/firestore/reference/rpc/google.firestore.v1beta1#google.firestore.v1beta1.ArrayValue)
+     * @throws \RuntimeException If the array contains a nested array.
+     * @codingStandardsIgnoreEnd
+     */
+    public function encodeArrayValue(array $value)
+    {
+        $out = [];
+        foreach ($value as $item) {
+            if (is_array($item) && !$this->isAssoc($item)) {
+                throw new \RuntimeException('Nested array values are not permitted.');
+            }
+
+            $out[] = $this->encodeValue($item);
+        }
+
+        return ['values' => $out];
     }
 
     /**
@@ -308,28 +331,5 @@ class ValueMapper
         }
 
         return ['mapValue' => ['fields' => $out]];
-    }
-
-    /**
-     * Encode a simple array as a Firestore array value.
-     *
-     * @codingStandardsIgnoreStart
-     * @param array $value
-     * @return array [ArrayValue](https://firebase.google.com/docs/firestore/reference/rpc/google.firestore.v1beta1#google.firestore.v1beta1.ArrayValue)
-     * @throws \RuntimeException If the array contains a nested array.
-     * @codingStandardsIgnoreEnd
-     */
-    private function encodeArrayValue(array $value)
-    {
-        $out = [];
-        foreach ($value as $item) {
-            if (is_array($item) && !$this->isAssoc($item)) {
-                throw new \RuntimeException('Nested array values are not permitted.');
-            }
-
-            $out[] = $this->encodeValue($item);
-        }
-
-        return ['arrayValue' => ['values' => $out]];
     }
 }

--- a/Firestore/src/WriteBatch.php
+++ b/Firestore/src/WriteBatch.php
@@ -687,7 +687,7 @@ class WriteBatch
                         ? $inArray
                         : !$this->isAssoc($value);
 
-                    $fields[$key] = $filterFn($value, $currentPath, $inArray);
+                    $fields[$key] = $filterFn($value, $currentPath, $localInArray);
                     if (empty($fields[$key])) {
                         unset($fields[$key]);
                     }

--- a/Firestore/src/WriteBatch.php
+++ b/Firestore/src/WriteBatch.php
@@ -23,7 +23,9 @@ use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Core\TimeTrait;
 use Google\Cloud\Core\ValidateTrait;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
-use Google\Cloud\Firestore\V1beta1\DocumentTransform\FieldTransform\ServerValue;
+use Google\Cloud\Firestore\FieldValue\DeleteFieldValue;
+use Google\Cloud\Firestore\FieldValue\DocumentTransformInterface;
+use Google\Cloud\Firestore\FieldValue\FieldValueInterface;
 
 /**
  * Enqueue and write multiple mutations to Cloud Firestore.
@@ -51,8 +53,6 @@ class WriteBatch
     const TYPE_UPDATE = 'update';
     const TYPE_DELETE = 'delete';
     const TYPE_TRANSFORM = 'transform';
-
-    const REQUEST_TIME = ServerValue::REQUEST_TIME;
 
     /**
      * @var ConnectionInterface
@@ -124,16 +124,10 @@ class WriteBatch
         // Record whether the document is empty before any filtering.
         $emptyDocument = count($fields) === 0;
 
-        list ($fields, $sentinels, $flags) = $this->filterFields($fields);
+        list ($fields, $sentinels, $metadata) = $this->filterFields($fields);
 
-        if ($sentinels[FieldValue::deleteField()]) {
+        if (in_array(DeleteFieldValue::class, $metadata['types'])) {
             throw new \InvalidArgumentException('Cannot delete fields when creating a document.');
-        }
-
-        if ($flags['timestampInArray']) {
-            throw new \InvalidArgumentException(
-                'Server Timestamps cannot be used anywhere within a non-associative array value.'
-            );
         }
 
         // Cannot create a document that already exists!
@@ -155,14 +149,8 @@ class WriteBatch
             ];
         }
 
-        // Some sentinel values (at the time of writing server timestamps)
-        // are implemented using TRANSFORM mutations rather than being embedded
-        // in the normal update.
-        $this->updateTransforms(
-            $document,
-            $sentinels,
-            $transformOptions
-        );
+        // document transform operations are enqueued as a separate mutation.
+        $this->enqueueTransforms($document, $sentinels, $transformOptions);
 
         return $this;
     }
@@ -208,32 +196,27 @@ class WriteBatch
         // Record whether the document is empty before any filtering.
         $emptyDocument = count($fields) === 0;
 
-        list ($fields, $sentinels, $flags) = $this->filterFields($fields);
+        list ($fields, $sentinels, $metadata) = $this->filterFields($fields);
 
-        if (!$merge && $sentinels[FieldValue::deleteField()]) {
+        if (!$merge && in_array(DeleteFieldValue::class, $metadata['types'])) {
             throw new \InvalidArgumentException('Delete cannot appear in data unless `$options[\'merge\']` is set.');
         }
-
-        if ($flags['timestampInArray']) {
-            throw new \InvalidArgumentException(
-                'Server Timestamps cannot be used anywhere within a non-associative array value.'
-            );
-        }
-
-        $hasOnlyTimestamps = count($fields) === 0
-            && !$emptyDocument
-            && $sentinels[FieldValue::serverTimestamp()]
-            && !$sentinels[FieldValue::deleteField()];
 
         // Enqueue a write if any of the following conditions are met
         // - if there are still fields remaining after sentinels were removed
         // - if the user provided an empty set to begin with
-        // - if the user provided only server timestamp sentinel values AND did not specify merge behavior
+        // - if the user provided only transform sentinel values AND did not specify merge behavior
         // - if the user provided only delete sentinel field values.
+
+        $updateNotRequired = count($fields) === 0
+            && !$emptyDocument
+            && $metadata['hasTransform']
+            && !isset($metadata['types'][DeleteFieldValue::class]);
+
         $shouldEnqueueUpdate = $fields
             || $emptyDocument
-            || ($hasOnlyTimestamps && !$merge)
-            || $sentinels[FieldValue::deleteField()];
+            || ($updateNotRequired && !$merge)
+            || isset($metadata['types'][DeleteFieldValue::class]);
 
         if ($shouldEnqueueUpdate) {
             $write = [
@@ -241,20 +224,14 @@ class WriteBatch
             ];
 
             if ($merge) {
-                $deletes = $sentinels[FieldValue::deleteField()];
-
-                $write['updateMask'] = $this->pathsToStrings(
-                    array_merge($this->encodeFieldPaths($fields), $deletes)
-                );
+                $write['updateMask'] = $this->pathsToStrings($this->encodeFieldPaths($fields), $sentinels);
             }
 
             $this->writes[] = $this->createDatabaseWrite(self::TYPE_UPDATE, $document, $write, $options);
         }
 
-        // Some sentinel values (at the time of writing server timestamps)
-        // are implemented using TRANSFORM mutations rather than being embedded
-        // in the normal update.
-        $this->updateTransforms($document, $sentinels, $options);
+        // document transform operations are enqueued as a separate mutation.
+        $this->enqueueTransforms($document, $sentinels, $options);
 
         return $this;
     }
@@ -373,52 +350,27 @@ class WriteBatch
         // Record whether the document is empty before any filtering.
         $emptyDocument = count($fields) === 0;
 
-        list ($fields, $sentinels, $flags) = $this->filterFields($fields);
+        list ($fields, $sentinels, $metadata) = $this->filterFields($fields, $paths);
 
         // to conform to specification.
         if (isset($options['precondition']['exists'])) {
             throw new \InvalidArgumentException('Exists preconditions are not supported by this method.');
         }
 
-        if ($flags['timestampInArray']) {
-            throw new \InvalidArgumentException(
-                'Server Timestamps cannot be used anywhere within a non-associative array value.'
-            );
-        }
-
         // We only want to enqueue an update write if there are non-sentinel fields
-        // OR no timestamp sentinels are found.
+        // OR no transform sentinels are found.
         // We MUST always enqueue at least one write, so if there are no fields
-        // and no timestamp sentinels, we can assume an empty write is intended
+        // and no transform sentinels, we can assume an empty write is intended
         // and enqueue an empty UPDATE operation.
         $shouldEnqueueUpdate = $fields
-            || !$sentinels[FieldValue::serverTimestamp()]
-            || $sentinels[FieldValue::deleteField()];
+            || $emptyDocument
+            || in_array(DeleteFieldValue::class, $metadata['types']);
 
         if ($shouldEnqueueUpdate) {
             $write = [
                 'fields' => $this->valueMapper->encodeValues($fields),
+                'updateMask' => $this->pathsToStrings($paths, $sentinels, true)
             ];
-
-            $deletes = $sentinels[FieldValue::deleteField()];
-            $timestamps = $sentinels[FieldValue::serverTimestamp()];
-
-            // Add deletes to the list of paths
-            $mask = array_merge($paths, $deletes);
-            $mask = array_unique($this->pathsToStrings($mask));
-
-            // Check the update mask for prefix paths.
-            // This needs to happen before we remove server timestamp sentinels.
-            $this->checkPrefixes($mask);
-
-            // remove timestamps from the mask.
-            // since we constructed the input mask before removing sentinels,
-            // we'll need to run through and pull them out now.
-            $mask = array_filter($mask, function ($item) use ($timestamps) {
-                return !in_array($item, $timestamps);
-            });
-
-            $write['updateMask'] = $mask;
 
             $this->writes[] = $this->createDatabaseWrite(
                 self::TYPE_UPDATE,
@@ -431,8 +383,8 @@ class WriteBatch
             $options = $this->formatPrecondition($options, true);
         }
 
-        // Setting values to the server timestamp is implemented as a document tranformation.
-        $this->updateTransforms($document, $sentinels, $options);
+        // document transform operations are enqueued as a separate mutation.
+        $this->enqueueTransforms($document, $sentinels, $options);
 
         return $this;
     }
@@ -539,31 +491,37 @@ class WriteBatch
     }
 
     /**
-     * Enqueue transforms for sentinels found in UPDATE calls.
+     * Enqueue transforms for CREATE, UPDATE, and SET calls.
      *
      * @param DocumentReference|string $document The document to target, either
      *        as a string document name, or DocumentReference object.
-     * @param array $sentinels
+     * @param DocumentTransformInterface[] $transforms
      * @param array $options
      * @return void
      */
-    private function updateTransforms($document, array $sentinels, array $options = [])
+    private function enqueueTransforms($document, array $transforms, array $options = [])
     {
-        $transforms = [];
-        foreach ($sentinels[FieldValue::serverTimestamp()] as $timestamp) {
-            $transforms[] = [
-                'fieldPath' => $timestamp->pathString(),
-                'setToServerValue' => self::REQUEST_TIME
+        $operations = [];
+
+        foreach ($transforms as $transform) {
+            if (!($transform instanceof DocumentTransformInterface)) {
+                continue;
+            }
+
+            $args = $transform->args();
+            if (is_array($args) && !$this->isAssoc($args)) {
+                $args = $this->valueMapper->encodeArrayValue($args);
+            }
+
+            $operations[] = [
+                'fieldPath' => $transform->fieldPath()->pathString(),
+                $transform->key() => $args
             ];
         }
 
-        if ($transforms) {
-            $document = ($document instanceof DocumentReference)
-                ? $document->name()
-                : $document;
-
+        if ($operations) {
             $this->writes[] = $this->createDatabaseWrite(self::TYPE_TRANSFORM, $document, [
-                'fieldTransforms' => $transforms
+                'fieldTransforms' => $operations
             ] + $options);
         }
     }
@@ -688,31 +646,34 @@ class WriteBatch
      * Filter fields, removing sentinel values from the field list and recording
      * their location.
      *
-     * @param array $fields The fields input
-     * @return array An array containing the output fields at position 0 and the
-     *         sentinels list at position 1.
+     * @param array $fields The structured fields input.
+     * @param FieldPath[] $inputPaths The paths provided by update-paths.
+     * @return array An array containing the output fields at position 0,
+     *         a sentinels list at position 1, and metadata at position 2.
+     *         Metadata includes `array $types`, a list of class names of
+     *         sentinels, and `bool $hasTransform`, indicating whether any
+     *         instanceof of `DocumentTransformInterface` existed in the
+     *         original input data.
      */
-    private function filterFields(array $fields)
+    private function filterFields(array $fields, array $inputPaths = [])
     {
-        // initialize the sentinels list with empty arrays.
         $sentinels = [];
-        foreach (FieldValue::sentinelValues() as $sentinel) {
-            $sentinels[$sentinel] = [];
-        }
-
-        // Track useful information here to keep complexity low elsewhere.
-        $flags = [
-            'timestampInArray' => false
+        $metadata = [
+            'types' => [],
+            'hasTransform' => false
         ];
 
-        $filterSentinels = function (
+        // Recurses through the fields list, filtering for sentinel values
+        // and performing common validation.
+        $filterFn = function (
             array $fields,
             FieldPath $path = null,
             $inArray = false
         ) use (
             &$sentinels,
-            &$filterSentinels,
-            &$flags
+            &$filterFn,
+            &$metadata,
+            $inputPaths
         ) {
             if (!$path) {
                 $path = new FieldPath([]);
@@ -726,18 +687,48 @@ class WriteBatch
                         ? $inArray
                         : !$this->isAssoc($value);
 
-                    $fields[$key] = $filterSentinels($value, $currentPath, $localInArray);
+                    $fields[$key] = $filterFn($value, $currentPath, $inArray);
                     if (empty($fields[$key])) {
                         unset($fields[$key]);
                     }
                 } else {
-                    if (FieldValue::isSentinelValue($value)) {
-                        $sentinels[$value][] = $currentPath;
-                        if ($value === FieldValue::serverTimestamp() && $inArray) {
-                            $flags['timestampInArray'] = true;
+                    if ($value instanceof FieldValueInterface) {
+                        $value->setFieldPath($currentPath);
+                        $sentinels[] = $value;
+
+                        // Sentinels cannot be used within a non-associative array.
+                        if ($inArray) {
+                            throw new \InvalidArgumentException(sprintf(
+                                '%s values cannot be used anywhere within a non-associative array value.',
+                                FieldValue::class
+                            ));
                         }
 
+                        // Delete cannot be nested in update-paths
+                        // (i.e. the only case where `$inputPaths` would be available)
+                        $illegalNestedDelete = $inputPaths
+                            && $value instanceof DeleteFieldValue
+                            && !in_array($currentPath, $inputPaths);
+
+                        if ($illegalNestedDelete) {
+                            throw new \InvalidArgumentException(sprintf(
+                                '%s::deleteField() values cannot be nested.',
+                                FieldValue::class
+                            ));
+                        }
+
+                        // Remove the sentinel value from the fields array.
                         unset($fields[$key]);
+
+                        // Record the sentinel type.
+                        if (!in_array(get_class($value), $metadata['types'])) {
+                            $metadata['types'][] = get_class($value);
+                        }
+
+                        // Record whether the mutation contains a transform value.
+                        if (!$metadata['hasTransform'] && $value instanceof DocumentTransformInterface) {
+                            $metadata['hasTransform'] = true;
+                        }
                     }
                 }
             }
@@ -745,48 +736,9 @@ class WriteBatch
             return $fields;
         };
 
-        $fields = $filterSentinels($fields);
+        $fields = $filterFn($fields);
 
-        return [$fields, $sentinels, $flags];
-    }
-
-    /**
-     * Check list of FieldPaths for prefix paths and throw exception.
-     *
-     * @param string[] $paths
-     * @throws \InvalidArgumentException If prefix paths are found.
-     */
-    private function checkPrefixes(array $paths)
-    {
-        sort($paths);
-
-        for ($i = 1; $i < count($paths); $i++) {
-            if ($this->isPrefix($paths[$i-1], $paths[$i])) {
-                throw new \InvalidArgumentException(sprintf(
-                    'Field path conflict detected for field path `%s`. ' .
-                    'Conflicts occur when a field path descends from another ' .
-                    'path. For instance `a.b` is not allowed when `a` is also ' .
-                    'provided.',
-                    $paths[$i-1]
-                ));
-            }
-        }
-    }
-
-    /**
-     * Compare two field paths to determine whether one is a prefix of the other.
-     *
-     * @param string $prefix The prefix path.
-     * @param string $suffix The suffix path.
-     * @return bool
-     */
-    private function isPrefix($prefix, $suffix)
-    {
-        $prefix = explode('.', $prefix);
-        $suffix = explode('.', $suffix);
-
-        return count($prefix) < count($suffix)
-            && $prefix === array_slice($suffix, 0, count($prefix));
+        return [$fields, $sentinels, $metadata];
     }
 
     /**
@@ -858,15 +810,75 @@ class WriteBatch
      * Convert a set of {@see Google\Cloud\Firestore\FieldPath} objects to strings.
      *
      * @param FieldPath[] $paths The input paths.
+     * @param FieldValueInterface[] $sentinels Sentinel values.
+     * @param bool $checkPrefixes Whether to search the paths for illegal path
+     *        prefixes.
      * @return string[]
      */
-    private function pathsToStrings(array $paths)
+    private function pathsToStrings(array $paths, array $sentinels, $checkPrefixes = false)
     {
         $out = [];
-        foreach ($paths as $path) {
-            $out[] = $path->pathString();
+        $excluded = [];
+        foreach ($sentinels as $sentinel) {
+            $path = $sentinel->fieldPath()
+                ? $sentinel->fieldPath()->pathString()
+                : null;
+
+            if (!$sentinel->includeInUpdateMask()) {
+                $excluded[] = $path;
+                continue;
+            }
+
+            $out[] = $path;
         }
 
-        return $out;
+        foreach ($paths as $path) {
+            $path = $path->pathString();
+            if (!in_array($path, $excluded)) {
+                $out[] = $path;
+            }
+        }
+
+        // The flag isn't really necessary since prefixes can only happen in
+        // update-paths, but using it lets us bypass the unnecessary check
+        // unless we need it.
+        if ($checkPrefixes) {
+            $this->checkPrefixes($out);
+        }
+
+        // Remove any duplicate values before returning.
+        return array_unique($out);
+    }
+
+    /**
+     * Check list of FieldPaths for prefix paths and throw exception.
+     *
+     * @param string[] $paths
+     * @throws \InvalidArgumentException If prefix paths are found.
+     */
+    private function checkPrefixes(array $paths)
+    {
+        sort($paths);
+
+        for ($i = 1; $i < count($paths); $i++) {
+            $prefix = $paths[$i-1];
+            $suffix = $paths[$i];
+
+            $prefix = explode('.', $prefix);
+            $suffix = explode('.', $suffix);
+
+            $isPrefix = count($prefix) < count($suffix)
+                && $prefix === array_slice($suffix, 0, count($prefix));
+
+            if ($isPrefix) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Field path conflict detected for field path `%s`. ' .
+                    'Conflicts occur when a field path descends from another ' .
+                    'path. For instance `a.b` is not allowed when `a` is also ' .
+                    'provided.',
+                    $prefix
+                ));
+            }
+        }
     }
 }

--- a/Firestore/tests/Snippet/FieldValueTest.php
+++ b/Firestore/tests/Snippet/FieldValueTest.php
@@ -23,7 +23,7 @@ use Google\Cloud\Core\Testing\TestHelpers;
 use Google\Cloud\Firestore\Connection\ConnectionInterface;
 use Google\Cloud\Firestore\FieldValue;
 use Google\Cloud\Firestore\FirestoreClient;
-use Google\Cloud\Firestore\V1beta1\DocumentTransform_FieldTransform_ServerValue;
+use Google\Cloud\Firestore\V1beta1\DocumentTransform\FieldTransform\ServerValue;
 use Prophecy\Argument;
 
 /**
@@ -85,7 +85,7 @@ class FieldValueTest extends SnippetTestCase
                         "fieldTransforms" => [
                             [
                                 "fieldPath" => "lastLogin",
-                                "setToServerValue" => DocumentTransform_FieldTransform_ServerValue::REQUEST_TIME
+                                "setToServerValue" => ServerValue::REQUEST_TIME
                             ]
                         ]
                     ],
@@ -99,6 +99,82 @@ class FieldValueTest extends SnippetTestCase
         $this->firestore->___setProperty('connection', $this->connection->reveal());
 
         $snippet = $this->snippetFromMethod(FieldValue::class, 'serverTimestamp');
+        $snippet->setLine(3, '');
+        $snippet->addLocal('firestore', $this->firestore);
+
+        $snippet->invoke();
+    }
+
+    public function testArrayUnion()
+    {
+        $this->connection->commit([
+            "database" => "projects/my-awesome-project/databases/(default)",
+            "writes" => [
+                [
+                    "transform" => [
+                        "document" => "projects/my-awesome-project/databases/(default)/documents/users/dave",
+                        "fieldTransforms" => [
+                            [
+                                "fieldPath" => "favoriteColors",
+                                'appendMissingElements' => [
+                                    'values' => [
+                                        [
+                                            'stringValue' => 'red'
+                                        ], [
+                                            'stringValue' => 'blue'
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
+                    "currentDocument" => [
+                        "exists" => true
+                    ]
+                ]
+            ]
+        ])->willReturn([[]]);
+
+        $this->firestore->___setProperty('connection', $this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(FieldValue::class, 'arrayUnion');
+        $snippet->setLine(3, '');
+        $snippet->addLocal('firestore', $this->firestore);
+
+        $snippet->invoke();
+    }
+
+    public function testArrayRemove()
+    {
+        $this->connection->commit([
+            "database" => "projects/my-awesome-project/databases/(default)",
+            "writes" => [
+                [
+                    "transform" => [
+                        "document" => "projects/my-awesome-project/databases/(default)/documents/users/dave",
+                        "fieldTransforms" => [
+                            [
+                                "fieldPath" => "favoriteColors",
+                                'removeAllFromArray' => [
+                                    'values' => [
+                                        [
+                                            'stringValue' => 'green'
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
+                    "currentDocument" => [
+                        "exists" => true
+                    ]
+                ]
+            ]
+        ])->willReturn([[]]);
+
+        $this->firestore->___setProperty('connection', $this->connection->reveal());
+
+        $snippet = $this->snippetFromMethod(FieldValue::class, 'arrayRemove');
         $snippet->setLine(3, '');
         $snippet->addLocal('firestore', $this->firestore);
 

--- a/Firestore/tests/Snippet/QueryTest.php
+++ b/Firestore/tests/Snippet/QueryTest.php
@@ -113,6 +113,30 @@ class QueryTest extends SnippetTestCase
         ]);
     }
 
+    public function testWhereArrayContains()
+    {
+        $snippet = $this->snippetFromMethod(Query::class, 'where', 2);
+        $this->runAndAssert($snippet, 'where', [
+            'fieldFilter' => [
+                'field' => [
+                    'fieldPath' => 'friends'
+                ],
+                'op' => Query::OP_ARRAY_CONTAINS,
+                'value' => [
+                    'arrayValue' => [
+                        'values' => [
+                            [
+                                'stringValue' => 'Steve'
+                            ], [
+                                'stringValue' => 'Sarah'
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+    }
+
     public function testOrderBy()
     {
         $snippet = $this->snippetFromMethod(Query::class, 'orderBy');

--- a/Firestore/tests/System/DocumentAndCollectionTest.php
+++ b/Firestore/tests/System/DocumentAndCollectionTest.php
@@ -17,10 +17,6 @@
 
 namespace Google\Cloud\Firestore\Tests\System;
 
-use Google\Cloud\Core\Timestamp;
-use Google\Cloud\Firestore\FieldValue;
-use Google\Cloud\Firestore\FirestoreClient;
-
 /**
  * @group firestore
  * @group firestore-documentandcollection
@@ -72,12 +68,7 @@ class DocumentAndCollectionTest extends FirestoreTestCase
         $snapshot = $this->document->snapshot();
         $this->assertEquals('Dave', $snapshot['firstName']);
 
-        try {
-            $snapshot['country'];
-            $this->assertTrue(false);
-        } catch (\PHPUnit_Framework_Error_Notice $e) {
-            $this->assertTrue(true);
-        }
+        $this->assertArrayNotHasKey('country', $snapshot->data());
     }
 
     public function testSetMerge()
@@ -113,39 +104,6 @@ class DocumentAndCollectionTest extends FirestoreTestCase
         $collection = $this->document->collections()->current();
 
         $this->assertEquals($childName, $collection->id());
-    }
-
-    public function testDeleteField()
-    {
-        $this->document->set([
-            'foo' => 'bar'
-        ]);
-        $this->assertEquals('bar', $this->document->snapshot()['foo']);
-
-        $this->document->update([
-            ['path' => 'foo', 'value' => FieldValue::deleteField()]
-        ]);
-
-        try {
-            $this->document->snapshot()->get('foo');
-            $this->assertTrue(false);
-        } catch (\InvalidArgumentException $e) {
-            $this->assertTrue(true);
-        }
-    }
-
-    public function testServerTimestamp()
-    {
-        $this->document->set([
-            'foo' => 'bar'
-        ]);
-        $this->assertEquals('bar', $this->document->snapshot()['foo']);
-
-        $this->document->update([
-            ['path' => 'foo', 'value' => FieldValue::serverTimestamp()]
-        ]);
-
-        $this->assertInstanceOf(Timestamp::class, $this->document->snapshot()['foo']);
     }
 
     public function testNonAlphaNumericFieldPaths()

--- a/Firestore/tests/System/SentinelValueTest.php
+++ b/Firestore/tests/System/SentinelValueTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Firestore\Tests\System;
+
+use Google\Cloud\Core\Timestamp;
+use Google\Cloud\Firestore\FieldValue;
+
+/**
+ * @group firestore
+ * @group firestore-write
+ */
+class SentinelValueTest extends FirestoreTestCase
+{
+    private $document;
+
+    public function setUp()
+    {
+        $this->document = self::$collection->add([
+            'firstName' => 'John',
+            'country' => 'USA'
+        ]);
+    }
+
+    public function testServerTimestamp()
+    {
+        $this->document->update([
+            ['path' => 'foo', 'value' => 'bar']
+        ]);
+        $this->assertEquals('bar', $this->document->snapshot()['foo']);
+
+        $this->document->update([
+            ['path' => 'foo', 'value' => FieldValue::serverTimestamp()]
+        ]);
+
+        $this->assertInstanceOf(Timestamp::class, $this->document->snapshot()['foo']);
+    }
+
+    public function testDelete()
+    {
+        $this->document->update([
+            ['path' => 'foo', 'value' => 'bar']
+        ]);
+        $this->assertEquals('bar', $this->document->snapshot()['foo']);
+
+        $this->document->update([
+            ['path' => 'foo', 'value' => FieldValue::deleteField()]
+        ]);
+
+        $this->assertArrayNotHasKey('foo', $this->document->snapshot()->data());
+    }
+
+    public function testArrayUnion()
+    {
+        $initialValue = ['a','b'];
+        $this->document->update([
+            ['path' => 'foo', 'value' => $initialValue]
+        ]);
+        $this->assertEquals($initialValue, $this->document->snapshot()['foo']);
+
+        $this->document->update([
+            ['path' => 'foo', 'value' => FieldValue::arrayUnion(['a', 'c', 'd'])]
+        ]);
+
+        $this->assertEquals(array_merge($initialValue, ['c', 'd']), $this->document->snapshot()['foo']);
+    }
+
+    public function testArrayRemove()
+    {
+        $initialValue = ['a', 'b'];
+        $this->document->update([
+            ['path' => 'foo', 'value' => $initialValue]
+        ]);
+        $this->assertEquals($initialValue, $this->document->snapshot()['foo']);
+
+        $this->document->update([
+            ['path' => 'foo', 'value' => FieldValue::arrayRemove(['a'])]
+        ]);
+
+        $this->assertEquals(['b'], $this->document->snapshot()['foo']);
+    }
+}

--- a/Firestore/tests/Unit/FieldPathTest.php
+++ b/Firestore/tests/Unit/FieldPathTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Firestore\Tests\Unit;
 
 use Google\Cloud\Firestore\FieldPath;
+use Google\Cloud\Firestore\FieldValue;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/Firestore/tests/Unit/FieldValueTest.php
+++ b/Firestore/tests/Unit/FieldValueTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Firestore\Tests\Unit;
+
+use Google\Cloud\Firestore\FieldValue;
+use Google\Cloud\Firestore\FieldValue\ArrayRemoveValue;
+use Google\Cloud\Firestore\FieldValue\ArrayUnionValue;
+use Google\Cloud\Firestore\FieldValue\ServerTimestampValue;
+use Google\Cloud\Firestore\V1beta1\DocumentTransform\FieldTransform\ServerValue;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group firestore
+ * @group firestore-fieldvalue
+ */
+class FieldValueTest extends TestCase
+{
+    /**
+     * @dataProvider statics
+     */
+    public function testStatics($name, $type, $args = [])
+    {
+        $v = FieldValue::$name($args);
+
+        $this->assertInstanceOf($type, $v);
+        $this->assertEquals($args, $v->args());
+    }
+
+    public function statics()
+    {
+        return [
+            ['serverTimestamp', ServerTimestampValue::class, ServerValue::REQUEST_TIME],
+            ['arrayUnion', ArrayUnionValue::class, ['a']],
+            ['arrayRemove', ArrayRemoveValue::class, ['b']]
+        ];
+    }
+}

--- a/Firestore/tests/Unit/QueryTest.php
+++ b/Firestore/tests/Unit/QueryTest.php
@@ -27,9 +27,9 @@ use Google\Cloud\Firestore\DocumentSnapshot;
 use Google\Cloud\Firestore\FieldValue;
 use Google\Cloud\Firestore\FirestoreClient;
 use Google\Cloud\Firestore\Query;
-use Google\Cloud\Firestore\V1beta1\StructuredQuery_CompositeFilter_Operator;
-use Google\Cloud\Firestore\V1beta1\StructuredQuery_Direction;
-use Google\Cloud\Firestore\V1beta1\StructuredQuery_FieldFilter_Operator;
+use Google\Cloud\Firestore\V1beta1\StructuredQuery\CompositeFilter\Operator;
+use Google\Cloud\Firestore\V1beta1\StructuredQuery\Direction;
+use Google\Cloud\Firestore\V1beta1\StructuredQuery\FieldFilter\Operator as FieldFilterOperator;
 use Google\Cloud\Firestore\ValueMapper;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -223,14 +223,14 @@ class QueryTest extends TestCase
                 'from' => $this->queryFrom(),
                 'where' => [
                     'compositeFilter' => [
-                        'op' => StructuredQuery_CompositeFilter_Operator::PBAND,
+                        'op' => Operator::PBAND,
                         'filters' => [
                             [
                                 'fieldFilter' => [
                                     'field' => [
                                         'fieldPath' => 'user.name'
                                     ],
-                                    'op' => StructuredQuery_FieldFilter_Operator::EQUAL,
+                                    'op' => FieldFilterOperator::EQUAL,
                                     'value' => [
                                         'stringValue' => 'John'
                                     ]
@@ -240,7 +240,7 @@ class QueryTest extends TestCase
                                     'field' => [
                                         'fieldPath' => 'user.age'
                                     ],
-                                    'op' => StructuredQuery_FieldFilter_Operator::EQUAL,
+                                    'op' => FieldFilterOperator::EQUAL,
                                     'value' => [
                                         'integerValue' => '30'
                                     ]
@@ -307,11 +307,13 @@ class QueryTest extends TestCase
             [Query::OP_GREATER_THAN],
             [Query::OP_GREATER_THAN_OR_EQUAL],
             [Query::OP_EQUAL],
+            [Query::OP_ARRAY_CONTAINS],
             ['<'],
             ['<='],
             ['>'],
             ['>='],
             ['='],
+            ['array-contains'],
         ];
     }
 
@@ -346,10 +348,10 @@ class QueryTest extends TestCase
                 'orderBy' => [
                     [
                         'field' => ['fieldPath' => 'user.name'],
-                        'direction' => StructuredQuery_Direction::DESCENDING
+                        'direction' => Direction::DESCENDING
                     ], [
                         'field' => ['fieldPath' => 'user.age'],
-                        'direction' => StructuredQuery_Direction::ASCENDING
+                        'direction' => Direction::ASCENDING
                     ]
                 ]
             ]
@@ -886,8 +888,11 @@ class QueryTest extends TestCase
 
     public function sentinels()
     {
-        return array_map(function ($val) {
-            return [$val];
-        }, FieldValue::sentinelValues());
+        return [
+            [FieldValue::deleteField()],
+            [FieldValue::serverTimestamp()],
+            [FieldValue::arrayUnion([])],
+            [FieldValue::arrayRemove([])]
+        ];
     }
 }

--- a/Firestore/tests/Unit/WriteBatchTest.php
+++ b/Firestore/tests/Unit/WriteBatchTest.php
@@ -353,6 +353,17 @@ class WriteBatchTest extends TestCase
     }
 
     /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessageRegExp /Document transforms cannot contain/
+     */
+    public function testSentinelCannotContainSentinel()
+    {
+        $this->batch->set('name', [
+            'foo' => FieldValue::arrayRemove([FieldValue::arrayUnion([])])
+        ]);
+    }
+
+    /**
      * @dataProvider documents
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage Delete cannot appear in data unless `$options['merge']` is set.

--- a/Firestore/tests/Unit/WriteBatchTest.php
+++ b/Firestore/tests/Unit/WriteBatchTest.php
@@ -24,7 +24,7 @@ use Google\Cloud\Firestore\DocumentReference;
 use Google\Cloud\Firestore\FieldPath;
 use Google\Cloud\Firestore\FieldValue;
 use Google\Cloud\Firestore\FirestoreClient;
-use Google\Cloud\Firestore\V1beta1\DocumentTransform_FieldTransform_ServerValue;
+use Google\Cloud\Firestore\V1beta1\DocumentTransform\FieldTransform\ServerValue;
 use Google\Cloud\Firestore\ValueMapper;
 use Google\Cloud\Firestore\WriteBatch;
 use PHPUnit\Framework\TestCase;
@@ -153,6 +153,8 @@ class WriteBatchTest extends TestCase
             ['path' => 'foo', 'value' =>  'bar'],
             ['path' => 'hello', 'value' =>  FieldValue::deleteField()],
             ['path' => 'world', 'value' =>  FieldValue::serverTimestamp()],
+            ['path' => 'arr', 'value' => FieldValue::arrayUnion(['a'])],
+            ['path' => 'arr2', 'value' => FieldValue::arrayRemove(['b'])],
         ]);
 
         $this->commitAndAssert([
@@ -173,13 +175,65 @@ class WriteBatchTest extends TestCase
                         'fieldTransforms' => [
                             [
                                 'fieldPath' => 'world',
-                                'setToServerValue' => DocumentTransform_FieldTransform_ServerValue::REQUEST_TIME
+                                'setToServerValue' => ServerValue::REQUEST_TIME
+                            ], [
+                                'fieldPath' => 'arr',
+                                'appendMissingElements' => [
+                                    'values' => [
+                                        [
+                                            'stringValue' => 'a'
+                                        ]
+                                    ]
+                                ]
+                            ], [
+                                'fieldPath' => 'arr2',
+                                'removeAllFromArray' => [
+                                    'values' => [
+                                        [
+                                            'stringValue' => 'b'
+                                        ]
+                                    ]
+                                ]
                             ]
                         ]
                     ]
                 ]
             ]
         ]);
+    }
+
+    /**
+     * @dataProvider noUpdateSentinels
+     */
+    public function testSentinelsOmitUpdateWrite($val)
+    {
+        $ref = $this->prophesize(DocumentReference::class);
+        $ref->name()->willReturn(self::DOCUMENT);
+
+        $this->batch->update($ref->reveal(), [
+            ['path' => 'foo', 'value' =>  $val],
+        ]);
+
+        $this->commitAndAssert(function ($arg) {
+            if (count($arg['writes']) > 1) {
+                return false;
+            }
+
+            if (!isset($arg['writes'][0]['transform']['fieldTransforms'][0])) {
+                return false;
+            }
+
+            return $arg['writes'][0]['transform']['fieldTransforms'][0]['fieldPath'] === 'foo';
+        });
+    }
+
+    public function noUpdateSentinels()
+    {
+        return [
+            [FieldValue::serverTimestamp()],
+            [FieldValue::arrayUnion([])],
+            [FieldValue::arrayRemove([])]
+        ];
     }
 
     /**
@@ -255,7 +309,7 @@ class WriteBatchTest extends TestCase
                         'fieldTransforms' => [
                             [
                                 'fieldPath' => 'world',
-                                'setToServerValue' => DocumentTransform_FieldTransform_ServerValue::REQUEST_TIME
+                                'setToServerValue' => ServerValue::REQUEST_TIME
                             ]
                         ]
                     ]
@@ -306,7 +360,7 @@ class WriteBatchTest extends TestCase
     public function testSetSentinelsDeleteRequiresMerge($name, $ref)
     {
         $this->batch->set($ref, [
-            'hello' => FieldValue::DeleteField(),
+            'hello' => FieldValue::deleteField(),
         ]);
     }
 


### PR DESCRIPTION
This change adds support for adding array elements and removing array elements. It also adds support for querying using the `array-contains` operator.

The bulk of the work is in a refactor of WriteBatch to improve handling of values from the FieldValue statics. The work is based heavily off of the latest iteration of [nodejs-firestore](https://github.com/googleapis/nodejs-firestore/blob/master/dev/src/field-value.ts) and should allow much easier implementation of future DocumentTransform values.

The breaking changes are minor and should not impact users in normal (expected) usage, though should still be noted.

* `Google\Cloud\Firestore\FieldValue` method return values have changed.
* `Google\Cloud\Firestore\WriteBatch::REQUEST_TIME` moved to `Google\Cloud\Firestore\FieldValue\ServerTimestampValue::REQUEST_TIME`.
* `Google\Cloud\Firestore\FieldValue` methods `sentinelValues()` and `isSentinelValue()` have been removed.

cc @schmidt-sebastian