### PR TITLE
Revert back to old method name

### DIFF
--- a/Core/src/Iterator/PageIteratorTrait.php
+++ b/Core/src/Iterator/PageIteratorTrait.php
@@ -138,7 +138,7 @@ trait PageIteratorTrait
      */
     public function nextResultToken()
     {
-        return $this->getNestedResource($this->resultTokenPath, $this->callOptions);
+        return $this->get($this->resultTokenPath, $this->callOptions);
     }
 
     /**
@@ -175,7 +175,7 @@ trait PageIteratorTrait
             $this->page = $this->executeCall();
         }
 
-        $page = $this->getNestedResource($this->itemsPath, $this->page);
+        $page = $this->get($this->itemsPath, $this->page);
 
         if ($this->nextResultToken()) {
             return $page ?: [];
@@ -248,7 +248,7 @@ trait PageIteratorTrait
      */
     private function mapResults(array $results)
     {
-        $items = $this->getNestedResource($this->itemsPath, $results);
+        $items = $this->get($this->itemsPath, $results);
         $resultMapper = $this->resultMapper;
         $shouldContinue = true;
 
@@ -278,7 +278,7 @@ trait PageIteratorTrait
     private function determineNextResultToken(array $results, $shouldContinue = true)
     {
         return $shouldContinue && $this->config['setNextResultTokenCondition']($results)
-            ? $this->getNestedResource($this->nextResultTokenPath, $results)
+            ? $this->get($this->nextResultTokenPath, $results)
             : null;
     }
 
@@ -287,7 +287,7 @@ trait PageIteratorTrait
      * @param array $array
      * @return mixed
      */
-    private function getNestedResource(array $path, array $array)
+    private function get(array $path, array $array)
     {
         $result = $array;
 

--- a/Datastore/src/EntityPageIterator.php
+++ b/Datastore/src/EntityPageIterator.php
@@ -61,6 +61,6 @@ class EntityPageIterator implements \Iterator
             ? $this->page['batch']['moreResults']
             : null;
 
-        return $this->getNestedResource($this->itemsPath, $this->page);
+        return $this->get($this->itemsPath, $this->page);
     }
 }

--- a/Storage/src/ObjectPageIterator.php
+++ b/Storage/src/ObjectPageIterator.php
@@ -58,7 +58,7 @@ class ObjectPageIterator implements \Iterator
             $this->updatePrefixes();
         }
 
-        return $this->getNestedResource($this->itemsPath, $this->page);
+        return $this->get($this->itemsPath, $this->page);
     }
 
     /**


### PR DESCRIPTION
Renaming this private method ended up being a mistake, and can cause issues.